### PR TITLE
Add delta to all folder stat showcases

### DIFF
--- a/client/src/components/user/UGPTStatShowcase.tsx
+++ b/client/src/components/user/UGPTStatShowcase.tsx
@@ -297,7 +297,12 @@ function StatDelta({
 	let delta = null;
 
 	// don't bother highlighting grade/lamp deltas, since they're kinda meaningless
-	if (property === "percent" || property === "score" || property === "playcount") {
+	if (
+		property === "percent" ||
+		property === "score" ||
+		property === "playcount" ||
+		mode === "folder"
+	) {
 		delta = ` (${v2 > v1 ? `+${d}` : v2 === v1 ? `±${d}` : d})`;
 	}
 

--- a/client/src/components/user/UGPTStatShowcase.tsx
+++ b/client/src/components/user/UGPTStatShowcase.tsx
@@ -297,6 +297,7 @@ function StatDelta({
 	let delta = null;
 
 	// don't bother highlighting grade/lamp deltas, since they're kinda meaningless
+	// unless it's a folder then always show the delta for charts that meet requirement
 	if (
 		property === "percent" ||
 		property === "score" ||


### PR DESCRIPTION
Currently the delta does show for percent, score and playcount on folders however lamp and grade folder showcases does not show.