### PR TITLE
refactor(client): unify user profile components

### DIFF
--- a/client/src/app/pages/dashboard/DashboardPage.tsx
+++ b/client/src/app/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,3 @@
-import { APIFetchV1 } from "util/api";
 import { CreateGoalMap } from "util/data";
 import { RFA } from "util/misc";
 import { NumericSOV } from "util/sorts";
@@ -9,7 +8,6 @@ import { DashboardHeader } from "components/dashboard/DashboardHeader";
 import useSetSubheader from "components/layout/header/useSetSubheader";
 import SessionCard from "components/sessions/SessionCard";
 import ApiError from "components/util/ApiError";
-import AsyncLoader from "components/util/AsyncLoader";
 import Divider from "components/util/Divider";
 import GoalLink from "components/util/GoalLink";
 import LinkButton from "components/util/LinkButton";
@@ -21,13 +19,12 @@ import { TachiConfig } from "lib/config";
 import React, { useContext, useMemo } from "react";
 import Alert from "react-bootstrap/Alert";
 import Stack from "react-bootstrap/Stack";
-import Row from "react-bootstrap/Row";
 import { Link, Route, Switch } from "react-router-dom";
-import { GetGameConfig, UserDocument } from "tachi-common";
-import { UGSWithRankingData, UserRecentSummary } from "types/api-returns";
+import { UserDocument } from "tachi-common";
+import { UserRecentSummary } from "types/api-returns";
 import SessionCalendar from "components/sessions/SessionCalendar";
 import { WindowContext } from "context/WindowContext";
-import { GameStatContainer } from "./users/UserGamesPage";
+import UGPTProfiles from "components/user/UGPTProfiles";
 import SupportBanner from "./misc/SupportBanner";
 
 export function DashboardPage() {
@@ -70,7 +67,7 @@ function DashboardLoggedIn({ user }: { user: UserDocument }) {
 					/>
 				</Route>
 				<Route exact path="/profiles">
-					<UserGameStatsInfo user={user} />
+					<UGPTProfiles />
 				</Route>
 				<Route exact path="/global-activity">
 					<Activity url="/activity" />
@@ -185,46 +182,6 @@ function RecentInfo({ user }: { user: UserDocument }) {
 				</>
 			)} */}
 		</>
-	);
-}
-
-function UserGameStatsInfo({ user }: { user: UserDocument }) {
-	return (
-		<Row xs={{ cols: 1 }} lg={{ cols: 2 }}>
-			<AsyncLoader
-				promiseFn={async () => {
-					const res = await APIFetchV1<UGSWithRankingData[]>(
-						`/users/${user.id}/game-stats`
-					);
-
-					if (!res.success) {
-						throw new Error(res.description);
-					}
-
-					return res.body.sort((a, b) => {
-						if (a.game === b.game) {
-							const gameConfig = GetGameConfig(a.game);
-
-							return (
-								gameConfig.playtypes.indexOf(a.playtype) -
-								gameConfig.playtypes.indexOf(b.playtype)
-							);
-						}
-
-						const i1 = TachiConfig.GAMES.indexOf(a.game);
-						const i2 = TachiConfig.GAMES.indexOf(b.game);
-
-						return i1 - i2;
-					});
-				}}
-			>
-				{(ugs) =>
-					ugs.map((e) => (
-						<GameStatContainer ugs={e} reqUser={user} key={`${e.game}:${e.playtype}`} />
-					))
-				}
-			</AsyncLoader>
-		</Row>
 	);
 }
 

--- a/client/src/app/pages/dashboard/users/UserGamesPage.tsx
+++ b/client/src/app/pages/dashboard/users/UserGamesPage.tsx
@@ -1,107 +1,14 @@
-import { APIFetchV1 } from "util/api";
-import { GetSortedGPTs } from "util/site";
 import useSetSubheader from "components/layout/header/useSetSubheader";
-import Card from "components/layout/page/Card";
-import RankingData from "components/user/UGPTRankingData";
-import UGPTRatingsTable from "components/user/UGPTStatsOverview";
-import AsyncLoader from "components/util/AsyncLoader";
-import LinkButton from "components/util/LinkButton";
-import Muted from "components/util/Muted";
-import ReferToUser from "components/util/ReferToUser";
 import React from "react";
