### PR TITLE
feat: add minimum score amount to render class update for ddr

### DIFF
--- a/bot/src/webhookHandlers/classUpdate.ts
+++ b/bot/src/webhookHandlers/classUpdate.ts
@@ -115,6 +115,8 @@ function GetMinimumScores(
 		return 20;
 	} else if (game === "pms") {
 		return 20;
+	} else if (game === "ddr") {
+		return 90;
 	}
 
 	return null;


### PR DESCRIPTION
Pretty self-explanatory.

Class calculation is based on the best 30 scores in 3 different tiers, so you need _at least_ 90 scores to have a complete list.
Knowing that, setting the minimum to 90 for DDR isn't entirely accurate but it'll be just fine to prevent most of the spam. Once you reach that hard cap, ranks will start to evolve much, much slower.