### PR TITLE
feat: support exScore, fast, slow, maxCombo as optional metrics for DDR

### DIFF
--- a/client/src/components/tables/cells/DDRScoreCell.tsx
+++ b/client/src/components/tables/cells/DDRScoreCell.tsx
@@ -6,12 +6,14 @@ export default function DDRScoreCell({
 	score,
 	colour,
 	grade,
+	exScore,
 	scoreRenderFn,
 }: {
 	score?: integer;
 	grade: string;
 	colour: string;
 	showScore?: boolean;
+	exScore?: integer;
 	scoreRenderFn?: (s: number) => string;
 }) {
 	return (
@@ -23,6 +25,12 @@ export default function DDRScoreCell({
 			<strong>{grade}</strong>
 			<br />
 			{score !== undefined && <>{scoreRenderFn ? scoreRenderFn(score) : score}</>}
+			{(!!exScore || exScore === 0) && (
+				<>
+					<br />
+					[EX: {exScore}]
+				</>
+			)}
 		</td>
 	);
 }

--- a/client/src/components/tables/cells/DDRScoreCell.tsx
+++ b/client/src/components/tables/cells/DDRScoreCell.tsx
@@ -25,7 +25,7 @@ export default function DDRScoreCell({
 			<strong>{grade}</strong>
 			<br />
 			{score !== undefined && <>{scoreRenderFn ? scoreRenderFn(score) : score}</>}
-			{(!!exScore || exScore === 0) && (
+			{typeof exScore === "number" && (
 				<>
 					<br />
 					[EX: {exScore}]

--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -4,6 +4,7 @@ import { ClassValue, zodNonNegativeInt } from "../config-utils";
 import { p } from "prudence";
 import { z } from "zod";
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_PT_CONFIG } from "../../types/internals";
+import {FAST_SLOW_MAXCOMBO} from "./_common";
 
 export const DDR_FLARE_CATEGORIES = z.enum(["CLASSIC", "WHITE", "GOLD", "NONE"]);
 
@@ -122,6 +123,19 @@ export const DDR_SP_CONF = {
 			minimumRelevantValue: "0",
 			description: "The Flare rank. If no Flare is provided, Flare 0 is chosen by default.",
 		},
+		exScore: {
+			type: "INTEGER",
+			formatter: FmtNum,
+			validate: p.isPositiveInteger,
+
+			// We want to track the best EXScore a user gets, but it is an optional
+			// metric.
+			partOfScoreID: true,
+
+			description:
+				"The EXScore value. Marvelous and O.K. judgements are worth 3 points, Perfect judgements are worth 2 points, Great judgements are worth 1 point, and Good and lower judgements are not worth any points.",
+		},
+		...FAST_SLOW_MAXCOMBO
 	},
 
 	defaultMetric: "score",
@@ -132,11 +146,19 @@ export const DDR_SP_CONF = {
 			description: "Flare Skill as it's implemented in DDR World.",
 			formatter: FmtScoreNoCommas,
 		},
+		exScore: {
+			description: "The EXScore.",
+			formatter: FmtScoreNoCommas,
+		},
 	},
 
 	sessionRatingAlgs: {
 		flareSkill: {
 			description: "Average of your 10 best Flare Points this session",
+			formatter: FmtScoreNoCommas,
+		},
+		exScore: {
+			description: "Average of your 10 best EXScores this session",
 			formatter: FmtScoreNoCommas,
 		},
 	},

--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -1,6 +1,5 @@
 import { FAST_SLOW_MAXCOMBO } from "./_common";
-import { IIDXDans } from "./iidx";
-import { FmtNum, FmtPercent, FmtScoreNoCommas } from "../../utils/util";
+import { FmtNum, FmtScoreNoCommas } from "../../utils/util";
 import { ClassValue, zodNonNegativeInt } from "../config-utils";
 import { p } from "prudence";
 import { z } from "zod";
@@ -146,19 +145,11 @@ export const DDR_SP_CONF = {
 			description: "Flare Skill as it's implemented in DDR World.",
 			formatter: FmtScoreNoCommas,
 		},
-		exScore: {
-			description: "The EXScore.",
-			formatter: FmtScoreNoCommas,
-		},
 	},
 
 	sessionRatingAlgs: {
 		flareSkill: {
 			description: "Average of your 10 best Flare Points this session",
-			formatter: FmtScoreNoCommas,
-		},
-		exScore: {
-			description: "Average of your 10 best EXScores this session",
 			formatter: FmtScoreNoCommas,
 		},
 	},

--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -1,10 +1,10 @@
+import { FAST_SLOW_MAXCOMBO } from "./_common";
 import { IIDXDans } from "./iidx";
 import { FmtNum, FmtPercent, FmtScoreNoCommas } from "../../utils/util";
 import { ClassValue, zodNonNegativeInt } from "../config-utils";
 import { p } from "prudence";
 import { z } from "zod";
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_PT_CONFIG } from "../../types/internals";
-import {FAST_SLOW_MAXCOMBO} from "./_common";
 
 export const DDR_FLARE_CATEGORIES = z.enum(["CLASSIC", "WHITE", "GOLD", "NONE"]);
 
@@ -135,7 +135,7 @@ export const DDR_SP_CONF = {
 			description:
 				"The EXScore value. Marvelous and O.K. judgements are worth 3 points, Perfect judgements are worth 2 points, Great judgements are worth 1 point, and Good and lower judgements are not worth any points.",
 		},
-		...FAST_SLOW_MAXCOMBO
+		...FAST_SLOW_MAXCOMBO,
 	},
 
 	defaultMetric: "score",

--- a/server/src/game-implementations/games/ddr.ts
+++ b/server/src/game-implementations/games/ddr.ts
@@ -358,13 +358,9 @@ export const DDR_IMPL: GPTServerImplementation<"ddr:DP" | "ddr:SP"> = {
 
 			return DDRFlare.calculate(chart.levelNum, flareLevel);
 		},
-		exScore: (scoreData) => {
-			return scoreData.optional.exScore ?? 0;
-		},
 	},
 	scoreValidators: DDR_SCORE_VALIDATORS,
 	sessionCalcs: {
 		flareSkill: SessionAvgBest10For("flareSkill"),
-		exScore: SessionAvgBest10For("exScore"),
 	},
 };


### PR DESCRIPTION
Add support for several optional metrics for DDR :
- Fast/Slow/MaxCombo
- exScore, based on SDVX. Also available as a secondary score and session alg