### PR TITLE
fix: make-things-available-in-inf: chart.data.inGameID can be an array

### DIFF
--- a/seeds/scripts/rerunners/iidx/make-things-available-in-inf.js
+++ b/seeds/scripts/rerunners/iidx/make-things-available-in-inf.js
@@ -1,10 +1,25 @@
 const { MutateCollection } = require("../../util");
 
+function idMatch(idSet, inGameID) {
+	if (Array.isArray(inGameID)) {
+		inGameID.forEach((id) => {
+			if (idSet.includes(id)) {
+				return true;
+			}
+		});
+	} else {
+		if (idSet.includes(inGameID)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 module.exports = (idSet) =>
 	MutateCollection("charts-iidx.json", (charts) => {
 		for (const chart of charts) {
 			if (
-				idSet.includes(chart.data.inGameID) &&
+				idMatch(idSet, chart.data.inGameID) &&
 				!chart.versions.includes("inf") &&
 				chart.data["2dxtraSet"] === null &&
 				chart.difficulty !== "LEGGENDARIA" &&


### PR DESCRIPTION
Allow `scripts/rerunners/iidx/make-things-available-in-inf` to check for a match where `chart.data.inGameID` is an array.