-import { FormatGame, UserDocument, UserGameStats } from "tachi-common";
-import { UGSWithRankingData } from "types/api-returns";
-import Col from "react-bootstrap/Col";
-import Row from "react-bootstrap/Row";
+import UGPTProfiles from "components/user/UGPTProfiles";
+import { UserDocument } from "tachi-common";
 
-interface Props {
-	reqUser: UserDocument;
-}
-
-export default function UserGamesPage({ reqUser }: Props) {
+export default function UserGamesPage({ reqUser }: { reqUser: UserDocument }) {
 	useSetSubheader(
 		["Users", reqUser.username, "Games"],
 		[reqUser],
 		`${reqUser.username}'s Game Profiles`
 	);
 
-	return (
-		<Row xs={{ cols: 1 }} lg={{ cols: 2 }}>
-			<AsyncLoader
-				promiseFn={async () => {
-					const res = await APIFetchV1<UGSWithRankingData[]>(
-						`/users/${reqUser.id}/game-stats`
-					);
-
-					if (!res.success) {
-						throw new Error(res.description);
-					}
-
-					return res.body;
-				}}
-			>
-				{(ugs) =>
-					ugs.length ? (
-						<GamesInfo ugs={ugs} reqUser={reqUser} />
-					) : (
-						<div className="col-12 text-center">
-							<Muted>
-								<ReferToUser reqUser={reqUser} /> not played anything.
-							</Muted>
-						</div>
-					)
-				}
-			</AsyncLoader>
-		</Row>
-	);
-}
-
-function GamesInfo({ ugs, reqUser }: { ugs: UserGameStats[]; reqUser: UserDocument }) {
-	const gpts = GetSortedGPTs();
-
-	const ugsMap = new Map();
-
-	for (const u of ugs) {
-		ugsMap.set(`${u.game}:${u.playtype}`, u);
-	}
-
-	return (
-		<>
-			{gpts.map(({ game, playtype }, i) => {
-				const e = ugsMap.get(`${game}:${playtype}`);
-
-				if (!e) {
-					return <React.Fragment key={`${game}:${playtype}`}></React.Fragment>;
-				}
-
-				return <GameStatContainer key={`${game}:${playtype}`} ugs={e} reqUser={reqUser} />;
-			})}
-		</>
-	);
-}
-
-export function GameStatContainer({ ugs, reqUser }: { ugs: UGSWithRankingData } & Props) {
-	return (
-		<Col className="p-2 flex-grow-1">
-			<Card
-				className="h-100"
-				footer={
-					<div className="d-flex justify-content-end">
-						<LinkButton to={`/u/${reqUser.username}/games/${ugs.game}/${ugs.playtype}`}>
-							View Game Profile
-						</LinkButton>
-					</div>
-				}
-				header={FormatGame(ugs.game, ugs.playtype)}
-			>
-				<UGPTRatingsTable ugs={ugs} />
-				<RankingData
-					game={ugs.game}
-					playtype={ugs.playtype}
-					rankingData={ugs.__rankingData}
-					userID={ugs.userID}
-				/>
-			</Card>
-		</Col>
-	);
+	return <UGPTProfiles reqUser={reqUser} />;
 }

--- a/client/src/components/layout/header/Header.tsx
+++ b/client/src/components/layout/header/Header.tsx
@@ -54,11 +54,7 @@ export default function Header({ styles }: { styles: LayoutStyles }) {
 							</Link>
 						</Offcanvas.Header>
 						<Offcanvas.Body className="d-flex flex-column">
-							<HeaderMenu
-								user={user}
-								dropdownMenuStyle={dropdownMenuStyle}
-								setState={setState}
-							/>
+							<HeaderMenu dropdownMenuStyle={dropdownMenuStyle} setState={setState} />
 						</Offcanvas.Body>
 						{user && (
 							<div className="d-flex bottom-0 pb-2 px-4 d-lg-none">

--- a/client/src/components/layout/header/HeaderMenu.tsx
+++ b/client/src/components/layout/header/HeaderMenu.tsx
@@ -1,10 +1,11 @@
 import { AllLUGPTStatsContext } from "context/AllLUGPTStatsContext";
 import { UserSettingsContext } from "context/UserSettingsContext";
 import React, { useContext, useEffect } from "react";
-import { UserDocument, UserGameStats } from "tachi-common";
+import { UserGameStats } from "tachi-common";
 import useApiQuery from "components/util/query/useApiQuery";
 import Nav from "react-bootstrap/Nav";
 import { SetState } from "types/react";
+import { UserContext } from "context/UserContext";
 import GlobalInfoDropdown from "./GlobalInfoDropdown";
 import ImportScoresDropdown from "./ImportScoresDropdown";
 import UtilsDropdown from "./UtilsDropdown";
@@ -14,21 +15,24 @@ const toggleClassNames = "w-100 justify-content-between";
 const menuClassNames = "shadow-none shadow-lg-lg";
 
 export function HeaderMenu({
-	user,
 	dropdownMenuStyle,
 	setState,
 }: {
-	user: UserDocument | null;
 	dropdownMenuStyle?: React.CSSProperties;
 	setState?: SetState<boolean>;
 }) {
+	const { user } = useContext(UserContext);
 	const { ugs, setUGS } = useContext(AllLUGPTStatsContext);
 	const { settings } = useContext(UserSettingsContext);
 
-	const { data, error } = useApiQuery<UserGameStats[]>("/users/me/game-stats", undefined, [
-		user?.id,
-		"game_stats",
-	]);
+	const { data, error } = useApiQuery<UserGameStats[]>(
+		// We should generate a valid url just in case the skip somehow fails
+		`/users/${user?.id ?? "me"}/game-stats`,
+		undefined,
+		undefined,
+		// We should skip if a user isn't logged in.
+		!user
+	);
 
 	useEffect(() => {
 		if (error) {

--- a/client/src/components/tables/dropdowns/PBDropdown.tsx
+++ b/client/src/components/tables/dropdowns/PBDropdown.tsx
@@ -181,9 +181,11 @@ export default function PBDropdown({
 							{targetData && ` (${targetData.goals.length})`}
 						</SelectButton>
 					)}
-					<SelectButton setValue={setView} value={view} id="rivals">
-						<Icon type="users" /> Rivals
-					</SelectButton>
+					{currentUser && (
+						<SelectButton setValue={setView} value={view} id="rivals">
+							<Icon type="users" /> Rivals
+						</SelectButton>
+					)}
 					<HasDevModeOn>
 						<SelectButton setValue={setView} value={view} id="debug">
 							<Icon type="bug" /> Debug Info

--- a/client/src/components/user/UGPTProfiles.tsx
+++ b/client/src/components/user/UGPTProfiles.tsx
@@ -1,0 +1,130 @@
+import { GetSortedGPTs } from "util/site";
+import Muted from "components/util/Muted";
+import ReferToUser from "components/util/ReferToUser";
+import React, { memo, useContext } from "react";
+import { Col, Row } from "react-bootstrap";
+import { FormatGame, UserDocument, UserGameStats } from "tachi-common";
+import { UGSWithRankingData } from "types/api-returns";
+import LinkButton from "components/util/LinkButton";
+import Card from "components/layout/page/Card";
+import { UserContext } from "context/UserContext";
+import { AllLUGPTStatsContext } from "context/AllLUGPTStatsContext";
+import useApiQuery from "components/util/query/useApiQuery";
+import LoadingWrapper from "components/util/LoadingWrapper";
+import UGPTRatingsTable from "./UGPTStatsOverview";
+import RankingData from "./UGPTRankingData";
+
+interface GamesInfoProps {
+	ugsList: UserGameStats[];
+	reqUser: UserDocument;
+}
+
+interface GamesInfoUnitProps {
+	ugs: UGSWithRankingData;
+	reqUser: UserDocument;
+}
+
+export default function UGPTProfiles({ reqUser }: { reqUser?: UserDocument }) {
+	const { user } = useContext(UserContext);
+
+	return (
+		<Row xs={{ cols: 1 }} lg={{ cols: 2 }}>
+			{/*
+                If a user is logged in and the component hasn't been provided reqUser or this is the logged in user's stats,
+                we can just grab the user's stats that have already been loaded into context on load.
+            */}
+			{user && (!reqUser || reqUser.id === user.id) ? (
+				<ContextualGamesInfo user={user} />
+			) : reqUser ? (
+				<QueryGamesInfo reqUser={reqUser} />
+			) : (
+				<>User not provided; can't show games for nobody!</>
+			)}
+		</Row>
+	);
+}
+
+const ContextualGamesInfo = memo(({ user }: { user: UserDocument }) => {
+	const { ugs } = useContext(AllLUGPTStatsContext);
+
+	return <GamesInfo ugsList={ugs ?? []} reqUser={user} />;
+});
+
+function QueryGamesInfo({ reqUser }: { reqUser: UserDocument }) {
+	const { data, error } = useApiQuery<UGSWithRankingData[]>(
+		`/users/${reqUser.id}/game-stats`,
+		undefined,
+		undefined,
+		!reqUser
+	);
+
+	if (error) {
+		throw new Error("An error occurred fetching User Game Stats.", { cause: error });
+	}
+
+	return (
+		<LoadingWrapper error={error} dataset={data}>
+			<GamesInfo ugsList={data!} reqUser={reqUser} />
+		</LoadingWrapper>
+	);
+}
+
+function GamesInfo({ ugsList, reqUser }: GamesInfoProps) {
+	if (ugsList.length === 0) {
+		return (
+			<div className="col-12 text-center">
+				<Muted>
+					<ReferToUser reqUser={reqUser} /> not played anything.
+				</Muted>
+			</div>
+		);
+	}
+
+	const gpts = GetSortedGPTs();
+
+	const ugsMap = new Map();
+
+	for (const ugs of ugsList) {
+		ugsMap.set(`${ugs.game}:${ugs.playtype}`, ugs);
+	}
+
+	return (
+		<>
+			{gpts.map(({ game, playtype }) => {
+				const e = ugsMap.get(`${game}:${playtype}`);
+
+				if (!e) {
+					return null;
+				}
+
+				return <GamesInfoUnit key={`${game}:${playtype}`} ugs={e} reqUser={reqUser} />;
+			})}
+		</>
+	);
+}
+
+function GamesInfoUnit({ ugs, reqUser }: GamesInfoUnitProps) {
+	return (
+		<Col className="p-2 flex-grow-1">
+			<Card
+				className="h-100"
+				footer={
+					<div className="d-flex justify-content-end">
+						<LinkButton to={`/u/${reqUser.username}/games/${ugs.game}/${ugs.playtype}`}>
+							View Game Profile
+						</LinkButton>
+					</div>
+				}
+				header={FormatGame(ugs.game, ugs.playtype)}
+			>
+				<UGPTRatingsTable ugs={ugs} />
+				<RankingData
+					game={ugs.game}
+					playtype={ugs.playtype}
+					rankingData={ugs.__rankingData}
+					userID={ugs.userID}
+				/>
+			</Card>
+		</Col>
+	);
+}

--- a/client/src/components/util/query/useApiQuery.tsx
+++ b/client/src/components/util/query/useApiQuery.tsx
@@ -23,10 +23,6 @@ export default function useApiQuery<T>(
 	return useQuery<T, UnsuccessfulAPIFetchResponse>(
 		deps,
 		async () => {
-			if (skip) {
-				throw new Error("Skipped");
-			}
-
 			if (Array.isArray(url)) {
 				const results = await Promise.all(url.map((u) => APIFetchV1(u, options)));
 
@@ -48,6 +44,7 @@ export default function useApiQuery<T>(
 		},
 		{
 			retry: false,
+			enabled: !skip,
 		}
 	);
 }


### PR DESCRIPTION
Currently, the UGS info component is used in two different ways. This new component merges the functionality of the two and simplifies the data flow.

Current behaviour fetches the game stats of the requested user whenever the component is created. This generates an unneccessary fetch everytime the component is created and, because the component isn't memoised, creates a second fetch after the component renders.

To fix this, it now chooses how to source data based on conditions:

- If a logged in user is viewing their own profiles, the stats are already available and up-to-date in context, so we can use the context to prevent asking the server.
- For viewing other profiles, it now uses react query.

One semi-important thing to note is that is that both instances currently use different methods to sort game:playtypes. The method I've left in is the oldest, and I'm not sure why the dashboard instance deviated from this; if there's a good reason for that let me know.