### PR TITLE
feat: Display Flare Rank in DDR scores

### DIFF
--- a/client/src/components/tables/cells/FlareCell.tsx
+++ b/client/src/components/tables/cells/FlareCell.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function FlareCell({ value }: { value: string }) {
+	return (
+		<td
+			style={{
+				whiteSpace: "nowrap",
+			}}
+		>
+			<strong>{value}</strong>
+		</td>
+	);
+}

--- a/client/src/lib/games/ddr.tsx
+++ b/client/src/lib/games/ddr.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import RatingCell from "components/tables/cells/RatingCell";
 import LampCell from "../../components/tables/cells/LampCell";
 import DDRScoreCell from "../../components/tables/cells/DDRScoreCell";
-import { bg, bgc } from "./_util";
 import FlareCell from "../../components/tables/cells/FlareCell";
+import { bg, bgc } from "./_util";
 
 const DDR_ENUM_COLOURS: GPTClientImplementation<GPTStrings["ddr"]>["enumColours"] = {
 	grade: {

--- a/client/src/lib/games/ddr.tsx
+++ b/client/src/lib/games/ddr.tsx
@@ -51,8 +51,8 @@ const DDR_DIFF_COLOURS: GPTClientImplementation<GPTStrings["ddr"]>["difficultyCo
 
 const DDR_HEADERS: GPTClientImplementation<"ddr:SP" | "ddr:DP">["scoreHeaders"] = [
 	["Score", "Score", NumericSOV((x) => x.scoreData.score)],
-	["Lamp", "Lamp", NumericSOV((x) => x.scoreData.enumIndexes.lamp)],
 	["Flare", "Flare", NumericSOV((x) => x.scoreData.optional.enumIndexes.flare ?? 0)],
+	["Lamp", "Lamp", NumericSOV((x) => x.scoreData.enumIndexes.lamp)],
 ];
 
 const DDR_COLOURS: GPTClientImplementation<"ddr:SP" | "ddr:DP">["classColours"] = {
@@ -111,8 +111,8 @@ const DDRCoreCells: GPTClientImplementation<GPTStrings["ddr"]>["scoreCoreCells"]
 			grade={sc.scoreData.grade}
 			score={sc.scoreData.score}
 		/>
-		<LampCell lamp={sc.scoreData.lamp} colour={GetEnumColour(sc, "lamp")} />
 		<FlareCell value={sc.scoreData.optional.flare ?? "0"}></FlareCell>
+		<LampCell lamp={sc.scoreData.lamp} colour={GetEnumColour(sc, "lamp")} />
 	</>
 );
 

--- a/client/src/lib/games/ddr.tsx
+++ b/client/src/lib/games/ddr.tsx
@@ -8,6 +8,7 @@ import RatingCell from "components/tables/cells/RatingCell";
 import LampCell from "../../components/tables/cells/LampCell";
 import DDRScoreCell from "../../components/tables/cells/DDRScoreCell";
 import { bg, bgc } from "./_util";
+import FlareCell from "../../components/tables/cells/FlareCell";
 
 const DDR_ENUM_COLOURS: GPTClientImplementation<GPTStrings["ddr"]>["enumColours"] = {
 	grade: {
@@ -51,6 +52,7 @@ const DDR_DIFF_COLOURS: GPTClientImplementation<GPTStrings["ddr"]>["difficultyCo
 const DDR_HEADERS: GPTClientImplementation<"ddr:SP" | "ddr:DP">["scoreHeaders"] = [
 	["Score", "Score", NumericSOV((x) => x.scoreData.score)],
 	["Lamp", "Lamp", NumericSOV((x) => x.scoreData.enumIndexes.lamp)],
+	["Flare", "Flare", NumericSOV((x) => x.scoreData.optional.enumIndexes.flare ?? 0)],
 ];
 
 const DDR_COLOURS: GPTClientImplementation<"ddr:SP" | "ddr:DP">["classColours"] = {
@@ -110,6 +112,7 @@ const DDRCoreCells: GPTClientImplementation<GPTStrings["ddr"]>["scoreCoreCells"]
 			score={sc.scoreData.score}
 		/>
 		<LampCell lamp={sc.scoreData.lamp} colour={GetEnumColour(sc, "lamp")} />
+		<FlareCell value={sc.scoreData.optional.flare ?? "0"}></FlareCell>
 	</>
 );
 

--- a/server/src/game-implementations/games/ddr.ts
+++ b/server/src/game-implementations/games/ddr.ts
@@ -32,10 +32,6 @@ interface PBScoreDocumentWithSong extends PBScoreDocument<"ddr:DP" | "ddr:SP"> {
 	top?: number;
 }
 
-const FLARE_0_POINTS = [
-	145, 155, 170, 185, 205, 230, 255, 290, 335, 400, 465, 510, 545, 575, 600, 620, 635, 650, 665,
-];
-
 const DDR_GOAL_FMT: GPTGoalFormatters<"ddr:DP" | "ddr:SP"> = {
 	score: GoalFmtScore,
 };


### PR DESCRIPTION
Displaying Flare Rank in scores is relevant to better understand the associated Flare Skill points for a given song