### PR TITLE
fix(client): use the rating formatter specified in tachi-common for history graphs

### DIFF
--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
@@ -1,5 +1,5 @@
 import { CreateUserMap } from "util/data";
-import { FormatGPTProfileRating, ToFixedFloor, UppercaseFirst } from "util/misc";
+import { FormatGPTProfileRating, UppercaseFirst } from "util/misc";
 import { NumericSOV, StrSOV } from "util/sorts";
 import ClassBadge from "components/game/ClassBadge";
 import ScoreLeaderboard from "components/game/ScoreLeaderboard";

--- a/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
+++ b/client/src/app/pages/dashboard/games/_game/_playtype/GPTLeaderboardsPage.tsx
@@ -1,5 +1,5 @@
 import { CreateUserMap } from "util/data";
-import { ToFixedFloor, UppercaseFirst } from "util/misc";
+import { FormatGPTProfileRating, ToFixedFloor, UppercaseFirst } from "util/misc";
 import { NumericSOV, StrSOV } from "util/sorts";
 import ClassBadge from "components/game/ClassBadge";
 import ScoreLeaderboard from "components/game/ScoreLeaderboard";
@@ -142,9 +142,7 @@ function ProfileLeaderboard({ game, playtype }: GamePT) {
 						).map((e) => (
 							<td key={e}>
 								{r.ratings[e]
-									? gptConfig.profileRatingAlgs[e].formatter
-										? gptConfig.profileRatingAlgs[e].formatter!(r.ratings[e]!)
-										: ToFixedFloor(r.ratings[e]!, 2)
+									? FormatGPTProfileRating(game, playtype, e, r.ratings[e]!)
 									: "No Data."}
 							</td>
 						))}

--- a/client/src/app/pages/dashboard/users/games/_game/_playtype/OverviewPage.tsx
+++ b/client/src/app/pages/dashboard/users/games/_game/_playtype/OverviewPage.tsx
@@ -1,5 +1,4 @@
-import { ClumpActivity } from "util/activity";
-import { ToFixedFloor, UppercaseFirst } from "util/misc";
+import { FormatGPTProfileRating, UppercaseFirst } from "util/misc";
 import { FormatDate, MillisToSince } from "util/time";
 import TimelineChart from "components/charts/TimelineChart";
 import useSetSubheader from "components/layout/header/useSetSubheader";
@@ -17,7 +16,14 @@ import SelectButton from "components/util/SelectButton";
 import { useProfileRatingAlg } from "components/util/useScoreRatingAlg";
 import { DateTime } from "luxon";
 import React, { useMemo, useState } from "react";
-import { FormatGame, GetGameConfig, GetGamePTConfig, UserGameStats } from "tachi-common";
+import {
+	FormatGame,
+	Game,
+	GetGameConfig,
+	GetGamePTConfig,
+	Playtype,
+	UserGameStats,
+} from "tachi-common";
 import { UGPTHistory } from "types/api-returns";
 import { GamePT, SetState, UGPT } from "types/react";
 import FormSelect from "react-bootstrap/FormSelect";
@@ -110,7 +116,13 @@ function UserHistory({
 
 	const currentPropValue = useMemo(() => {
 		if (mode === "rating" && rating) {
-			return data[0].ratings[rating] ? ToFixedFloor(data[0].ratings[rating]!, 2) : "N/A";
+			const ratingValue = data[0].ratings[rating];
+
+			if (!ratingValue) {
+				return "N/A";
+			}
+
+			return FormatGPTProfileRating(game, playtype, rating, ratingValue);
 		} else if (mode === "ranking") {
 			return (
 				<>
@@ -228,7 +240,7 @@ function UserHistory({
 						</div>
 					)}
 
-					<RatingTimeline {...{ data, rating }} />
+					<RatingTimeline {...{ game, playtype, data, rating }} />
 				</>
 			)}
 		</>
@@ -236,9 +248,13 @@ function UserHistory({
 }
 
 function RatingTimeline({
+	game,
+	playtype,
 	data,
 	rating,
 }: {
+	game: Game;
+	playtype: Playtype;
 	data: UGPTHistory;
 	rating: keyof UserGameStats["ratings"];
 }) {
@@ -259,12 +275,19 @@ function RatingTimeline({
 				tickSize: 5,
 				tickPadding: 5,
 				tickRotation: 0,
-				format: (y) => (y ? ToFixedFloor(y, 2) : "N/A"),
+				format: (y) => (y ? FormatGPTProfileRating(game, playtype, rating, y) : "N/A"),
 			}}
 			tooltip={(p) => (
 				<ChartTooltip>
 					<div>
-						{p.point.data.y ? ToFixedFloor(p.point.data.y as number, 2) : "N/A"}{" "}
+						{p.point.data.y
+							? FormatGPTProfileRating(
+									game,
+									playtype,
+									rating,
+									p.point.data.y as number
+							  )
+							: "N/A"}{" "}
 						{UppercaseFirst(rating)}
 					</div>
 					<small className="text-body-secondary">

--- a/client/src/components/charts/TimelineChart.tsx
+++ b/client/src/components/charts/TimelineChart.tsx
@@ -40,7 +40,7 @@ export default function TimelineChart({
 		<div style={graphStyle}>
 			<ResponsiveLine
 				data={data}
-				margin={{ top: 40, bottom: 40, left: 50, right: 50 }}
+				margin={{ top: 40, bottom: 40, left: 60, right: 40 }}
 				xScale={{ type: "time", format: "%Q" }}
 				xFormat="time:%Q"
 				gridXValues={3}

--- a/client/src/components/charts/TimelineChart.tsx
+++ b/client/src/components/charts/TimelineChart.tsx
@@ -40,7 +40,7 @@ export default function TimelineChart({
 		<div style={graphStyle}>
 			<ResponsiveLine
 				data={data}
-				margin={{ top: 40, bottom: 40, left: 40, right: 40 }}
+				margin={{ top: 40, bottom: 40, left: 50, right: 50 }}
 				xScale={{ type: "time", format: "%Q" }}
 				xFormat="time:%Q"
 				gridXValues={3}

--- a/common/src/config/game-support/museca.ts
+++ b/common/src/config/game-support/museca.ts
@@ -70,6 +70,7 @@ export const MUSECA_SINGLE_CONF = {
 		curatorSkill: {
 			description:
 				"The sum of your best 20 Curator Skills. This is identical to how it's calculated in-game.",
+			formatter: NoDecimalPlace,
 		},
 	},
 


### PR DESCRIPTION
Fixes #1185

Other changes:
- Dropped trailing decimals for MUSECA CuratorSkill. It was always `.00`.
- Changed `TimelineGraph` margins to accommodate bigger y-values 

![new rating graph that uses `FormatGPTProfileRating`. the trailing `.00` has been removed.](https://nazunacord.net/KnZCcU1kMRoD.png)