### PR TITLE
feat: songTitle+artist match

### DIFF
--- a/common/src/lib/schemas.ts
+++ b/common/src/lib/schemas.ts
@@ -880,6 +880,7 @@ const PR_BATCH_MANUAL_SCORE = (game: Game, playtype: Playtype): PrudenceSchema =
 		identifier: "string",
 		comment: optNull(p.isBoundedString(3, 240)),
 		difficulty: "*?string",
+		artist: "*?string",
 
 		// this is checked in converting instead
 		// the lowest acceptable time is september 9th 2001 - this check saves people who dont

--- a/common/src/types/batch-manual.ts
+++ b/common/src/types/batch-manual.ts
@@ -34,6 +34,7 @@ export type BatchManualScore<GPT extends GPTString = GPTString> = ExtractMetrics
 	comment?: string | null;
 	judgements?: Record<Judgements[GPT], integer>;
 	timeAchieved?: number | null;
+	artist?: string | null;
 	optional?: AllFieldsNullableOptional<ExtractMetrics<ConfOptionalMetrics[GPT]>>;
 
 	/**

--- a/server/example/conf.json5
+++ b/server/example/conf.json5
@@ -50,6 +50,7 @@
 			"maimai",
 			"maimaidx",
 			"itg",
+			"ongeki",
 			"ddr"
 		],
 		IMPORT_TYPES: [

--- a/server/src/lib/score-import/import-types/common/batch-manual/converter.ts
+++ b/server/src/lib/score-import/import-types/common/batch-manual/converter.ts
@@ -233,7 +233,7 @@ export async function ResolveMatchTypeToTachiData(
 		}
 
 		case "songTitle": {
-			const song = await FindSongOnTitleInsensitive(game, data.identifier);
+			const song = await FindSongOnTitleInsensitive(game, data.identifier, data.artist);
 
 			if (!song) {
 				throw new SongOrChartNotFoundFailure(

--- a/server/src/utils/queries/songs.ts
+++ b/server/src/utils/queries/songs.ts
@@ -50,22 +50,31 @@ export async function FindSongOnTitle(game: Game, title: string): Promise<SongDo
  */
 export async function FindSongOnTitleInsensitive(
 	game: Game,
-	title: string
+	title: string,
+	artist?: string | null
 ): Promise<SongDocument | null> {
 	// @optimisable: Performance should be tested here by having a utility field for all-titles.
 
-	const regex = new RegExp(`^${EscapeStringRegexp(title)}$`, "iu");
+	const regexTitle = new RegExp(`^${EscapeStringRegexp(title)}$`, "iu");
+	const regexArtist = new RegExp(`^${EscapeStringRegexp(artist ?? '')}$`, "iu");
 
 	const res = await db.anySongs[game].find(
 		{
-			$or: [
+			$and: [
 				{
-					title: { $regex: regex },
+					$or: [
+						{
+							title: { $regex: regexTitle },
+						},
+						{
+							altTitles: { $regex: regexTitle },
+						},
+					],
 				},
-				{
-					altTitles: { $regex: regex },
-				},
-			],
+				artist ? {
+					artist: { $regex: regexArtist }
+				} : {}
+			]
 		},
 		{
 			limit: 2,
@@ -75,7 +84,9 @@ export async function FindSongOnTitleInsensitive(
 	if (res.length === 2) {
 		throw new AmbiguousTitleFailure(
 			title,
-			`Multiple songs exist with the case-insensitive title ${title}. We cannot resolve this. Please try and use a different song resolution method.`
+			artist
+				? `Multiple songs exist with the case-insensitive title ${title} by artist ${artist}. We cannot resolve this. Please try and use a different song resolution method.`
+				: `Multiple songs exist with the case-insensitive title ${title}. We cannot resolve this. Please try adding an artist field.`
 		);
 	}
 

--- a/server/src/utils/queries/songs.ts
+++ b/server/src/utils/queries/songs.ts
@@ -56,7 +56,7 @@ export async function FindSongOnTitleInsensitive(
 	// @optimisable: Performance should be tested here by having a utility field for all-titles.
 
 	const regexTitle = new RegExp(`^${EscapeStringRegexp(title)}$`, "iu");
-	const regexArtist = new RegExp(`^${EscapeStringRegexp(artist ?? '')}$`, "iu");
+	const regexArtist = new RegExp(`^${EscapeStringRegexp(artist ?? "")}$`, "iu");
 
 	const res = await db.anySongs[game].find(
 		{
@@ -71,10 +71,12 @@ export async function FindSongOnTitleInsensitive(
 						},
 					],
 				},
-				artist ? {
-					artist: { $regex: regexArtist }
-				} : {}
-			]
+				artist
+					? {
+							artist: { $regex: regexArtist },
+					  }
+					: {},
+			],
 		},
 		{
 			limit: 2,


### PR DESCRIPTION
 This branch adds an optional `artist` field to the batch-manual spec, which gets taken into account if matching by `songTitle`. Consider it a specialized `identifier2`. I think this is the path of least resistance towards `songTitle` not sucking.

Not benchmarked because I wouldn't know how.

Tested with the import below.
There are 3 Singularities and 1 World Vanquisher in the game.
Everything is imported correctly except the `30` score, as expected, because it doesn't have an `artist` field.

```json
{
    "meta": {
        "game": "ongeki",
        "playtype": "Single",
        "service": "Test"
    },
    "scores": [
        {
            "score": 10,
            "noteLamp": "LOSS",
            "bellLamp": "NONE",
            "matchType": "songTitle",
            "identifier": "Singularity",
            "difficulty": "MASTER",
            "artist": "ETIA.「Arcaea」"
        },
        {
            "score": 20,
            "noteLamp": "LOSS",
            "bellLamp": "NONE",
            "matchType": "songTitle",
            "identifier": "Singularity",
            "difficulty": "MASTER",
            "artist": "technoplanet"
        },
        {
            "score": 30,
            "noteLamp": "LOSS",
            "bellLamp": "NONE",
            "matchType": "songTitle",
            "identifier": "Singularity",
            "difficulty": "MASTER"
        },
        {
            "score": 40,
            "noteLamp": "LOSS",
            "bellLamp": "NONE",
            "matchType": "songTitle",
            "identifier": "World Vanquisher",
            "difficulty": "MASTER"
        },
        {
            "score": 50,
            "noteLamp": "LOSS",
            "bellLamp": "NONE",
            "matchType": "songTitle",
            "identifier": "World Vanquisher",
            "artist": "void (Mournfinale)",
            "difficulty": "MASTER"
        }
    ]
}
```