### PR TITLE
feat: maidx + chunithm seeds update

### DIFF
--- a/seeds/collections/charts-maimaidx.json
+++ b/seeds/collections/charts-maimaidx.json
@@ -20028,8 +20028,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -20048,8 +20047,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -20068,8 +20066,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -20088,8 +20085,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -47827,8 +47823,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -47847,8 +47842,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -47867,8 +47861,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -47887,8 +47880,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -47907,8 +47899,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -50927,8 +50918,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -50947,8 +50937,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -50967,8 +50956,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -50987,8 +50975,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -51007,8 +50994,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -60006,8 +59992,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -60026,8 +60011,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -60046,8 +60030,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -60066,8 +60049,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75676,8 +75658,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75696,8 +75677,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75716,8 +75696,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75736,8 +75715,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75756,8 +75734,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75776,8 +75753,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75796,8 +75772,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75816,8 +75791,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75836,8 +75810,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75856,8 +75829,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75876,8 +75848,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75896,8 +75867,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75916,8 +75886,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75936,8 +75905,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75956,8 +75924,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75976,8 +75943,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -75996,8 +75962,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -76016,8 +75981,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -77592,8 +77556,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -77612,8 +77575,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -77632,8 +77594,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -77652,8 +77613,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -78952,8 +78912,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -78972,8 +78931,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -78992,8 +78950,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -79012,8 +78969,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -79132,8 +79088,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -79152,8 +79107,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -79172,8 +79126,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{
@@ -79192,8 +79145,7 @@
 			"festival",
 			"festivalplus",
 			"buddies",
-			"buddies-omni",
-			"buddiesplus"
+			"buddies-omni"
 		]
 	},
 	{

--- a/seeds/collections/tables.json
+++ b/seeds/collections/tables.json
@@ -972,7 +972,7 @@
 			"F5f260a335a1d003fc9be961463c6bc5ca1b841daeb6cb36b70bf21490c565cfb"
 		],
 		"game": "chunithm",
-		"inactive": false,
+		"inactive": true,
 		"playtype": "Single",
 		"tableID": "chunithm-Single-newplus-levels",
 		"title": "CHUNITHM (NEW PLUS)"
@@ -988,7 +988,7 @@
 			"Fd6a94db3cac613d154a826fb210ed7de035d9ae77814a46f852f091adb474828"
 		],
 		"game": "chunithm",
-		"inactive": false,
+		"inactive": true,
 		"playtype": "Single",
 		"tableID": "chunithm-Single-newplus-difficulties",
 		"title": "CHUNITHM (NEW PLUS) (Difficulties)"


### PR DESCRIPTION
## changes

- chunithm: mark new plus folders as inactive, as mythos got sun (plus?) now.
- maimaidx: seeds update to remove songs with expired license from buddies+.

data from @beer-psi as always.