### PR TITLE
fix: invert folder thermometer data direction

### DIFF
--- a/client/src/components/game/folder/FolderDistributionTable.tsx
+++ b/client/src/components/game/folder/FolderDistributionTable.tsx
@@ -1,6 +1,6 @@
 import { ChangeOpacity } from "util/color-opacity";
 import { TACHI_BAR_THEME } from "util/constants/chart-theme";
-import { Reverse, StepFromToMax, PercentFrom } from "util/misc";
+import { StepFromToMax, PercentFrom } from "util/misc";
 import { ResponsiveBar } from "@nivo/bar";
 import { BarChartTooltip } from "components/charts/ChartTooltip";
 import MiniTable from "components/tables/components/MiniTable";
@@ -63,7 +63,7 @@ function FolderThermometer<T extends string>({
 	return (
 		<td rowSpan={keys.length} style={{ width: 200, height: 40 * keys.length }}>
 			<ResponsiveBar
-				keys={Reverse(keys)}
+				keys={keys}
 				data={[Object.assign({ id: "" }, values)]}
 				theme={Object.assign({}, TACHI_BAR_THEME)}
 				// @ts-expect-error temp


### PR DESCRIPTION
better lamps/grades should start from bottom,
so that the cumulative lamps/grades can be deduced more easily

![Screenshot 2024-10-03 232154](https://github.com/user-attachments/assets/1770e16c-e594-47ce-9676-fe423fe54b50)
![Screenshot 2024-10-03 232208](https://github.com/user-attachments/assets/c24dfcd1-7c8a-4c78-84dd-fec3d348638e)
