### PR TITLE
remove newline from MyPageScraper CSV parser check

### DIFF
--- a/client/src/app/pages/dashboard/import/WACCAMyPageScraperPage.tsx
+++ b/client/src/app/pages/dashboard/import/WACCAMyPageScraperPage.tsx
@@ -7,7 +7,7 @@ import React from "react";
 function RecordsParseFunction(data: string) {
 	if (
 		!data.startsWith(
-			"music_id,music_title,music_artist,music_genre,music_levels,music_play_counts,music_scores,music_achieves\n"
+			"music_id,music_title,music_artist,music_genre,music_levels,music_play_counts,music_scores,music_achieves"
 		)
 	) {
 		throw new Error(
@@ -30,7 +30,7 @@ function RecordsParseFunction(data: string) {
 function PlayerParseFunction(data: string) {
 	if (
 		!data.startsWith(
-			"player_name,player_level,player_rate,player_stage,player_play_count,player_play_count_versus,player_play_count_coop,player_total_rp_earned,player_total_rp_spent\n"
+			"player_name,player_level,player_rate,player_stage,player_play_count,player_play_count_versus,player_play_count_coop,player_total_rp_earned,player_total_rp_spent"
 		)
 	) {
 		throw new Error(


### PR DESCRIPTION
It seems there are CSVs in the wild that use \r\n instead of just \n, which can cause this to fail. Since this check is already best-effort, just drop the newline since it doesn't really matter.

Untested. Unclear if the \r\n can cause additional downstream  serverside parsing issues that will also need to be addressed.