### PR TITLE
New match type: `ddrSongHash`

### DIFF
--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -201,12 +201,13 @@ export const DDR_SP_CONF = {
 	chartData: z.strictObject({
 		inGameID: zodNonNegativeInt,
 		stepCount: zodNonNegativeInt.optional(),
+		ddrSongHash: z.string().optional(), // optional because konaste-only songs have no hashes
 	}),
 
 	preferences: z.strictObject({}),
 	scoreMeta: z.strictObject({}),
 
-	supportedMatchTypes: ["inGameID", "songTitle", "tachiSongID"],
+	supportedMatchTypes: ["inGameID", "songTitle", "tachiSongID", "ddrSongHash"],
 } as const satisfies INTERNAL_GAME_PT_CONFIG;
 
 export const DDR_DP_CONF = {

--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -60,6 +60,7 @@ export const DDR_CONF = {
 		inGameID: zodNonNegativeInt,
 		flareCategory: DDR_FLARE_CATEGORIES,
 		basename: z.string().optional(),
+		ddrSongHash: z.string().optional(), // optional because konaste-only songs have no hashes
 	}),
 } as const satisfies INTERNAL_GAME_CONFIG;
 
@@ -201,7 +202,6 @@ export const DDR_SP_CONF = {
 	chartData: z.strictObject({
 		inGameID: zodNonNegativeInt,
 		stepCount: zodNonNegativeInt.optional(),
-		ddrSongHash: z.string().optional(), // optional because konaste-only songs have no hashes
 	}),
 
 	preferences: z.strictObject({}),

--- a/common/src/lib/schemas.ts
+++ b/common/src/lib/schemas.ts
@@ -875,7 +875,8 @@ const PR_BATCH_MANUAL_SCORE = (game: Game, playtype: Playtype): PrudenceSchema =
 			"inGameID",
 			"inGameStrID",
 			"uscChartHash",
-			"popnChartHash"
+			"popnChartHash",
+			"ddrSongHash"
 		),
 		identifier: "string",
 		comment: optNull(p.isBoundedString(3, 240)),

--- a/common/src/types/batch-manual.ts
+++ b/common/src/types/batch-manual.ts
@@ -23,7 +23,8 @@ type MatchTypesWithDifficulty =
 	| "inGameStrID"
 	| "sdvxInGameID"
 	| "songTitle"
-	| "tachiSongID";
+	| "tachiSongID"
+	| "ddrSongHash";
 
 export type MatchTypes = MatchTypesNoDifficulty | MatchTypesWithDifficulty;
 

--- a/common/src/types/batch-manual.ts
+++ b/common/src/types/batch-manual.ts
@@ -19,12 +19,12 @@ type MatchTypesNoDifficulty = "bmsChartHash" | "itgChartHash" | "popnChartHash" 
 
 // These MatchTypes need `difficulty` set in the batch manual.
 type MatchTypesWithDifficulty =
+	| "ddrSongHash"
 	| "inGameID"
 	| "inGameStrID"
 	| "sdvxInGameID"
 	| "songTitle"
-	| "tachiSongID"
-	| "ddrSongHash";
+	| "tachiSongID";
 
 export type MatchTypes = MatchTypesNoDifficulty | MatchTypesWithDifficulty;
 

--- a/docs/docs/codebase/batch-manual/index.md
+++ b/docs/docs/codebase/batch-manual/index.md
@@ -150,6 +150,11 @@ means that it will check for any of `INF/GRV/HVN/VVD/XCD` for this song.
 
 This is useful for services that store all of those as the same difficulty.
 
+- ddrSongHash
+
+This is a 32-character hash used by the official DDR e-amusement website to
+identify a song; you must specify the difficulty for this chart as well.
+
 ## Example
 
 A final example of a simple BATCH MANUAL format

--- a/docs/docs/game-support/common-config/match-types.md
+++ b/docs/docs/game-support/common-config/match-types.md
@@ -31,6 +31,10 @@ Uses `identifier` as a SHA1 hash, since that's what USC uses.
 
 These match types need both `identifier` and a `difficulty` defined.
 
+### `ddrSongHash`
+
+Looks up on the 32-character song hash for this chart, where the hash is from the official DDR e-amusement website.
+
 ### `inGameID`
 
 Looks up on the in game ID for this chart.

--- a/docs/docs/game-support/games/ddr-DP.md
+++ b/docs/docs/game-support/games/ddr-DP.md
@@ -84,3 +84,4 @@ The folowing judgements are defined:
 - `inGameID`
 - `songTitle`
 - `tachiSongID`
+- `ddrSongHash`

--- a/docs/docs/game-support/games/ddr-SP.md
+++ b/docs/docs/game-support/games/ddr-SP.md
@@ -84,3 +84,4 @@ The folowing judgements are defined:
 - `inGameID`
 - `songTitle`
 - `tachiSongID`
+- `ddrSongHash`

--- a/seeds/collections/songs-ddr.json
+++ b/seeds/collections/songs-ddr.json
@@ -4,6 +4,7 @@
 		"artist": "UZI-LAY",
 		"data": {
 			"basename": "puty",
+			"ddrSongHash": "DQlQ1DlPbq900oqdOo8l0d6I1lIOl99l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 10
 		},
@@ -16,6 +17,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bril",
+			"ddrSongHash": "DblIbDd6lQQQoO9bloOI9iIqO1IiQoID",
 			"flareCategory": "CLASSIC",
 			"inGameID": 11
 		},
@@ -28,6 +30,7 @@
 		"artist": "UZI-LAY",
 		"data": {
 			"basename": "puty2",
+			"ddrSongHash": "IQqOIb6ob8bIbOII66ID0oIQDPl6bdbb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 12
 		},
@@ -40,6 +43,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bril2",
+			"ddrSongHash": "DbPodlqiOQdD88bo8lPO9D6iql1DO8P0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 13
 		},
@@ -52,6 +56,7 @@
 		"artist": "mitsu-O!",
 		"data": {
 			"basename": "make",
+			"ddrSongHash": "8Il6980di8P89lil1PDIqqIbiq1QO8lQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 14
 		},
@@ -64,6 +69,7 @@
 		"artist": "mitsu-O!SUMMER",
 		"data": {
 			"basename": "make2",
+			"ddrSongHash": "9qP16D6l11i9P1lQ0b1DIqoOqqiIQDl9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 15
 		},
@@ -76,6 +82,7 @@
 		"artist": "KTz",
 		"data": {
 			"basename": "star",
+			"ddrSongHash": "dq190Il9iO1bD698ll6ddObIlqdIQ1O9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 25
 		},
@@ -88,6 +95,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "trip",
+			"ddrSongHash": "Pb9II0oiI9ODQ8OP8IqIPQP9P68biqIi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 26
 		},
@@ -100,6 +108,7 @@
 		"artist": "180",
 		"data": {
 			"basename": "para",
+			"ddrSongHash": "06loOQ0DQb0DqbOibl6qO81qlIdoP9DI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 27
 		},
@@ -112,6 +121,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "sptr",
+			"ddrSongHash": "1P9qQdiiodODqQPl0OO88iiiqdoDIPO6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28
 		},
@@ -124,6 +134,7 @@
 		"artist": "190",
 		"data": {
 			"basename": "para2",
+			"ddrSongHash": "Pl0dPid9lQDo6PDQDqPboPqO6iIDIqoo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 29
 		},
@@ -136,6 +147,7 @@
 		"artist": "U1",
 		"data": {
 			"basename": "ajam",
+			"ddrSongHash": "6IPiID10iO699bOQlODd1PQ0liDi9i1I",
 			"flareCategory": "WHITE",
 			"inGameID": 41
 		},
@@ -148,6 +160,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "clea",
+			"ddrSongHash": "9doPbId8qid9I9l6ooloPQD1lq1Plb6I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 42
 		},
@@ -160,6 +173,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "luvm",
+			"ddrSongHash": "qQ9Oo611P0dObD8q6O0Q968bbl8I91OO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 43
 		},
@@ -172,6 +186,7 @@
 		"artist": "Chang ma",
 		"data": {
 			"basename": "this",
+			"ddrSongHash": "i8II16blIIbQQd196b616OPbPO910oi9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 44
 		},
@@ -184,6 +199,7 @@
 		"artist": "sAmi",
 		"data": {
 			"basename": "thin",
+			"ddrSongHash": "9lob1d1QPd9qiPlQOQ6l0dbodOoDPq1d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 45
 		},
@@ -196,6 +212,7 @@
 		"artist": "N.M.R",
 		"data": {
 			"basename": "keep",
+			"ddrSongHash": "0lDDIlQ91lq6O16q9QQ681d6Db1l0oOb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 46
 		},
@@ -208,6 +225,7 @@
 		"artist": "e.o.s",
 		"data": {
 			"basename": "emot",
+			"ddrSongHash": "8liDbidQoI6Q01lO9iibIdboIiDl66Qo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 58
 		},
@@ -220,6 +238,7 @@
 		"artist": "L.E.D.LIGHT",
 		"data": {
 			"basename": "geno",
+			"ddrSongHash": "Dq0Iio09Pb9iD0lbb0I0qd8Q8i10II09",
 			"flareCategory": "CLASSIC",
 			"inGameID": 84
 		},
@@ -232,6 +251,7 @@
 		"artist": "RE-VENGE",
 		"data": {
 			"basename": "afro",
+			"ddrSongHash": "Pd99DQo0bD9D9oIbPIId18P6l8qlDQO6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 124
 		},
@@ -244,6 +264,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "dyna",
+			"ddrSongHash": "1QIPID18qib8D9Oo9lOo8I6DPi9qiod6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 126
 		},
@@ -256,6 +277,7 @@
 		"artist": "N & S",
 		"data": {
 			"basename": "dead",
+			"ddrSongHash": "P98dl8qdoilqbPqIO86ood601o1696D8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 127
 		},
@@ -268,6 +290,7 @@
 		"artist": "CAPTAIN.T",
 		"data": {
 			"basename": "lase",
+			"ddrSongHash": "901q61iP6lPiDqIQoQod9PDqlOPq1bb9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 128
 		},
@@ -280,6 +303,7 @@
 		"artist": "THOMAS HOWARD",
 		"data": {
 			"basename": "sile",
+			"ddrSongHash": "80bQi8IQ8o1iidqd6oQiDPQoPi909olq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 129
 		},
@@ -292,6 +316,7 @@
 		"artist": "190'",
 		"data": {
 			"basename": "rebi",
+			"ddrSongHash": "0lDP0P06PIPl1iiIDOb919iqo1oPdlP8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 130
 		},
@@ -304,6 +329,7 @@
 		"artist": "BIG-O feat. TAKA",
 		"data": {
 			"basename": "dgra",
+			"ddrSongHash": "q6qI6llb69D1IQq0OiP8OD06Qioob91Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 133
 		},
@@ -316,6 +342,7 @@
 		"artist": "NPD3",
 		"data": {
 			"basename": "afte",
+			"ddrSongHash": "Qo9P1oOoDQIoOb8Dd0PdOdoD1D1Pbd8D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 137
 		},
@@ -328,6 +355,7 @@
 		"artist": "CLUB SPICE",
 		"data": {
 			"basename": "cuti",
+			"ddrSongHash": "di9ddbd1lb80q98ODdod0ODQ0q6PdQP1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 138
 		},
@@ -340,6 +368,7 @@
 		"artist": "Scotty D.",
 		"data": {
 			"basename": "theb",
+			"ddrSongHash": "8O0D9P6l9P9ooQdODioDIdQPq6DiDlbl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 139
 		},
@@ -352,6 +381,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "virt",
+			"ddrSongHash": "boP0i08bqQ9d9OoP8Ol6I0l9Po01DiQb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 140
 		},
@@ -364,6 +394,7 @@
 		"artist": "KTz(remixed by U1)",
 		"data": {
 			"basename": "amcs",
+			"ddrSongHash": "dQ1oPoQqD0db8O19P1P0D1oq8I68i1Id",
 			"flareCategory": "CLASSIC",
 			"inGameID": 141
 		},
@@ -376,6 +407,7 @@
 		"artist": "NW260",
 		"data": {
 			"basename": "drop",
+			"ddrSongHash": "Q0OiPQQ8IbIDq08IO9Io0qDdoDPPdd1q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 154
 		},
@@ -388,6 +420,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "stop",
+			"ddrSongHash": "ioi6db99oOPPDd1db888D6oi6bb06o0P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 155
 		},
@@ -400,6 +433,7 @@
 		"artist": "FACTOR-X",
 		"data": {
 			"basename": "wild",
+			"ddrSongHash": "01808Q1Q6lQQ1lP0qd80I0b0qqDd1OOP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 156
 		},
@@ -412,6 +446,7 @@
 		"artist": "D.J.RICH feat. TAILBROS.",
 		"data": {
 			"basename": "sprs",
+			"ddrSongHash": "88do8dl8O6Ql1Qlb981lOi8D86oiq91P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 158
 		},
@@ -424,6 +459,7 @@
 		"artist": "NAOKI 190",
 		"data": {
 			"basename": "hyst",
+			"ddrSongHash": "8l808Do60DP0qDbD066QQqP1qOQdob90",
 			"flareCategory": "CLASSIC",
 			"inGameID": 159
 		},
@@ -436,6 +472,7 @@
 		"artist": "200",
 		"data": {
 			"basename": "pevo",
+			"ddrSongHash": "DPQo8Q0l9D8IPiDiq11l8OI6i11OOb6O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 160
 		},
@@ -448,6 +485,7 @@
 		"artist": "DIVAS",
 		"data": {
 			"basename": "baby",
+			"ddrSongHash": "P8P1dlqi9D111iIDPOP0l9DIO1l6lqO9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 182
 		},
@@ -460,6 +498,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "clim",
+			"ddrSongHash": "D81D8689llDiOqPq0IP19bbQQiioPl8d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 183
 		},
@@ -472,6 +511,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "burn",
+			"ddrSongHash": "ii6Oooool0IoOqi1qdDo96QIil6IoOq0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 184
 		},
@@ -484,6 +524,7 @@
 		"artist": "NM feat. SUNNY",
 		"data": {
 			"basename": "gher",
+			"ddrSongHash": "O1blDPOQ8IQb00o0D89QIDIlo8b06liD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 185
 		},
@@ -496,6 +537,7 @@
 		"artist": "RE-VENGE",
 		"data": {
 			"basename": "naha",
+			"ddrSongHash": "1d10660Dd0IOibDI890Ild80q6ddoQO8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 186
 		},
@@ -508,6 +550,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bfor",
+			"ddrSongHash": "6Qq1q91q8iIPlI89qDq96bO8QDD0qOql",
 			"flareCategory": "CLASSIC",
 			"inGameID": 187
 		},
@@ -520,6 +563,7 @@
 		"artist": "NAOKI feat. PAULA TERRY",
 		"data": {
 			"basename": "agai",
+			"ddrSongHash": "boOdPIqbDd8li0O0IqliPo1Doq99Ob09",
 			"flareCategory": "CLASSIC",
 			"inGameID": 188
 		},
@@ -532,6 +576,7 @@
 		"artist": "MITSU-O! with GEILA",
 		"data": {
 			"basename": "summ",
+			"ddrSongHash": "6Ddo196olOPi9IQdbQ8Qbd8do8Q1obOD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 190
 		},
@@ -544,6 +589,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "lead",
+			"ddrSongHash": "8lDOiqP0biD8dD9lOQO619i1PqbqDiP8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 195
 		},
@@ -556,6 +602,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "teng",
+			"ddrSongHash": "IQ0dIiDql9Q68d9ddQIiQbq1OPq8Db69",
 			"flareCategory": "CLASSIC",
 			"inGameID": 196
 		},
@@ -568,6 +615,7 @@
 		"artist": "TaQ",
 		"data": {
 			"basename": "olic",
+			"ddrSongHash": "ODq019O9o1OPdq9PiPl0o8D8DQ8bid88",
 			"flareCategory": "CLASSIC",
 			"inGameID": 197
 		},
@@ -580,6 +628,7 @@
 		"artist": "TaQ",
 		"data": {
 			"basename": "eran",
+			"ddrSongHash": "D81Pq66DQPiQdliqIPl0ioPOi9OlQoQ9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 198
 		},
@@ -592,6 +641,7 @@
 		"artist": "Dr.VIBE feat. JP Miles",
 		"data": {
 			"basename": "onts",
+			"ddrSongHash": "1q6obddbql8lQdPI19liD6PdQ0dPIODd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 201
 		},
@@ -604,6 +654,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "orio",
+			"ddrSongHash": "61ido0DPl8q0dI1i011Do1b6669dPIlo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 213
 		},
@@ -616,6 +667,7 @@
 		"artist": "N.M.R",
 		"data": {
 			"basename": "nite",
+			"ddrSongHash": "i0bdP6II6dqb6lbQQ9q9OQq68i1qPddO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 221
 		},
@@ -628,6 +680,7 @@
 		"artist": "Crystal Aliens",
 		"data": {
 			"basename": "sexy",
+			"ddrSongHash": "60QoP9DoIo90D616989Q0D0iodOoOd91",
 			"flareCategory": "CLASSIC",
 			"inGameID": 222
 		},
@@ -640,6 +693,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "feal",
+			"ddrSongHash": "qIDI69oIo8OlQqdqqDilI1do6IbP16Q6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 233
 		},
@@ -652,6 +706,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "stil",
+			"ddrSongHash": "Qb90bo6I0Pd9181iIoOPoqPOOOQq6dQ1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 234
 		},
@@ -664,6 +719,7 @@
 		"artist": "d-complex",
 		"data": {
 			"basename": "ecst",
+			"ddrSongHash": "bPD6ObloQPOOiQb1DbQDdilodiddlIlb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 235
 		},
@@ -676,6 +732,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "abso",
+			"ddrSongHash": "qdi88l6bo1Iqi9Qiqli8lIQQIPO1doQ9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 236
 		},
@@ -688,6 +745,7 @@
 		"artist": "NAOKI feat. PAULA TERRY",
 		"data": {
 			"basename": "brok",
+			"ddrSongHash": "iIP09bOq1l1b9b1l011IDIQ6Iill90Io",
 			"flareCategory": "CLASSIC",
 			"inGameID": 237
 		},
@@ -700,6 +758,7 @@
 		"artist": "TaQ",
 		"data": {
 			"basename": "dxyy",
+			"ddrSongHash": "QDP0i688bQi1Idqil1dOqDdPdoIPP6Q0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 238
 		},
@@ -712,6 +771,7 @@
 		"artist": "TaQ",
 		"data": {
 			"basename": "elec",
+			"ddrSongHash": "IPi69l86oqdDd8qoll61166D8969869I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 243
 		},
@@ -724,6 +784,7 @@
 		"artist": "STM 200",
 		"data": {
 			"basename": "peta",
+			"ddrSongHash": "PP1q0iii1D6Dq9QOd0qqDOQD0160QoPD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 244
 		},
@@ -736,6 +797,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "abys",
+			"ddrSongHash": "Q0qQO0P8818lIoo0boO66O0qd09dIlO8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 257
 		},
@@ -748,6 +810,7 @@
 		"artist": "Togo Project feat. Sana",
 		"data": {
 			"basename": "sana",
+			"ddrSongHash": "doIiQl6oDPP6i9qobqoobblPQqPiI9bD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 258
 		},
@@ -760,6 +823,7 @@
 		"artist": "8 bit",
 		"data": {
 			"basename": "pafr",
+			"ddrSongHash": "18911Q6o6do9Dd1blIo6IliPd0PPb99i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 267
 		},
@@ -772,6 +836,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "inse",
+			"ddrSongHash": "6oldqOoilo1OoP6P9OoO8bdD9lI86qdQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 269
 		},
@@ -784,6 +849,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "lcan",
+			"ddrSongHash": "DOqPd1Iid6oObd8i96I9oo8obbODb96o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 270
 		},
@@ -796,6 +862,7 @@
 		"artist": "Stone Bros.",
 		"data": {
 			"basename": "lett",
+			"ddrSongHash": "bP69QdDQ0QQ9dP0dDio0dO61i9Dbdl00",
 			"flareCategory": "CLASSIC",
 			"inGameID": 297
 		},
@@ -808,6 +875,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "heal",
+			"ddrSongHash": "olQQ8QPPqqObDD9ooodOl9i9od8b06I9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 299
 		},
@@ -820,6 +888,7 @@
 		"artist": "Ω",
 		"data": {
 			"basename": "maxx",
+			"ddrSongHash": "6P18lOliIQqIO6Di0PP8iDlDQ01b0o0q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 325
 		},
@@ -832,6 +901,7 @@
 		"artist": "RevenG",
 		"data": {
 			"basename": "exot",
+			"ddrSongHash": "iOPbIi1b99819b9QiD8QbdPbq0DqO0DO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 332
 		},
@@ -844,6 +914,7 @@
 		"artist": "Luv UNLIMITED",
 		"data": {
 			"basename": "cand",
+			"ddrSongHash": "OPbqldiq0dQIo1011086IOl1qbOloOl9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 333
 		},
@@ -856,6 +927,7 @@
 		"artist": "Caramel.S",
 		"data": {
 			"basename": "soin",
+			"ddrSongHash": "D06P88iOlIdbbQ1Qd8OOI11dQoq0iOqd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 336
 		},
@@ -868,6 +940,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "drte",
+			"ddrSongHash": "iQo0QOoI6bOPQlbb9ldOo9lbdD1idiOO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 342
 		},
@@ -880,6 +953,7 @@
 		"artist": "NAOKI feat. PAULA TERRY",
 		"data": {
 			"basename": "esti",
+			"ddrSongHash": "98q8616ddDIqdo1dbqbO0Po96oldo1Oo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 343
 		},
@@ -892,6 +966,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "swee",
+			"ddrSongHash": "8809ol0qbbd6919bbl0b8id1669PqQ08",
 			"flareCategory": "CLASSIC",
 			"inGameID": 346
 		},
@@ -904,6 +979,7 @@
 		"artist": "DIVAS",
 		"data": {
 			"basename": "secr",
+			"ddrSongHash": "Db9D6Old6lIo01q0qlQ0dD1oDdbdob8I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 354
 		},
@@ -916,6 +992,7 @@
 		"artist": "NM feat. EBONY FAY",
 		"data": {
 			"basename": "rain",
+			"ddrSongHash": "Qo9l6l6lq0q618bQOb8d6qiooiiPQqoI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 356
 		},
@@ -928,6 +1005,7 @@
 		"artist": "Z",
 		"data": {
 			"basename": "unli",
+			"ddrSongHash": "lObPDQDI08DoodDq1061IP1qbQ1qQQbl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 357
 		},
@@ -940,6 +1018,7 @@
 		"artist": "小坂りゆ",
 		"data": {
 			"basename": "toth",
+			"ddrSongHash": "8Pb6oPdbO6lo8lbiQ181IDidI9ll8q80",
 			"flareCategory": "CLASSIC",
 			"inGameID": 358
 		},
@@ -952,6 +1031,7 @@
 		"artist": "RevenG vs DE-SIRE",
 		"data": {
 			"basename": "tsug",
+			"ddrSongHash": "io688qld6Pqq6bI01q86illP18biq0bd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 359
 		},
@@ -964,6 +1044,7 @@
 		"artist": "BeForU",
 		"data": {
 			"basename": "roll",
+			"ddrSongHash": "bqQ1OQDidQD8QbIqql06O6o1QD6oOodP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 360
 		},
@@ -976,6 +1057,7 @@
 		"artist": "Mr.T with Motoaki. F",
 		"data": {
 			"basename": "opti",
+			"ddrSongHash": "i86qD6Pl61dPI0Q9db1P8bl1ii99q1lD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 361
 		},
@@ -988,6 +1070,7 @@
 		"artist": "AKIRA YAMAOKA",
 		"data": {
 			"basename": "ifee",
+			"ddrSongHash": "DddIPd6iId8Doqq8OibDlD1dOi8PO8o9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 364
 		},
@@ -1000,6 +1083,7 @@
 		"artist": "小坂りゆ",
 		"data": {
 			"basename": "andy",
+			"ddrSongHash": "1Qqo9bID18OdiI1Qb0lP9DIqIO6ldPOP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 365
 		},
@@ -1012,6 +1096,7 @@
 		"artist": "dj TAKA with NAOKI",
 		"data": {
 			"basename": "kaku",
+			"ddrSongHash": "l9lq19DdiD8qQPoPOlboi1qQii0IQI86",
 			"flareCategory": "CLASSIC",
 			"inGameID": 371
 		},
@@ -1024,6 +1109,7 @@
 		"artist": "RE-VENGE",
 		"data": {
 			"basename": "afro3",
+			"ddrSongHash": "DdO1iboqI6980Q6QPD9P1PbQQ88I16lq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 372
 		},
@@ -1036,6 +1122,7 @@
 		"artist": "KTz",
 		"data": {
 			"basename": "star3",
+			"ddrSongHash": "808dq8OIq16PP19i1bP0IDP1OqPOlo6q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 373
 		},
@@ -1048,6 +1135,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bril3",
+			"ddrSongHash": "i18OPo6l8Q6bo9q0qP6889IDqoP8O0Qq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 374
 		},
@@ -1060,6 +1148,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bfor3",
+			"ddrSongHash": "POIDil00didIo98D10loIObibPOob88O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 375
 		},
@@ -1072,6 +1161,7 @@
 		"artist": "NW260",
 		"data": {
 			"basename": "drop3",
+			"ddrSongHash": "d0P01d9q8oOd8OP1bQPoqlq96906PqPD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 376
 		},
@@ -1084,6 +1174,7 @@
 		"artist": "NM",
 		"data": {
 			"basename": "hyst3",
+			"ddrSongHash": "lPloI86odlIbIo96P169b9I0Ob8lD189",
 			"flareCategory": "CLASSIC",
 			"inGameID": 378
 		},
@@ -1096,6 +1187,7 @@
 		"artist": "Crystal Aliens",
 		"data": {
 			"basename": "sexy3",
+			"ddrSongHash": "O06Id8PIDbDblO109ddi1dldd0bqDdQ1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 380
 		},
@@ -1108,6 +1200,7 @@
 		"artist": "D.J.RICH feat. TAILBROS.",
 		"data": {
 			"basename": "sprs3",
+			"ddrSongHash": "0qQ1odlooiQO99DDP6bD9bOq89669PQb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 381
 		},
@@ -1120,6 +1213,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "stil3",
+			"ddrSongHash": "DOOb99dlP8PdIbDOQIqoqll60Iob9189",
 			"flareCategory": "CLASSIC",
 			"inGameID": 382
 		},
@@ -1132,6 +1226,7 @@
 		"artist": "FACTOR-X",
 		"data": {
 			"basename": "wild3",
+			"ddrSongHash": "ibOQ0QOdIPdIbIo0oPoDDI1DqPId00li",
 			"flareCategory": "CLASSIC",
 			"inGameID": 383
 		},
@@ -1144,6 +1239,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "burn3",
+			"ddrSongHash": "QdbPPPDlIQiI191qPdblO01O8P8o6D68",
 			"flareCategory": "CLASSIC",
 			"inGameID": 384
 		},
@@ -1156,6 +1252,7 @@
 		"artist": "RevenG vs DE-SIRE",
 		"data": {
 			"basename": "tsug3",
+			"ddrSongHash": "1qDD1DdPlId69010IQ18I6q8Q00IoI6D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 385
 		},
@@ -1168,6 +1265,7 @@
 		"artist": "d-complex",
 		"data": {
 			"basename": "ecst3",
+			"ddrSongHash": "Dd6lP00DPqIb0d6iqOdlO08l69l6q1di",
 			"flareCategory": "CLASSIC",
 			"inGameID": 386
 		},
@@ -1180,6 +1278,7 @@
 		"artist": "THOMAS HOWARD",
 		"data": {
 			"basename": "sile3",
+			"ddrSongHash": "oio6bqP08PPoP9qIq1oi9Dib9PIq9l11",
 			"flareCategory": "CLASSIC",
 			"inGameID": 387
 		},
@@ -1192,6 +1291,7 @@
 		"artist": "N.M.R",
 		"data": {
 			"basename": "nite3",
+			"ddrSongHash": "O6q1o06Po9lQbqOl08Io1obqQ9QPi09b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 388
 		},
@@ -1204,6 +1304,7 @@
 		"artist": "NM feat. SUNNY",
 		"data": {
 			"basename": "gher3",
+			"ddrSongHash": "8DQDq16PPlli6o9iDl11DqooqOPlOb08",
 			"flareCategory": "CLASSIC",
 			"inGameID": 389
 		},
@@ -1216,6 +1317,7 @@
 		"artist": "MITSU-O! with GEILA",
 		"data": {
 			"basename": "summ3",
+			"ddrSongHash": "d99P0I1i960QO0oolD6oQIO8OObO9Plb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 390
 		},
@@ -1228,6 +1330,7 @@
 		"artist": "FIXX",
 		"data": {
 			"basename": "vani",
+			"ddrSongHash": "DDqDDqDQ1Db60IiIDbIl6Pd8DPOq0q06",
 			"flareCategory": "CLASSIC",
 			"inGameID": 411
 		},
@@ -1240,6 +1343,7 @@
 		"artist": "FinalOffset",
 		"data": {
 			"basename": "jamm",
+			"ddrSongHash": "IoI10obli6qd9DI699l61Pq16P9bboDd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 414
 		},
@@ -1252,6 +1356,7 @@
 		"artist": "DJ TAKA",
 		"data": {
 			"basename": "logi",
+			"ddrSongHash": "8O86IP9dqQ8818ld9od8Q0PiDId6666P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 415
 		},
@@ -1264,6 +1369,7 @@
 		"artist": "L.E.D. feat. Sana",
 		"data": {
 			"basename": "shin",
+			"ddrSongHash": "ODQOP1dblD6q8d160Ioi0dIoQloI6oQO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 420
 		},
@@ -1276,6 +1382,7 @@
 		"artist": "Scotty D.",
 		"data": {
 			"basename": "bom2",
+			"ddrSongHash": "I0b6lIP691dOOI8PqDDlbPid9iO8o0lO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 421
 		},
@@ -1288,6 +1395,7 @@
 		"artist": "CLUB SPICE",
 		"data": {
 			"basename": "mcut",
+			"ddrSongHash": "doQI0i6lQbOo66DOi6olPqOPqIqO8Qd1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 428
 		},
@@ -1300,6 +1408,7 @@
 		"artist": "小坂りゆ",
 		"data": {
 			"basename": "suns",
+			"ddrSongHash": "qIP6DPdbD9iO86i1DO9qDd8l6dPdbl0P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 429
 		},
@@ -1312,6 +1421,7 @@
 		"artist": "270",
 		"data": {
 			"basename": "surv",
+			"ddrSongHash": "O9Id8Qi6OIDIQ6bPi610q0001l1P099q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 430
 		},
@@ -1324,6 +1434,7 @@
 		"artist": "NAOKI feat. SHANTI",
 		"data": {
 			"basename": "issk",
+			"ddrSongHash": "qIoDdQ1OOoPO8Q1Io0P168161DODPoqb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 436
 		},
@@ -1336,6 +1447,7 @@
 		"artist": "dj TAKA feat.のりあ",
 		"data": {
 			"basename": "suga",
+			"ddrSongHash": "iI8qbP0IIb16Oi9bIbb8O9dbDDi1ql86",
 			"flareCategory": "CLASSIC",
 			"inGameID": 437
 		},
@@ -1348,6 +1460,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "lamo",
+			"ddrSongHash": "8IIoIQQqlooiI6QD9ldIO6qidP98QP68",
 			"flareCategory": "CLASSIC",
 			"inGameID": 438
 		},
@@ -1360,6 +1473,7 @@
 		"artist": "Kelly Cosmo",
 		"data": {
 			"basename": "imgo",
+			"ddrSongHash": "lPoD60qooQ91QDq1qO9d19q9IoDIlPq9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 439
 		},
@@ -1372,6 +1486,7 @@
 		"artist": "くにたけ みゆき",
 		"data": {
 			"basename": "stin",
+			"ddrSongHash": "1diQi81loIodIdOlQ8Pd6Qd8b69Q1DP8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 440
 		},
@@ -1384,6 +1499,7 @@
 		"artist": "Hirofumi Sasaki",
 		"data": {
 			"basename": "thel",
+			"ddrSongHash": "lO68Q0iPIOiOIDDd8dOPoiql9OI81DQ0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 441
 		},
@@ -1396,6 +1512,7 @@
 		"artist": "TOMOSUKE",
 		"data": {
 			"basename": "game",
+			"ddrSongHash": "69qoD0l6olQqqbl09b069q898b600I6o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 442
 		},
@@ -1408,6 +1525,7 @@
 		"artist": "T.E.M.P.O. feat.Mohammed & Emi",
 		"data": {
 			"basename": "jane",
+			"ddrSongHash": "8qd9d01dPOq1lOOoPiOIoPobdd1QODPq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 443
 		},
@@ -1420,6 +1538,7 @@
 		"artist": "D-Crew",
 		"data": {
 			"basename": "belo",
+			"ddrSongHash": "P0O81Dl9Oiiid8bdOi0oqbD8DqolObbP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 445
 		},
@@ -1432,6 +1551,7 @@
 		"artist": "Togo Project feat. Sana",
 		"data": {
 			"basename": "ledl",
+			"ddrSongHash": "i9DPi1Do9qoIQid09o1oilodPlDP6doO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 446
 		},
@@ -1444,6 +1564,7 @@
 		"artist": "BeForU",
 		"data": {
 			"basename": "radu",
+			"ddrSongHash": "10oQOoD00O1ql8qD88dI0i0biP69blq6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 447
 		},
@@ -1456,6 +1577,7 @@
 		"artist": "TAKA",
 		"data": {
 			"basename": "vvvv",
+			"ddrSongHash": "Ilo6IboPOq8Q10qDOdDDoO6P989bPPi6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 448
 		},
@@ -1468,6 +1590,7 @@
 		"artist": "D.J.Amuro",
 		"data": {
 			"basename": "aaaa",
+			"ddrSongHash": "oIb699q80OIPdlP0odl6bqbD0PlQodOq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 449
 		},
@@ -1480,6 +1603,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "colo",
+			"ddrSongHash": "odOQ1d1i6oil81b1QIDP6dOqqdooD918",
 			"flareCategory": "CLASSIC",
 			"inGameID": 452
 		},
@@ -1492,6 +1616,7 @@
 		"artist": "emi",
 		"data": {
 			"basename": "tayy",
+			"ddrSongHash": "6lqoOddiPQ6D6160bOdP116bQdIliII8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 453
 		},
@@ -1504,6 +1629,7 @@
 		"artist": "NAOKI J-STYLE feat.MIU",
 		"data": {
 			"basename": "meal",
+			"ddrSongHash": "iOqb60DOOolIioDIOPi09P91i8PDiOqq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 454
 		},
@@ -1516,6 +1642,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "froz",
+			"ddrSongHash": "IQ9bDo1dPbIo0ODQiObbQ99iP1bOi8iI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 456
 		},
@@ -1528,6 +1655,7 @@
 		"artist": "Des-ROW feat. TSUBOI for ALPHA",
 		"data": {
 			"basename": "daik",
+			"ddrSongHash": "I8lidoibqQqoQOqiDi6QiDbP9DIdd989",
 			"flareCategory": "CLASSIC",
 			"inGameID": 459
 		},
@@ -1540,6 +1668,7 @@
 		"artist": "Mutsuhiko Izumi",
 		"data": {
 			"basename": "jetw",
+			"ddrSongHash": "1PQdDiqOD6o1b61iiDOoiiblIQbI91Pb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 462
 		},
@@ -1552,6 +1681,7 @@
 		"artist": "ASKA",
 		"data": {
 			"basename": "wedd",
+			"ddrSongHash": "oo8DId90dbDliiQQlQPQQoIq6lPliqo9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 463
 		},
@@ -1564,6 +1694,7 @@
 		"artist": "290",
 		"data": {
 			"basename": "surv3",
+			"ddrSongHash": "68iQ9666QIQP1IOQbbd9989DQQ1D0dOl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 464
 		},
@@ -1576,6 +1707,7 @@
 		"artist": "RevenG",
 		"data": {
 			"basename": "bagg",
+			"ddrSongHash": "9qbdq1PiI1O81P1PdioQli66Ob9QiiQP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 465
 		},
@@ -1588,6 +1720,7 @@
 		"artist": "ZZ",
 		"data": {
 			"basename": "lege",
+			"ddrSongHash": "li608di8PolqqIP808iddOqi11qDDq0Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 466
 		},
@@ -1600,6 +1733,7 @@
 		"artist": "NAOKI feat.YUKI",
 		"data": {
 			"basename": "aois",
+			"ddrSongHash": "OboID1PloIIoOOObQdQOP110I61Ddl9I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 467
 		},
@@ -1612,6 +1746,7 @@
 		"artist": "亜熱帯マジ-SKA爆弾",
 		"data": {
 			"basename": "mike",
+			"ddrSongHash": "Dl69Pb9OQDlbOi80OQdIObiQ1Q08Dlqo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 468
 		},
@@ -1624,6 +1759,7 @@
 		"artist": "OutPhase",
 		"data": {
 			"basename": "yncc",
+			"ddrSongHash": "8lo1IDqPDD88DObIPodOd8oQ0Q6qQ1Dd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 469
 		},
@@ -1636,6 +1772,7 @@
 		"artist": "TaQ",
 		"data": {
 			"basename": "stoi",
+			"ddrSongHash": "OoIPPqIDbQ6qIb69q8dil0iq0l6q6DQD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 470
 		},
@@ -1648,6 +1785,7 @@
 		"artist": "DJ SIMON",
 		"data": {
 			"basename": "tars",
+			"ddrSongHash": "Q96bO9D61lib19IiIi0i69P80bo6q69Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 471
 		},
@@ -1660,6 +1798,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "ichi",
+			"ddrSongHash": "ddOOOibQ6qIi9DI1bl8b108I1Ib6QDl9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 472
 		},
@@ -1672,6 +1811,7 @@
 		"artist": "FinalOffset",
 		"data": {
 			"basename": "gene",
+			"ddrSongHash": "0l181DPDqbQPb0qQl0i0dlQd0oQPlQ6i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 473
 		},
@@ -1684,6 +1824,7 @@
 		"artist": "Mr.T",
 		"data": {
 			"basename": "xeno",
+			"ddrSongHash": "bDDd08iP8dlIlOo6iqd91dPiI1lQdOQq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 474
 		},
@@ -1696,6 +1837,7 @@
 		"artist": "Reven-G",
 		"data": {
 			"basename": "saku",
+			"ddrSongHash": "911lId0IooIOq1oDPoQ0iQiDiOIbd6oo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 475
 		},
@@ -1708,6 +1850,7 @@
 		"artist": "Kiyommy+Seiya",
 		"data": {
 			"basename": "rose",
+			"ddrSongHash": "O09lbd0I8D0DI08O06l6iiI0i11I1iIb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 476
 		},
@@ -1720,6 +1863,7 @@
 		"artist": "Hiro feat. Sweet little 30's",
 		"data": {
 			"basename": "heav",
+			"ddrSongHash": "oDlO8QQOQ68IO61q9PQd800QiOll1odI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 477
 		},
@@ -1732,6 +1876,7 @@
 		"artist": "NAOKI feat. DDR ALL STARS",
 		"data": {
 			"basename": "hype",
+			"ddrSongHash": "I08olqilqQi9Dd0qOq0o09PPqI0l11QI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 478
 		},
@@ -1744,6 +1889,7 @@
 		"artist": "メキシコ民謡",
 		"data": {
 			"basename": "laba",
+			"ddrSongHash": "9IOdDPPO1IIPD9oDbOPo0Qo99Ii6Q8oi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 479
 		},
@@ -1756,6 +1902,7 @@
 		"artist": "DDR ALL STARS",
 		"data": {
 			"basename": "ddre",
+			"ddrSongHash": "6lQ9iQdq8P0Q11q9O8dbl9Q9Pi8bIb98",
 			"flareCategory": "CLASSIC",
 			"inGameID": 480
 		},
@@ -1768,6 +1915,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "ripm",
+			"ddrSongHash": "POO9PlPq66OqIQO6Oq1i90D6Ill100il",
 			"flareCategory": "CLASSIC",
 			"inGameID": 481
 		},
@@ -1780,6 +1928,7 @@
 		"artist": "DJ SIMON",
 		"data": {
 			"basename": "airr",
+			"ddrSongHash": "il6PIiDq11dD1981dQ00918D96lPQ0iQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 482
 		},
@@ -1792,6 +1941,7 @@
 		"artist": "NAOKI underground feat.EK",
 		"data": {
 			"basename": "tear",
+			"ddrSongHash": "1Q1Q8oO600lodPbio8b8d66b8do1PIlQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 484
 		},
@@ -1804,6 +1954,7 @@
 		"artist": "Jimmy Weckl",
 		"data": {
 			"basename": "acro",
+			"ddrSongHash": "O6I9ioqii8i6I1DIb1PqOD6q0ooo8bDo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 486
 		},
@@ -1816,6 +1967,7 @@
 		"artist": "Funk Kid feat. KOOL BOYS",
 		"data": {
 			"basename": "funk",
+			"ddrSongHash": "i6Q00D16PbbQPl19oibiiQ6qQD01D6o8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24576
 		},
@@ -1828,6 +1980,7 @@
 		"artist": "S.F.M.P.",
 		"data": {
 			"basename": "tryl",
+			"ddrSongHash": "doqDbod0d81qP6PoPiP8b0P00PD8oboD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24577
 		},
@@ -1840,6 +1993,7 @@
 		"artist": "Chel Y.",
 		"data": {
 			"basename": "frve",
+			"ddrSongHash": "Q8Ioq8POo69ol8bPiOPQPq61oqoPo0DO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24581
 		},
@@ -1852,6 +2006,7 @@
 		"artist": "Sota feat. Brenda V.",
 		"data": {
 			"basename": "satn",
+			"ddrSongHash": "o9l8Id0D1lQdl1o9DDIPbO6q998lq8bd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24582
 		},
@@ -1864,6 +2019,7 @@
 		"artist": "D.J. Spugna",
 		"data": {
 			"basename": "brou",
+			"ddrSongHash": "d0q8IDbqDI686q9Dl09ll0Id6bIio9Pd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24583
 		},
@@ -1876,6 +2032,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "tomo",
+			"ddrSongHash": "D1D88PPI0PDQqOq00OI6QI1o6dPolqlI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 24586
 		},
@@ -1888,6 +2045,7 @@
 		"artist": "CLI-MAX S.",
 		"data": {
 			"basename": "mize",
+			"ddrSongHash": "OQol16I968Q8bDoQd80i90oQQbqOdbdP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28690
 		},
@@ -1900,6 +2058,7 @@
 		"artist": "Supa Fova feat. Jenny F.",
 		"data": {
 			"basename": "inee",
+			"ddrSongHash": "1i6ObblIOoPo6dDd9dIIq11l60qiD9di",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28691
 		},
@@ -1912,6 +2071,7 @@
 		"artist": "Sho-T",
 		"data": {
 			"basename": "stup",
+			"ddrSongHash": "DibQ8O0bIodbdQo8D681qlqiDqllDPql",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28700
 		},
@@ -1924,6 +2084,7 @@
 		"artist": "Shawn the Horny Master",
 		"data": {
 			"basename": "scor",
+			"ddrSongHash": "16Pio809ID669Di8OoPblQO0lDq668dQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28701
 		},
@@ -1936,6 +2097,7 @@
 		"artist": "SDMS",
 		"data": {
 			"basename": "deux",
+			"ddrSongHash": "99P8bDO1PqlddQqo81QOIPO60lPQqlO8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 28717
 		},
@@ -1948,6 +2110,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "maxp",
+			"ddrSongHash": "89I0ooQbbI1I6O1iq861PQQqIo9iO86b",
 			"flareCategory": "WHITE",
 			"inGameID": 28718
 		},
@@ -1960,6 +2123,7 @@
 		"artist": "Vision F",
 		"data": {
 			"basename": "canb",
+			"ddrSongHash": "68dqbIdOiiiiddlbb1OD66qq6d80I6D8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 32768
 		},
@@ -1972,6 +2136,7 @@
 		"artist": ".3k",
 		"data": {
 			"basename": "parb",
+			"ddrSongHash": "IP00ID9bdlOoP9o9lo1qlO0D1Pdo9I8l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 32774
 		},
@@ -1984,6 +2149,7 @@
 		"artist": "BeForU",
 		"data": {
 			"basename": "free",
+			"ddrSongHash": "PPddP6OOldodoOPqiId19Pd919OOid61",
 			"flareCategory": "CLASSIC",
 			"inGameID": 32784
 		},
@@ -1996,6 +2162,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "stas",
+			"ddrSongHash": "6qQb9I0QbD89IID9b9iOPdO6dbqPDolQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 32785
 		},
@@ -2008,6 +2175,7 @@
 		"artist": "NM feat. Thomas Howard",
 		"data": {
 			"basename": "bald",
+			"ddrSongHash": "ObP1P1OoDII9b9ll698Q981ilIddb8Id",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33028
 		},
@@ -2020,6 +2188,7 @@
 		"artist": "THE SURRENDERS",
 		"data": {
 			"basename": "gorg",
+			"ddrSongHash": "b0Po680ibI600ObOi6qqidI06oqo0Olq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33034
 		},
@@ -2032,6 +2201,7 @@
 		"artist": "N.M.R-typeG",
 		"data": {
 			"basename": "kee2",
+			"ddrSongHash": "PQPloiIQ19QDP9QoI1ld9DlDObIOP689",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33038
 		},
@@ -2044,6 +2214,7 @@
 		"artist": "TOMOSUKE",
 		"data": {
 			"basename": "mind",
+			"ddrSongHash": "b6dqPiOO6iO6b8D90Ido6QPOlObd9o98",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33044
 		},
@@ -2056,6 +2227,7 @@
 		"artist": "UZI-LAY",
 		"data": {
 			"basename": "put3",
+			"ddrSongHash": "OI01b6I6OQ9IdQidll890oqlOPDql9ol",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33047
 		},
@@ -2068,6 +2240,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "quic",
+			"ddrSongHash": "QI96D9PqIQ90PidPQPdbqbi0q9q8lQbb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33048
 		},
@@ -2080,6 +2253,7 @@
 		"artist": "Naoto Suzuki feat. Martha",
 		"data": {
 			"basename": "polo",
+			"ddrSongHash": "l609D9lOqbDP6iIld1dI18l888dODQ6Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33664
 		},
@@ -2092,6 +2266,7 @@
 		"artist": "Orange Lounge",
 		"data": {
 			"basename": "oran",
+			"ddrSongHash": "D6oPIlOlIIOi1oq6Pd6011lqobbqOlib",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33665
 		},
@@ -2104,6 +2279,7 @@
 		"artist": "Lala Moore with CoCoRo*Co",
 		"data": {
 			"basename": "diff",
+			"ddrSongHash": "0Oo6iId08018qOqbo6O1o0QQ9D09Piq1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33666
 		},
@@ -2116,6 +2292,7 @@
 		"artist": "NAOKI feat. PAULA TERRY",
 		"data": {
 			"basename": "mari",
+			"ddrSongHash": "6P6dPoi66qO980bQo6l1QdlQIooq086l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33667
 		},
@@ -2128,6 +2305,7 @@
 		"artist": "nc ft. Dreamscanner",
 		"data": {
 			"basename": "tmrr",
+			"ddrSongHash": "lQbiI10Qo9DdD8liqPIiob61qDO9d861",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33668
 		},
@@ -2140,6 +2318,7 @@
 		"artist": "nc ft. FINALFORCE",
 		"data": {
 			"basename": "sedu",
+			"ddrSongHash": "oIQo8IQPbobO6bioiqqdP6P6O8898DOQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33669
 		},
@@ -2152,6 +2331,7 @@
 		"artist": "AKIRA YAMAOKA",
 		"data": {
 			"basename": "insi",
+			"ddrSongHash": "O8qii6oiooPd8lbPqDo9QQioIoQQOoq0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33670
 		},
@@ -2164,6 +2344,7 @@
 		"artist": "NAOKI feat. PAULA TERRY",
 		"data": {
 			"basename": "pass",
+			"ddrSongHash": "8PQooio0ilPoQ8Di66I19QOQP90Ddbdi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33672
 		},
@@ -2176,6 +2357,7 @@
 		"artist": "Yuzo Koshiro",
 		"data": {
 			"basename": "youg",
+			"ddrSongHash": "D8I68Ibib9ldQDIPIQdO6lqI61PQlPO9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33673
 		},
@@ -2188,6 +2370,7 @@
 		"artist": "Love machineguns",
 		"data": {
 			"basename": "mids",
+			"ddrSongHash": "iI1iQD6Id0PiPDoo919doOooDib09I6b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33806
 		},
@@ -2200,6 +2383,7 @@
 		"artist": "Big Idea",
 		"data": {
 			"basename": "monk",
+			"ddrSongHash": "OoQ6Oq81oIql8iIlbI6qldIlqoD1Di1I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33808
 		},
@@ -2212,6 +2396,7 @@
 		"artist": "Big Idea",
 		"data": {
 			"basename": "bais",
+			"ddrSongHash": "lii9bbbIq08b6DIdQ16Q0QOPiOibliIO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33811
 		},
@@ -2224,6 +2409,7 @@
 		"artist": "Jondi & Spesh",
 		"data": {
 			"basename": "remx",
+			"ddrSongHash": "qOP1qP69o6id061o9bo8l6P11P1PQI1O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33818
 		},
@@ -2236,6 +2422,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "doll",
+			"ddrSongHash": "OO0QbD9D6QQIb10Q9IDOQd8odb6ob6qP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33834
 		},
@@ -2248,6 +2435,7 @@
 		"artist": "AKIRA YAMAOKA",
 		"data": {
 			"basename": "ifut",
+			"ddrSongHash": "0ib0Pqol08o9ODDq166iDl8oll061lPl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 33835
 		},
@@ -2260,6 +2448,7 @@
 		"artist": "D.J.Amuro",
 		"data": {
 			"basename": "aaaa2",
+			"ddrSongHash": "0DDo1ilPDQoIoPd8ol9OPO1IPbi9ii6d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36864
 		},
@@ -2272,6 +2461,7 @@
 		"artist": "Tatsh＆NAOKI",
 		"data": {
 			"basename": "rzon",
+			"ddrSongHash": "81QD89Q6Ob911oOoobO0D98IQ1D1q60d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36865
 		},
@@ -2284,6 +2474,7 @@
 		"artist": "jun with TAHIRIH",
 		"data": {
 			"basename": "hpan",
+			"ddrSongHash": "8DdIqobi0liOPDO1qld6lQ9Dq00I66qi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36866
 		},
@@ -2296,6 +2487,7 @@
 		"artist": "Tatsh",
 		"data": {
 			"basename": "xeph",
+			"ddrSongHash": "PQQd6lQlDqilqliI0IobolqIDlo0Iboq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36867
 		},
@@ -2308,6 +2500,7 @@
 		"artist": "RIYU from BeForU",
 		"data": {
 			"basename": "hima",
+			"ddrSongHash": "Ibd8d0bllqOo61lqlQPd8lP01D0Qb9o6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36868
 		},
@@ -2320,6 +2513,7 @@
 		"artist": "Kozo Nakamura",
 		"data": {
 			"basename": "drab",
+			"ddrSongHash": "PD9lP16dllbPqbdIO0Ii0I8D1I90QIIl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36869
 		},
@@ -2332,6 +2526,7 @@
 		"artist": "D-crew",
 		"data": {
 			"basename": "curu",
+			"ddrSongHash": "ilIbq9Db1d86PIo0b96qdd0oPOQ6bqi1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36870
 		},
@@ -2344,6 +2539,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "muge",
+			"ddrSongHash": "DQO6qbiP6dldo6IIqlob9i8dqiqOio6o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36871
 		},
@@ -2356,6 +2552,7 @@
 		"artist": "DJ YOSHITAKA feat G.S.C license",
 		"data": {
 			"basename": "nizi",
+			"ddrSongHash": "Io1D1l9QiDo6IDObd8qo1Q9lQ6iollQ9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36872
 		},
@@ -2368,6 +2565,7 @@
 		"artist": "あさき",
 		"data": {
 			"basename": "gekk",
+			"ddrSongHash": "qiDOD0iidOli9l0qbP6IbOD19OQ8D8Po",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36873
 		},
@@ -2380,6 +2578,7 @@
 		"artist": "あさき",
 		"data": {
 			"basename": "kono",
+			"ddrSongHash": "9idOOIdDO01D8PO06bOPPbOIOoiQ8O0P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36874
 		},
@@ -2392,6 +2591,7 @@
 		"artist": "dj TAKA feat.Erika",
 		"data": {
 			"basename": "mooo",
+			"ddrSongHash": "lI8qIDQPD0PDOdO1d01iOq8bI98iiQ1l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36875
 		},
@@ -2404,6 +2604,7 @@
 		"artist": "TAKA respect for J.S.B.",
 		"data": {
 			"basename": "thir",
+			"ddrSongHash": "81qibDQqq8idiD1lQqq0qdqD6i6q1QDb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36876
 		},
@@ -2416,6 +2617,7 @@
 		"artist": "Des-ROW・組",
 		"data": {
 			"basename": "dand",
+			"ddrSongHash": "POoldOddQl9Dbq8b6iOP0iPoQd6IdOPl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36877
 		},
@@ -2428,6 +2630,7 @@
 		"artist": "Des-ROW・組スペシアルr",
 		"data": {
 			"basename": "kage",
+			"ddrSongHash": "ql1Q8P100IIlbl0Pdi08I8qD900idqQq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36878
 		},
@@ -2440,6 +2643,7 @@
 		"artist": "BeForU",
 		"data": {
 			"basename": "tika",
+			"ddrSongHash": "I9iODl9bl1d8PilOilii9Dd19PP6QI66",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36879
 		},
@@ -2452,6 +2656,7 @@
 		"artist": "南さやか（BeForU）with platoniX",
 		"data": {
 			"basename": "unde",
+			"ddrSongHash": "oiQliqIliq91Dl169ldqbb18OPblOb1i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36880
 		},
@@ -2464,6 +2669,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "rara",
+			"ddrSongHash": "0OQdlbo111ib1i88IdIPIbollD68Dii1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36882
 		},
@@ -2476,6 +2682,7 @@
 		"artist": "Berimbau '66",
 		"data": {
 			"basename": "braz",
+			"ddrSongHash": "D0dI08oDqi11Oo819D6ob1dlDbPlIPl0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36883
 		},
@@ -2488,6 +2695,7 @@
 		"artist": "Jimmy Weckl",
 		"data": {
 			"basename": "taur",
+			"ddrSongHash": "bd8o99iPI9lqOl1Q8P68lbQOlo8Oq1qO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36884
 		},
@@ -2500,6 +2708,7 @@
 		"artist": "WILMA DE OLIVEIRA",
 		"data": {
 			"basename": "tier",
+			"ddrSongHash": "idDdoI9bD186blQ9Q8610bIQqb86dilo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36885
 		},
@@ -2512,6 +2721,7 @@
 		"artist": "亜熱帯マジ-SKA爆弾",
 		"data": {
 			"basename": "sksk",
+			"ddrSongHash": "idI1dd69l1il16P0d9DoldDP1QDP0911",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36886
 		},
@@ -2524,6 +2734,7 @@
 		"artist": "Morning Blue Dragon",
 		"data": {
 			"basename": "okor",
+			"ddrSongHash": "ibI0QllidqQ089ql8dob6bIoodbbIoqq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36887
 		},
@@ -2536,6 +2747,7 @@
 		"artist": "yu_tokiwa.djw",
 		"data": {
 			"basename": "murm",
+			"ddrSongHash": "QQdIOi1Q81IqIoDqo80P0I1Q9qIdq1il",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36888
 		},
@@ -2548,6 +2760,7 @@
 		"artist": "ChiyoTia",
 		"data": {
 			"basename": "flya",
+			"ddrSongHash": "d96OiPiOIboqI8o6PIDO8D9qPb9P18il",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36889
 		},
@@ -2560,6 +2773,7 @@
 		"artist": "nc ft NRG Factory",
 		"data": {
 			"basename": "inno",
+			"ddrSongHash": "qDi0dIlObi6Q6P8dQ1b8oIb188O9608o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36890
 		},
@@ -2572,6 +2786,7 @@
 		"artist": "NAOKI feat. Becky Lucinda",
 		"data": {
 			"basename": "myon",
+			"ddrSongHash": "Io1661doQq6OQ8DoobPq1IQlbqoDD1q8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36891
 		},
@@ -2584,6 +2799,7 @@
 		"artist": "Scotty D. revisits U1",
 		"data": {
 			"basename": "flow",
+			"ddrSongHash": "dDOdPQOqD6P68dIOl6O6I8q99Q6dd9Ob",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36892
 		},
@@ -2596,6 +2812,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "rbow",
+			"ddrSongHash": "qbDidIlodPP6PqI00D18P6dDbioIdDPD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36893
 		},
@@ -2608,6 +2825,7 @@
 		"artist": "SySF. feat. Donna Burke",
 		"data": {
 			"basename": "gate",
+			"ddrSongHash": "QD0q90q9PIl9PdqqO9D9DO09DbiODOI6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36895
 		},
@@ -2620,6 +2838,7 @@
 		"artist": "100-200-400",
 		"data": {
 			"basename": "fasc",
+			"ddrSongHash": "O6llIdODQD6oDQ6QiPQDOlob9i8l6qib",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36906
 		},
@@ -2632,6 +2851,7 @@
 		"artist": "Mokky de Yah Yah's",
 		"data": {
 			"basename": "cach",
+			"ddrSongHash": "DObld6O6OdblOo1di9dlP86DO909O6qI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36914
 		},
@@ -2644,6 +2864,7 @@
 		"artist": "act deft",
 		"data": {
 			"basename": "qmas",
+			"ddrSongHash": "D01oOb0IOQ1bbIIdi88O0d80Qo9dblqP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36916
 		},
@@ -2656,6 +2877,7 @@
 		"artist": "NAOKI with Y&Co.",
 		"data": {
 			"basename": "stop2",
+			"ddrSongHash": "8IdP90DQDi9bqodPqDQIIqOqOO08PPio",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36917
 		},
@@ -2668,6 +2890,7 @@
 		"artist": "NC feat. NRG Factory",
 		"data": {
 			"basename": "sedu2",
+			"ddrSongHash": "PO1olqI8DiDiO0loDIIQ08oPd910bQbQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36920
 		},
@@ -2680,6 +2903,7 @@
 		"artist": "DE-SIRE retunes",
 		"data": {
 			"basename": "chao",
+			"ddrSongHash": "8o1iQPiId8P6Db9Iqo1Oo119QDoq8qQ8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36925
 		},
@@ -2692,6 +2916,7 @@
 		"artist": "LH MUSIC CREATION",
 		"data": {
 			"basename": "lab3",
+			"ddrSongHash": "qbQ9I1bI6q91Q18DlDlI1Qdi8q6Qlo91",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36928
 		},
@@ -2704,6 +2929,7 @@
 		"artist": "jun feat. Schanita",
 		"data": {
 			"basename": "tlov",
+			"ddrSongHash": "oD6l698q0bQqoIOi0Dd66bqObII8QqDl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36931
 		},
@@ -2716,6 +2942,7 @@
 		"artist": "DE-STRAD",
 		"data": {
 			"basename": "dvis",
+			"ddrSongHash": "109P1iO9i6q1q0bdQobiodQDoD619dqd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36934
 		},
@@ -2728,6 +2955,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "hana",
+			"ddrSongHash": "6iq1dqQ1PDQlDO0bio0l89oDDDi6b0oD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36935
 		},
@@ -2740,6 +2968,7 @@
 		"artist": "Scotty D. revisits U1",
 		"data": {
 			"basename": "flow2",
+			"ddrSongHash": "0D096II0i9l0doPlbPQbiPo1IQDDoOP0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36936
 		},
@@ -2752,6 +2981,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "fasc2",
+			"ddrSongHash": "8QbqP80q9PI8bbi0qOoiibOQD08OPdli",
 			"flareCategory": "CLASSIC",
 			"inGameID": 36937
 		},
@@ -2764,6 +2994,7 @@
 		"artist": "Shawn the Horny Master feat. ChiyoTia",
 		"data": {
 			"basename": "flya2",
+			"ddrSongHash": "DQI8O1bD9Oi9i90i0DqqOqbll91IiQI1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37120
 		},
@@ -2776,6 +3007,7 @@
 		"artist": "nc ft HARDCORE NATION",
 		"data": {
 			"basename": "soul",
+			"ddrSongHash": "o1QoI9dQ1i89bPl1oDl6999861obD0qI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37121
 		},
@@ -2788,6 +3020,7 @@
 		"artist": "SySF. feat. Donna Burke",
 		"data": {
 			"basename": "gate2",
+			"ddrSongHash": "6I0d1d8d690dl8boOb60O1Iq1Ddi6P8d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37122
 		},
@@ -2800,6 +3033,7 @@
 		"artist": "kobo uniting Marsha & D.",
 		"data": {
 			"basename": "moos",
+			"ddrSongHash": "olOOdb66Q0bP0dqQPdIdQ8IPQql8D6bi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37123
 		},
@@ -2812,6 +3046,7 @@
 		"artist": "Scotty D. revisits U1",
 		"data": {
 			"basename": "flow3",
+			"ddrSongHash": "O111bDqd0oQ1O8IqiIDQq091l1IDO8oI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37124
 		},
@@ -2824,6 +3059,7 @@
 		"artist": "SySF.",
 		"data": {
 			"basename": "felw",
+			"ddrSongHash": "98PiPl8P0qlq8dd8P60Iq6dq899lbQDI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37125
 		},
@@ -2836,6 +3072,7 @@
 		"artist": "U1 Reincarnates w/ Leah",
 		"data": {
 			"basename": "silv",
+			"ddrSongHash": "bi1Obd9i99P0O9PqQ1l1P6P6o1IOi11P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37126
 		},
@@ -2848,6 +3085,7 @@
 		"artist": "kobo",
 		"data": {
 			"basename": "trim",
+			"ddrSongHash": "POQQQqI8q69qP6Id8Ol01QI60OIoiil8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37127
 		},
@@ -2860,6 +3098,7 @@
 		"artist": "SySF.",
 		"data": {
 			"basename": "fied",
+			"ddrSongHash": "9d0oQdIolIb0Po9b06QOiOP60IQlb8qO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37187
 		},
@@ -2872,6 +3111,7 @@
 		"artist": "nc ft. 触電",
 		"data": {
 			"basename": "mitr",
+			"ddrSongHash": "i11d86DOOdOb8Pbb1QqIilQI9Idib8PP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37188
 		},
@@ -2884,6 +3124,7 @@
 		"artist": "nc ft NRG factory",
 		"data": {
 			"basename": "mala",
+			"ddrSongHash": "1Q9l881P1bq8bQQ9OOqQ10OioP68bQ8o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37189
 		},
@@ -2896,6 +3137,7 @@
 		"artist": "jun feat. PAULA TERRY",
 		"data": {
 			"basename": "rasp",
+			"ddrSongHash": "60qiDd000qDIobO0QI916i18bbolO919",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37190
 		},
@@ -2908,6 +3150,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "bloo",
+			"ddrSongHash": "oQ0bqIQ8DdPlilO000DQloOo6Od8IdQ6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37191
 		},
@@ -2920,6 +3163,7 @@
 		"artist": "kobo feat. kr:agué",
 		"data": {
 			"basename": "dazz",
+			"ddrSongHash": "DdIbd6Pbl910P6QOqD6iQI0l0b1qdI8q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37206
 		},
@@ -2932,6 +3176,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "fway",
+			"ddrSongHash": "dd8PodO0ilIQQb0P0OQPDiodI9biP91d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37207
 		},
@@ -2944,6 +3189,7 @@
 		"artist": "W.W.S",
 		"data": {
 			"basename": "lshi",
+			"ddrSongHash": "8dDQIPOo681iID8IiibbD8IbIldI86P1",
 			"flareCategory": "GOLD",
 			"inGameID": 37221
 		},
@@ -2956,6 +3202,7 @@
 		"artist": "J-RAVERS",
 		"data": {
 			"basename": "spar",
+			"ddrSongHash": "dPb99qdqOQ1ioQ9Dqb1I9Q1bI0l0POII",
 			"flareCategory": "GOLD",
 			"inGameID": 37223
 		},
@@ -2968,6 +3215,7 @@
 		"artist": "The Sweetest",
 		"data": {
 			"basename": "cufo",
+			"ddrSongHash": "1idPoQOiI8611P01Oddo1D19lQO8dQdl",
 			"flareCategory": "GOLD",
 			"inGameID": 37224
 		},
@@ -2992,6 +3240,7 @@
 		"artist": "trance star",
 		"data": {
 			"basename": "conf",
+			"ddrSongHash": "i19IOi90Dq90ll989iIdOP9diodqi968",
 			"flareCategory": "WHITE",
 			"inGameID": 37226
 		},
@@ -3004,6 +3253,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "will",
+			"ddrSongHash": "d6iI8ii9qi0Pi80dDQQlPq6qQo69860P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37228
 		},
@@ -3016,6 +3266,7 @@
 		"artist": "Freeman",
 		"data": {
 			"basename": "lits",
+			"ddrSongHash": "Q8iOiOPbl1lI6D6bbib8Il8lPqlIl1b9",
 			"flareCategory": "GOLD",
 			"inGameID": 37229
 		},
@@ -3028,6 +3279,7 @@
 		"artist": "Stepper",
 		"data": {
 			"basename": "ifly",
+			"ddrSongHash": "OiDP81OQD0I810I89qdqIiDDP6i9qO0q",
 			"flareCategory": "GOLD",
 			"inGameID": 37231
 		},
@@ -3040,6 +3292,7 @@
 		"artist": "Happy CoreMAN",
 		"data": {
 			"basename": "wwlt",
+			"ddrSongHash": "I8Odid0QlODlOilqdllqlQldq996QQbP",
 			"flareCategory": "GOLD",
 			"inGameID": 37232
 		},
@@ -3052,6 +3305,7 @@
 		"artist": "The Lonely Hearts",
 		"data": {
 			"basename": "hand",
+			"ddrSongHash": "dqbd8PD01bI8qlQ1QQ9iP896P88D1O1o",
 			"flareCategory": "GOLD",
 			"inGameID": 37233
 		},
@@ -3064,6 +3318,7 @@
 		"artist": "Sparky",
 		"data": {
 			"basename": "tbea",
+			"ddrSongHash": "i1ibID6lOoiPQ1lli86P9lIIqOoDlldQ",
 			"flareCategory": "GOLD",
 			"inGameID": 37236
 		},
@@ -3076,6 +3331,7 @@
 		"artist": "NM feat. Alison Wade",
 		"data": {
 			"basename": "bins",
+			"ddrSongHash": "d0IiI99IlI00lq606l68qOIl8PidiOlO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37237
 		},
@@ -3088,6 +3344,7 @@
 		"artist": "Latenighter",
 		"data": {
 			"basename": "mwit",
+			"ddrSongHash": "8D9D6ld0bP9bP119OIlQI9ol919IDD86",
 			"flareCategory": "GOLD",
 			"inGameID": 37238
 		},
@@ -3100,6 +3357,7 @@
 		"artist": "Black Rose Garden",
 		"data": {
 			"basename": "trea",
+			"ddrSongHash": "1iIoi89doDiQoo8o0ddl9PQdQP0Ili8O",
 			"flareCategory": "WHITE",
 			"inGameID": 37239
 		},
@@ -3112,6 +3370,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "samu",
+			"ddrSongHash": "PDODO6Qdb9iqd6q0QoI0PiI0lb8l9I6d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37240
 		},
@@ -3124,6 +3383,7 @@
 		"artist": "U1",
 		"data": {
 			"basename": "ucha",
+			"ddrSongHash": "6o6OObQo9oQl6Q1oq6OPqibQI61IlPq8",
 			"flareCategory": "GOLD",
 			"inGameID": 37241
 		},
@@ -3136,6 +3396,7 @@
 		"artist": "800 slopes",
 		"data": {
 			"basename": "tigh",
+			"ddrSongHash": "Q910dl1olqQ9qdO6q1q1O9Pq9b80lP6P",
 			"flareCategory": "GOLD",
 			"inGameID": 37242
 		},
@@ -3148,6 +3409,7 @@
 		"artist": "鍋嶋圭一",
 		"data": {
 			"basename": "ngoo",
+			"ddrSongHash": "iP6qIl6lD809098io0OiPP08Ii18I6OI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37251
 		},
@@ -3160,6 +3422,7 @@
 		"artist": "泉 陸奥彦",
 		"data": {
 			"basename": "firr",
+			"ddrSongHash": "PlqI9Q1I6qdqb0IolOl1qP0bOQP0ibPP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37254
 		},
@@ -3172,6 +3435,7 @@
 		"artist": "Black Rose Garden",
 		"data": {
 			"basename": "unre",
+			"ddrSongHash": "olQl6Qoi0IbobI980q9Q0QIo9qlbq1PO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37255
 		},
@@ -3184,6 +3448,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "stah",
+			"ddrSongHash": "bq1O60D90Qbb6iPoi90Ii9olQOIO0Ib1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37256
 		},
@@ -3196,6 +3461,7 @@
 		"artist": "DJ YOSHITAKA feat.A/I",
 		"data": {
 			"basename": "vate",
+			"ddrSongHash": "Iqo9PQiPbq8Q0I6io6lPIDi608lQqbbq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37264
 		},
@@ -3208,6 +3474,7 @@
 		"artist": "Tatsh+RayZY",
 		"data": {
 			"basename": "venu",
+			"ddrSongHash": "6bIODbPoIDlOdO66b1id0q68qdQilDd6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37265
 		},
@@ -3220,6 +3487,7 @@
 		"artist": "Zektbach",
 		"data": {
 			"basename": "blin",
+			"ddrSongHash": "PP9QDQ0IQQID00P61d8qdDdP09b19iiI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37266
 		},
@@ -3232,6 +3500,7 @@
 		"artist": "D-crew 2 US",
 		"data": {
 			"basename": "athi",
+			"ddrSongHash": "O0O1lPoIIIQ9lbOi90odI0Di80qq16lo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37267
 		},
@@ -3244,6 +3513,7 @@
 		"artist": "TAKA respect for J.S.B.",
 		"data": {
 			"basename": "uber",
+			"ddrSongHash": "1oIo1DliQqPol00Q1l1bPODbdOilodod",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37269
 		},
@@ -3256,6 +3526,7 @@
 		"artist": "Reven-G改",
 		"data": {
 			"basename": "arra",
+			"ddrSongHash": "6bdDP91o1II60Qo99D60QI81o6oPlI80",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37270
 		},
@@ -3268,6 +3539,7 @@
 		"artist": "DE-SIRE改",
 		"data": {
 			"basename": "trix",
+			"ddrSongHash": "b0QQ6OPD1dDqQ6D6IDQqlDd180Db609I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37273
 		},
@@ -3280,6 +3552,7 @@
 		"artist": "Caldeira feat.Téka Penteriche",
 		"data": {
 			"basename": "vemb",
+			"ddrSongHash": "o6I06bPq8dqIlllbQDPP8boqdq6iQ8Qb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37274
 		},
@@ -3292,6 +3565,7 @@
 		"artist": "Kaori Nishina",
 		"data": {
 			"basename": "dofl",
+			"ddrSongHash": "ii119ll8dOQ8IQqi1IOP1o8DIQbqo8Pi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37276
 		},
@@ -3304,6 +3578,7 @@
 		"artist": "Yasuhiro Abe",
 		"data": {
 			"basename": "volc",
+			"ddrSongHash": "8idID0Pq0O68Qb0Q69P6IDldqI91qi1O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37277
 		},
@@ -3316,6 +3591,7 @@
 		"artist": "LEA DROP feat. Ant Johnston",
 		"data": {
 			"basename": "eday",
+			"ddrSongHash": "61Q6Q8OOiiQIbIi0l6l10qQ0Ii8P0Qb6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37278
 		},
@@ -3328,6 +3604,7 @@
 		"artist": "Black∞Hole",
 		"data": {
 			"basename": "plut",
+			"ddrSongHash": "dD6PqbboDil89DPIID86Pldi6obI1b8l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37279
 		},
@@ -3340,6 +3617,7 @@
 		"artist": "αTYPE-300",
 		"data": {
 			"basename": "pard",
+			"ddrSongHash": "io1d1Dq80Di08O1Pb9bQ8DoP9d9Ooi90",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37281
 		},
@@ -3352,6 +3630,7 @@
 		"artist": "DAISUKE ASAKURA ex.TЁЯRA",
 		"data": {
 			"basename": "swit",
+			"ddrSongHash": "9bo00PqOIDoDbO6P1116b9obolOiqPo1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37282
 		},
@@ -3364,6 +3643,7 @@
 		"artist": "DAISUKE ASAKURA",
 		"data": {
 			"basename": "alth",
+			"ddrSongHash": "b0DP0oqbid0iIQ6D88dDIiiDiq9oi19Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37283
 		},
@@ -3376,6 +3656,7 @@
 		"artist": "Tatsh feat. ヨーコ",
 		"data": {
 			"basename": "trus",
+			"ddrSongHash": "ddD8OPQoIiQi0IbDOIIdQ6dDDbPQ9bIO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37287
 		},
@@ -3388,6 +3669,7 @@
 		"artist": "2MB",
 		"data": {
 			"basename": "plur",
+			"ddrSongHash": "0IldoDlDQql99DqQo0Qq9ioPIiiPoIoi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37288
 		},
@@ -3400,6 +3682,7 @@
 		"artist": "NAOKI in the MERCURE",
 		"data": {
 			"basename": "lamd",
+			"ddrSongHash": "ddib8P601q0Oqdb0Pl8oqobq9DD608P1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37289
 		},
@@ -3412,6 +3695,7 @@
 		"artist": "iconoclasm",
 		"data": {
 			"basename": "votu",
+			"ddrSongHash": "PqPPDibPdD8qd88D0d01dqo6918b0POD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37290
 		},
@@ -3424,6 +3708,7 @@
 		"artist": "Tatsh SN 2 Style",
 		"data": {
 			"basename": "uran",
+			"ddrSongHash": "0b1660ibo0liI01ibOO6lD8olIb88qDi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37293
 		},
@@ -3436,6 +3721,7 @@
 		"artist": "JET GIRL SPIN",
 		"data": {
 			"basename": "mars",
+			"ddrSongHash": "oOdl0d1IOo0bd008DOl91606Pd0PP86d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37294
 		},
@@ -3448,6 +3734,7 @@
 		"artist": "Darwin",
 		"data": {
 			"basename": "whyn",
+			"ddrSongHash": "dbq9dPPOQ60ibOol0I6b9iQol9lD669D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37295
 		},
@@ -3460,6 +3747,7 @@
 		"artist": "Fracus",
 		"data": {
 			"basename": "shad",
+			"ddrSongHash": "qo6Ib8QqqDd16i91d8dlQoqIq08bo68d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37296
 		},
@@ -3472,6 +3760,7 @@
 		"artist": "Cheki-ROWS",
 		"data": {
 			"basename": "gili",
+			"ddrSongHash": "b8dqI0Iq60iQPPobiiQ8O6PiIqdodDiQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37297
 		},
@@ -3484,6 +3773,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "pose",
+			"ddrSongHash": "1PiiOiQoq8dbdi819q9Ild966o6o19QQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37298
 		},
@@ -3496,6 +3786,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bris",
+			"ddrSongHash": "d11l6160iiP1bDbQPQl0Pi8lddlld80i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37299
 		},
@@ -3508,6 +3799,7 @@
 		"artist": "KTz",
 		"data": {
 			"basename": "amch",
+			"ddrSongHash": "Oo91QPdQDd1Od1oQI6IIldbQ1lQ88bO0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37300
 		},
@@ -3520,6 +3812,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "dtwf",
+			"ddrSongHash": "1O9P1DqQQqObOQPP6Il989qDqi0bQ8Qb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37301
 		},
@@ -3532,6 +3825,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "dyns",
+			"ddrSongHash": "dd8loQPD0I86DiIql8b8o9qbO8l0d9Q9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37302
 		},
@@ -3544,6 +3838,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "bfov",
+			"ddrSongHash": "6boDb6Pdd6QDP1oPdlQ0Qo1ld0lQb6P6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37303
 		},
@@ -3556,6 +3851,7 @@
 		"artist": "N & S",
 		"data": {
 			"basename": "deag",
+			"ddrSongHash": "PooiIP8qP0IPd9D1Ibi6l9bDoqdi9P8O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37304
 		},
@@ -3568,6 +3864,7 @@
 		"artist": "jun with Alison",
 		"data": {
 			"basename": "sunk",
+			"ddrSongHash": "61IoqIoODb6dlQlQqd99b90idO9QP9iI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37306
 		},
@@ -3580,6 +3877,7 @@
 		"artist": "Mr.Saturn",
 		"data": {
 			"basename": "satu",
+			"ddrSongHash": "dDldd8OlbPQDoD80dO0DiDOiIoP1PQoD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37307
 		},
@@ -3592,6 +3890,7 @@
 		"artist": "jun feat. Schanita",
 		"data": {
 			"basename": "tloc",
+			"ddrSongHash": "1P00OOoibd668i90Oqb0dl9i8D10b1iD",
 			"flareCategory": "GOLD",
 			"inGameID": 37308
 		},
@@ -3604,6 +3903,7 @@
 		"artist": "WHITE WALL",
 		"data": {
 			"basename": "pluf",
+			"ddrSongHash": "PIO8dod8P9OOP1bi0D1POIi6OdOdQDql",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37309
 		},
@@ -3628,6 +3928,7 @@
 		"artist": "evo-X",
 		"data": {
 			"basename": "doub",
+			"ddrSongHash": "Iiq6Qoll0oQi801QdPdlOO06DOdIDdD9",
 			"flareCategory": "GOLD",
 			"inGameID": 37311
 		},
@@ -3640,6 +3941,7 @@
 		"artist": "TACOS NAOMI feat.小久保裕之",
 		"data": {
 			"basename": "smil",
+			"ddrSongHash": "boi66iD1809o6q199bbolO0bqQ1lqI8b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37312
 		},
@@ -3652,6 +3954,7 @@
 		"artist": "日本少年",
 		"data": {
 			"basename": "puzz",
+			"ddrSongHash": "091IQQ1PqOdIl9ioPQDdO60Dq069DP69",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37313
 		},
@@ -3664,6 +3967,7 @@
 		"artist": "Masanori Akita",
 		"data": {
 			"basename": "timh",
+			"ddrSongHash": "O110IdDiDlDQ66bb1o9lbqiqQq6lOid1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37315
 		},
@@ -3676,6 +3980,7 @@
 		"artist": "Veeton",
 		"data": {
 			"basename": "saga",
+			"ddrSongHash": "iObdoO9b1O9o8dP8o0id9b1QioQ0q9q9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37316
 		},
@@ -3688,6 +3993,7 @@
 		"artist": "Darwin",
 		"data": {
 			"basename": "ontb",
+			"ddrSongHash": "d88boiQ609PO8ODDo6IliPIb69I80dlP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37318
 		},
@@ -3700,6 +4006,7 @@
 		"artist": "Ruffage & Size",
 		"data": {
 			"basename": "trac",
+			"ddrSongHash": "iO61Dq9iiIQO0Qbbdo1O8bdqO8dqoiio",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37322
 		},
@@ -3712,6 +4019,7 @@
 		"artist": "DDT",
 		"data": {
 			"basename": "waiu",
+			"ddrSongHash": "96Q0Piqo9PPQoQdi9001DO6P9Piqi0dq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37323
 		},
@@ -3724,6 +4032,7 @@
 		"artist": "Darwin",
 		"data": {
 			"basename": "drem",
+			"ddrSongHash": "d9qd6lI0ddbQ068dq1oD8o6QDIi6blDO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37324
 		},
@@ -3736,6 +4045,7 @@
 		"artist": "Jena Rose",
 		"data": {
 			"basename": "flig",
+			"ddrSongHash": "8ll9P9bOloIqbI0O9PboP9li1iloIPPd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37354
 		},
@@ -3748,6 +4058,7 @@
 		"artist": "Jena Rose",
 		"data": {
 			"basename": "tick",
+			"ddrSongHash": "ld8b6iqPIiqqbb9q69l8obO66ibI96od",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37355
 		},
@@ -3760,6 +4071,7 @@
 		"artist": "DKC Crew",
 		"data": {
 			"basename": "tajh",
+			"ddrSongHash": "ob86bIdI1IbIl9DoQ1bboq9Q8O6PPPoq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37356
 		},
@@ -3772,6 +4084,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "sabe",
+			"ddrSongHash": "dIQDOoO80odDP8OiOQIQ9oI0o99OdQDQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37357
 		},
@@ -3784,6 +4097,7 @@
 		"artist": "TONI LEO",
 		"data": {
 			"basename": "lovy",
+			"ddrSongHash": "61D9oiPDI68Dq60Dqi99qqd9DqD1D1qd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37358
 		},
@@ -3796,6 +4110,7 @@
 		"artist": "NAOKI feat.YASMINE",
 		"data": {
 			"basename": "iyhr",
+			"ddrSongHash": "dPdO9OP6616o99l99qiI9DddQdD9D80b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37359
 		},
@@ -3808,6 +4123,7 @@
 		"artist": "DANNY D",
 		"data": {
 			"basename": "staa",
+			"ddrSongHash": "88qIddPQ9Q0QbQb0l6obD6IQ99oIiQQi",
 			"flareCategory": "GOLD",
 			"inGameID": 37360
 		},
@@ -3820,6 +4136,7 @@
 		"artist": "GAV",
 		"data": {
 			"basename": "want",
+			"ddrSongHash": "IoiD0b6IqiDi6qP1qb0P1dbQlIODbiid",
 			"flareCategory": "GOLD",
 			"inGameID": 37362
 		},
@@ -3832,6 +4149,7 @@
 		"artist": "wolli",
 		"data": {
 			"basename": "lift",
+			"ddrSongHash": "i1ol0PO8QbQD0q0oDI6qq0IO68868bP8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37368
 		},
@@ -3844,6 +4162,7 @@
 		"artist": "sonic-coll. feat. frances maya",
 		"data": {
 			"basename": "flou",
+			"ddrSongHash": "dQD6lbPO66DllOb1i0IoqDqbii0IOQi9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37369
 		},
@@ -3856,6 +4175,7 @@
 		"artist": "neuras feat. GATZ",
 		"data": {
 			"basename": "taka",
+			"ddrSongHash": "8i1ii188q9OlD0qQ9lQ0D1OdDbldqQbI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37370
 		},
@@ -3868,6 +4188,7 @@
 		"artist": "Hamel and St. Croix feat. Jules Mari",
 		"data": {
 			"basename": "play",
+			"ddrSongHash": "i66lIl9D60DPq0dQ0O9666ID8bPlID9i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37406
 		},
@@ -3880,6 +4201,7 @@
 		"artist": "Bill Hamel feat. Kevens",
 		"data": {
 			"basename": "dace",
+			"ddrSongHash": "I8ql1i90i80oDO0Q9qdIliIqPq66lQd0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37407
 		},
@@ -3892,6 +4214,7 @@
 		"artist": "Harmony Machine",
 		"data": {
 			"basename": "slip",
+			"ddrSongHash": "86688l9096PdIqDPl8qoQ10dI8Ioi86l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37408
 		},
@@ -3904,6 +4227,7 @@
 		"artist": "OR-IF-IS",
 		"data": {
 			"basename": "hora",
+			"ddrSongHash": "PIdPo9o0qOIiPDIIlbo9l9dObP81lQqi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37409
 		},
@@ -3916,6 +4240,7 @@
 		"artist": "Tommie Sunshine",
 		"data": {
 			"basename": "bene",
+			"ddrSongHash": "qDIdbDO1OiDPqd1i60Dd6OPOlO90D10Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37414
 		},
@@ -3928,6 +4253,7 @@
 		"artist": "DKC Crew",
 		"data": {
 			"basename": "tare",
+			"ddrSongHash": "b0lI9Ili8loOb1DD6Dd8lqII60b90101",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37415
 		},
@@ -3940,6 +4266,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "sare",
+			"ddrSongHash": "PIP60POo0dDQlIiqO9bIQ1oddQD8P9Il",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37416
 		},
@@ -3952,6 +4279,7 @@
 		"artist": "Harmony Machine",
 		"data": {
 			"basename": "slre",
+			"ddrSongHash": "lb1l0DibId6Pb9ddlqlDoP6d6oD0o0IP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37417
 		},
@@ -3964,6 +4292,7 @@
 		"artist": "Bill Hamel feat. Kevens",
 		"data": {
 			"basename": "dacr",
+			"ddrSongHash": "98D001P6b696O18P8qiIOl811bq1oQ16",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37418
 		},
@@ -3976,6 +4305,7 @@
 		"artist": "Lea Drop feat.Marissa Ship",
 		"data": {
 			"basename": "jube",
+			"ddrSongHash": "iI90119iIb9l609b9981l8QDblDOb0I6",
 			"flareCategory": "GOLD",
 			"inGameID": 37419
 		},
@@ -3988,6 +4318,7 @@
 		"artist": "U1 & Krystal B",
 		"data": {
 			"basename": "esca",
+			"ddrSongHash": "odQbP0bQqD89PolQ96II0PiqQQIddPi6",
 			"flareCategory": "WHITE",
 			"inGameID": 37420
 		},
@@ -4000,6 +4331,7 @@
 		"artist": "U1 night style",
 		"data": {
 			"basename": "sett",
+			"ddrSongHash": "DIoP0QD6i8PoQOo6DIdb1o19iqb10qQO",
 			"flareCategory": "GOLD",
 			"inGameID": 37421
 		},
@@ -4012,6 +4344,7 @@
 		"artist": "DIGI-SEQ-BAND2000",
 		"data": {
 			"basename": "soyo",
+			"ddrSongHash": "60dq6Plo0do9iQOl6ql111P9OPd9i01l",
 			"flareCategory": "WHITE",
 			"inGameID": 37422
 		},
@@ -4024,6 +4357,7 @@
 		"artist": "DJ YOSHITAKA feat.Michaela Thurlow",
 		"data": {
 			"basename": "suhe",
+			"ddrSongHash": "d1PbOD8o6b6o1OqOQ98ilDQbid6dddQd",
 			"flareCategory": "WHITE",
 			"inGameID": 37423
 		},
@@ -4036,6 +4370,7 @@
 		"artist": "The Remembers",
 		"data": {
 			"basename": "unit",
+			"ddrSongHash": "D9o1DqDidP696lii99881io9Dbb0lQl0",
 			"flareCategory": "GOLD",
 			"inGameID": 37424
 		},
@@ -4048,6 +4383,7 @@
 		"artist": "NM feat.JaY_bEe (JB Ah-Fua)",
 		"data": {
 			"basename": "open",
+			"ddrSongHash": "0OQiI9qD6OiodDoQlPllqPoPoqi98D8P",
 			"flareCategory": "GOLD",
 			"inGameID": 37425
 		},
@@ -4060,6 +4396,7 @@
 		"artist": "The Motion Sick",
 		"data": {
 			"basename": "thli",
+			"ddrSongHash": "i9Pidb18b9O8bdqQ91QQP0oPdIdIODq1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37431
 		},
@@ -4072,6 +4409,7 @@
 		"artist": "Z-licious",
 		"data": {
 			"basename": "ttlg",
+			"ddrSongHash": "99oQO1b8d9qQdPq6O1I6bd1bo1D16DP0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37432
 		},
@@ -4084,6 +4422,7 @@
 		"artist": "NM feat.Heather Elmer",
 		"data": {
 			"basename": "clos",
+			"ddrSongHash": "0ill9Po6Db090biqIlD1I9lo6PO8lQQ9",
 			"flareCategory": "GOLD",
 			"inGameID": 37433
 		},
@@ -4096,6 +4435,7 @@
 		"artist": "ＴЁЯＲＡ feat.宇宙戦隊NOIZ",
 		"data": {
 			"basename": "kyou",
+			"ddrSongHash": "q1DPdd1ooiPi9P0b0Obqq1QqbD86Qb18",
 			"flareCategory": "GOLD",
 			"inGameID": 37435
 		},
@@ -4108,6 +4448,7 @@
 		"artist": "TOMOSUKE feat. Adreana",
 		"data": {
 			"basename": "dmin",
+			"ddrSongHash": "89ooi0i98Qlq9PloIl1b190DIo8Do16l",
 			"flareCategory": "WHITE",
 			"inGameID": 37436
 		},
@@ -4120,6 +4461,7 @@
 		"artist": "DKC Crew",
 		"data": {
 			"basename": "insp",
+			"ddrSongHash": "Q61QoIQOQdoO98DP1oDlOIoO6D6lqq1o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37444
 		},
@@ -4132,6 +4474,7 @@
 		"artist": "neuras",
 		"data": {
 			"basename": "onbo",
+			"ddrSongHash": "OPDQ9Oi8I6D1I1iqi8iOiP0bDI9Pl86P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37445
 		},
@@ -4144,6 +4487,7 @@
 		"artist": "sonic-coll.",
 		"data": {
 			"basename": "trig",
+			"ddrSongHash": "OPOIPIi1OioQ98qbO100q6QiDP8dIDq6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37446
 		},
@@ -4156,6 +4500,7 @@
 		"artist": "neuras feat. Yurai",
 		"data": {
 			"basename": "danf",
+			"ddrSongHash": "Io9i8oQlbO1QqIdbbDPQl6b00OIPlIOP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37447
 		},
@@ -4168,6 +4513,7 @@
 		"artist": "D-crew feat.Matt Tucker",
 		"data": {
 			"basename": "weca",
+			"ddrSongHash": "O86D9iqi81QllOqP19dQqqId1qdIolqI",
 			"flareCategory": "GOLD",
 			"inGameID": 37448
 		},
@@ -4180,6 +4526,7 @@
 		"artist": "jun feat.Godis (Heather Twede)",
 		"data": {
 			"basename": "raci",
+			"ddrSongHash": "oloqOddo8oI1696Oqidb081ldlPQ89qO",
 			"flareCategory": "GOLD",
 			"inGameID": 37449
 		},
@@ -4192,6 +4539,7 @@
 		"artist": "dj TAKA",
 		"data": {
 			"basename": "dese",
+			"ddrSongHash": "PI1DiP0bIi8PodP6O1i8P0P1i8iI1oD8",
 			"flareCategory": "WHITE",
 			"inGameID": 37450
 		},
@@ -4204,6 +4552,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "sidr",
+			"ddrSongHash": "Q6ql0lOOdq90DI1PqO1bd10bP0Oi8Q0Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37451
 		},
@@ -4216,6 +4565,7 @@
 		"artist": "DJ Yoshitaka feat.Robert \"RAab\" Stevenson",
 		"data": {
 			"basename": "thlo",
+			"ddrSongHash": "90D66ObIiqP09oqoDoq6b908b699oqqi",
 			"flareCategory": "WHITE",
 			"inGameID": 37452
 		},
@@ -4228,6 +4578,7 @@
 		"artist": "Wendy Parr",
 		"data": {
 			"basename": "habi",
+			"ddrSongHash": "890q91iIbO96OOD10Qlob6qOObQoq1bd",
 			"flareCategory": "WHITE",
 			"inGameID": 37453
 		},
@@ -4240,6 +4591,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "osak1",
+			"ddrSongHash": "ldDD06dIQ0qQPD9OI88P90OOi0bQPD1O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37454
 		},
@@ -4252,6 +4604,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "osak2",
+			"ddrSongHash": "8006PP188Qldob68ld6OPqlbl1biod6D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37455
 		},
@@ -4264,6 +4617,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "osak3",
+			"ddrSongHash": "di088lOPlqQ1OoQIbilI1P0q119i8o9O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37456
 		},
@@ -4276,6 +4630,7 @@
 		"artist": "紅色リトマス",
 		"data": {
 			"basename": "rint",
+			"ddrSongHash": "QQOOldqQ8QQDQ06i81d9DP9PlOlo1lqq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37462
 		},
@@ -4288,6 +4643,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "zerr",
+			"ddrSongHash": "bq8DOQ9Idq9Ii9PQ1bqPIQoQPl961d1o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37466
 		},
@@ -4300,6 +4656,7 @@
 		"artist": "NAOKI-EX",
 		"data": {
 			"basename": "rezo",
+			"ddrSongHash": "1Ob9Il9bOQdbOQbq00oi1qoo1o1dPoI0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37472
 		},
@@ -4312,6 +4669,7 @@
 		"artist": "dj TAKA VS Ryu☆",
 		"data": {
 			"basename": "blra",
+			"ddrSongHash": "PO68qOQI1oo8iQidQ9iIi9o9PPOD9OP6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37484
 		},
@@ -4324,6 +4682,7 @@
 		"artist": "日本少年",
 		"data": {
 			"basename": "chan",
+			"ddrSongHash": "q1q8IlPI1111D8IqiQ190qIoP0b0bIIo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37485
 		},
@@ -4336,6 +4695,7 @@
 		"artist": "180",
 		"data": {
 			"basename": "parx",
+			"ddrSongHash": "I8bQ8ilD9l1Qi9Q9iI0q6qqqiolo01QP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37487
 		},
@@ -4348,6 +4708,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "trxs",
+			"ddrSongHash": "bql00PQ1PiboIqDQoD909Il8o1PIDiD1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37488
 		},
@@ -4360,6 +4721,7 @@
 		"artist": "190",
 		"data": {
 			"basename": "parx2",
+			"ddrSongHash": "dQ69Oqd0Do8Dodd6bQD9l16Olo9P01DQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37489
 		},
@@ -4372,6 +4734,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "sptx",
+			"ddrSongHash": "dDO8ili1081QQIb86POQ8qd0P111011o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37490
 		},
@@ -4384,6 +4747,7 @@
 		"artist": "190'",
 		"data": {
 			"basename": "rebx",
+			"ddrSongHash": "o6bPdI8O089O8lbl8OlIb1lPo8o1lODQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37491
 		},
@@ -4396,6 +4760,7 @@
 		"artist": "RE-VENGE",
 		"data": {
 			"basename": "afrx",
+			"ddrSongHash": "P01qbiIoO6dqIIqo6Db9dqq1bI6ddbqI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37492
 		},
@@ -4408,6 +4773,7 @@
 		"artist": "200",
 		"data": {
 			"basename": "pevx",
+			"ddrSongHash": "o6oqqiOOb9Pob66loQoQddlDP6PP69lo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37493
 		},
@@ -4420,6 +4786,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "clix",
+			"ddrSongHash": "boQPliilD01OD1bIdOOIOOi0Q9P16OlO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37494
 		},
@@ -4432,6 +4799,7 @@
 		"artist": "STM 200",
 		"data": {
 			"basename": "petx",
+			"ddrSongHash": "ioQP0b6I11Do1OQPIQ6OIDiPODD0l0dd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37495
 		},
@@ -4444,6 +4812,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "feax",
+			"ddrSongHash": "0D1618DDbol8bl9dP0lDdiD66ioIiidD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37496
 		},
@@ -4456,6 +4825,7 @@
 		"artist": "Luv UNLIMITED",
 		"data": {
 			"basename": "canx",
+			"ddrSongHash": "0qP01Q60boPPlQ8qO6O6q89iI91Pl0PP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37497
 		},
@@ -4468,6 +4838,7 @@
 		"artist": "Ω",
 		"data": {
 			"basename": "xmax",
+			"ddrSongHash": "oOI88lollO1OOQQd9DPi0690I6i6oiII",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37498
 		},
@@ -4480,6 +4851,7 @@
 		"artist": "Z",
 		"data": {
 			"basename": "unlx",
+			"ddrSongHash": "1980q80l1Q96O881IidPd16qDbOol9Qd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37499
 		},
@@ -4492,6 +4864,7 @@
 		"artist": "dj TAKA with NAOKI",
 		"data": {
 			"basename": "kakx",
+			"ddrSongHash": "qIqqdd1Odqi1Iiolq9qqPOi0bPPld8Pb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37500
 		},
@@ -4504,6 +4877,7 @@
 		"artist": "ZZ",
 		"data": {
 			"basename": "legx",
+			"ddrSongHash": "1o6dQqq9P8IQ6PbQO88OI1b91P9DoqQ8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37501
 		},
@@ -4516,6 +4890,7 @@
 		"artist": "DDR ALL STARS",
 		"data": {
 			"basename": "ddrx",
+			"ddrSongHash": "6o966dbdo9dPIil6qQ09d1I0o0Qld611",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37502
 		},
@@ -4528,6 +4903,7 @@
 		"artist": "NAOKI feat. SMiLE.dk",
 		"data": {
 			"basename": "geis",
+			"ddrSongHash": "l0QP6DiIDIId0oiQiOl8q10DlI96OPiO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37504
 		},
@@ -4540,6 +4916,7 @@
 		"artist": "Kotaro feat. Aya",
 		"data": {
 			"basename": "inlo",
+			"ddrSongHash": "b1ObooOQ9iI0DilD9Q6qlIQ8D1d8dQO9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37511
 		},
@@ -4552,6 +4929,7 @@
 		"artist": "Makoto feat. SK",
 		"data": {
 			"basename": "sttb",
+			"ddrSongHash": "IDldD8o8P8dbIP6oiDo11i10lo6bP6oQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37512
 		},
@@ -4576,6 +4954,7 @@
 		"artist": "NAOKI feat. Fracus",
 		"data": {
 			"basename": "tone",
+			"ddrSongHash": "iO90Qo66I88P1IdDldo1oIqb8bldqDI6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37517
 		},
@@ -4588,6 +4967,7 @@
 		"artist": "nc ft. Eddie Kay",
 		"data": {
 			"basename": "bewi",
+			"ddrSongHash": "DDPPb680Pd1Do0I0899Qq18OIIqiP06D",
 			"flareCategory": "GOLD",
 			"inGameID": 37518
 		},
@@ -4600,6 +4980,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "ropp1",
+			"ddrSongHash": "odd1O0boo1boqDb0dIOQdQi1IqdO1DQd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37520
 		},
@@ -4612,6 +4993,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "ropp2",
+			"ddrSongHash": "QobO6O8iQP6I16l0I8QPd0Iq6iQ1loQ6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37521
 		},
@@ -4624,6 +5006,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "ropp3",
+			"ddrSongHash": "lb9Qo61bbOdQidlQQD8DP8199Q911Id9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37522
 		},
@@ -4636,6 +5019,7 @@
 		"artist": "Lea Drop feat. McCall Clark",
 		"data": {
 			"basename": "prds",
+			"ddrSongHash": "db9qPQQ1lDbDIPP98IOqil9IO1i0oilO",
 			"flareCategory": "GOLD",
 			"inGameID": 37523
 		},
@@ -4648,6 +5032,7 @@
 		"artist": "The W feat. Rita Boudreau",
 		"data": {
 			"basename": "illf",
+			"ddrSongHash": "DiqobPO1iliqP6DbQiDodPIPDiQO96dl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37524
 		},
@@ -4660,6 +5045,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "sabe2",
+			"ddrSongHash": "Do6oPoo1QbOPo9DIii0Q0180l8b1Doqi",
 			"flareCategory": "WHITE",
 			"inGameID": 37527
 		},
@@ -4672,6 +5058,7 @@
 		"artist": "鍋嶋圭一",
 		"data": {
 			"basename": "newg",
+			"ddrSongHash": "6i99bQI11qD818DDdq6qb0Dql880lP8l",
 			"flareCategory": "WHITE",
 			"inGameID": 37530
 		},
@@ -4684,6 +5071,7 @@
 		"artist": "U1 feat. Tammy S. Hansen",
 		"data": {
 			"basename": "taki",
+			"ddrSongHash": "i1Q080DDQD81l8o0109Q6blq0oo8o69q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37532
 		},
@@ -4696,6 +5084,7 @@
 		"artist": "atomsoak ft. cerol",
 		"data": {
 			"basename": "priv",
+			"ddrSongHash": "0dOi10q9Q6oi0Q9960iQQDO6olqlDDqo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37537
 		},
@@ -4708,6 +5097,7 @@
 		"artist": "atomsoak ft. cerol",
 		"data": {
 			"basename": "teme",
+			"ddrSongHash": "6loP1dbiOq0Q8i9QQOI6o0iOO6bdIQOO",
 			"flareCategory": "WHITE",
 			"inGameID": 37538
 		},
@@ -4720,6 +5110,7 @@
 		"artist": "nc ft. NRG Factory",
 		"data": {
 			"basename": "frez",
+			"ddrSongHash": "8l0ld8Oq86P09lb91DdD9OliiPq9oq9D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37539
 		},
@@ -4732,6 +5123,7 @@
 		"artist": "Architect ft. Jasmine Nii",
 		"data": {
 			"basename": "haun",
+			"ddrSongHash": "POl689q8ODbPI0PDo8l8oD81Plio8qlP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37540
 		},
@@ -4744,6 +5136,7 @@
 		"artist": "nc ft. Electric Touch",
 		"data": {
 			"basename": "wick",
+			"ddrSongHash": "qI06bbQ1dloi0IIIO1IQ1q8bdPdl6l69",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37541
 		},
@@ -4756,6 +5149,7 @@
 		"artist": "nc ft. Jasmine Nii",
 		"data": {
 			"basename": "sosp",
+			"ddrSongHash": "oi9q8DQ1QddP1699qIbqP886iOIPI16I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37542
 		},
@@ -4768,6 +5162,7 @@
 		"artist": "TAG feat. Eric Anthony",
 		"data": {
 			"basename": "thei",
+			"ddrSongHash": "8Pl1i1o0O6oIio0b681qOoDOQdPPOObb",
 			"flareCategory": "WHITE",
 			"inGameID": 37543
 		},
@@ -4780,6 +5175,7 @@
 		"artist": "Jena Rose",
 		"data": {
 			"basename": "jena",
+			"ddrSongHash": "Q9bo8o9600D869o10ioPb8bPO10bIOiq",
 			"flareCategory": "GOLD",
 			"inGameID": 37544
 		},
@@ -4792,6 +5188,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "sacr",
+			"ddrSongHash": "qOQQ1qdQPPQ1bbdPldPlIil99IDoPi61",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37545
 		},
@@ -4804,6 +5201,7 @@
 		"artist": "Black Rose Garden",
 		"data": {
 			"basename": "wwcm",
+			"ddrSongHash": "olloQOobddiIIPObP91l0qPl6oo8P9Dl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37546
 		},
@@ -4816,6 +5214,7 @@
 		"artist": "Bill Hamel & Derek James feat. James Rowand",
 		"data": {
 			"basename": "canu",
+			"ddrSongHash": "Oo9O18oqOi9DIoOoqb9IqQDo0dbdqP9q",
 			"flareCategory": "WHITE",
 			"inGameID": 37551
 		},
@@ -4828,6 +5227,7 @@
 		"artist": "OR-IF-IS",
 		"data": {
 			"basename": "curr",
+			"ddrSongHash": "18d0iP6oIQQIb6IIOi99iDQ116bbP9I9",
 			"flareCategory": "GOLD",
 			"inGameID": 37562
 		},
@@ -4840,6 +5240,7 @@
 		"artist": "Harmony Machine",
 		"data": {
 			"basename": "tame",
+			"ddrSongHash": "iqlOo1bdoiDqDbIODDl0POl1PqlQd8l6",
 			"flareCategory": "GOLD",
 			"inGameID": 37563
 		},
@@ -4852,6 +5253,7 @@
 		"artist": "Bill Hamel & James Rowand",
 		"data": {
 			"basename": "iair",
+			"ddrSongHash": "qQI9IQOd061Q69Oo89lll9bd99108Qqd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37564
 		},
@@ -4864,6 +5266,7 @@
 		"artist": "Tommie Sunshine",
 		"data": {
 			"basename": "ahla",
+			"ddrSongHash": "Ilqd06QqoQd9IlQobq9idPqb1111Q96b",
 			"flareCategory": "WHITE",
 			"inGameID": 37565
 		},
@@ -4876,6 +5279,7 @@
 		"artist": "Jena Rose",
 		"data": {
 			"basename": "bbay",
+			"ddrSongHash": "18ibQ9qbqOI91Q1iiiOd990OPo1q1dPI",
 			"flareCategory": "WHITE",
 			"inGameID": 37570
 		},
@@ -4888,6 +5292,7 @@
 		"artist": "TOMOSUKE feat. Adreana",
 		"data": {
 			"basename": "shie",
+			"ddrSongHash": "q1o901oPqbbI1Q61qo688bDd0Pqlb08l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37571
 		},
@@ -4900,6 +5305,7 @@
 		"artist": "NM feat. Mr. E.",
 		"data": {
 			"basename": "lvag",
+			"ddrSongHash": "l0od6D6dl9PQdl1iDPOlD80io0iqqDb8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37572
 		},
@@ -4912,6 +5318,7 @@
 		"artist": "TAG feat. Angie Lee",
 		"data": {
 			"basename": "hest",
+			"ddrSongHash": "lIPP90Ilqib08Obob9901PiP19OQ18P9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37584
 		},
@@ -4924,6 +5331,7 @@
 		"artist": "TAG feat. Sydney Powers",
 		"data": {
 			"basename": "tasf",
+			"ddrSongHash": "ibiD8868D116OIqbQ1DQ1IOb8OD1qQ98",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37585
 		},
@@ -4936,6 +5344,7 @@
 		"artist": "U1 (NPD3 style) & KIDD KAZMEO",
 		"data": {
 			"basename": "inzo",
+			"ddrSongHash": "8o6ibb0b1i66Q0D8699boob69b80Qb1i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37586
 		},
@@ -4948,6 +5357,7 @@
 		"artist": "NM feat. Aleisha G",
 		"data": {
 			"basename": "ttim",
+			"ddrSongHash": "oDIliqQl90bQo6Qil9bOiD1iO19qI1dd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37587
 		},
@@ -4960,6 +5370,7 @@
 		"artist": "Brooke",
 		"data": {
 			"basename": "eine",
+			"ddrSongHash": "81O10b1Oob9blo0888PQbd1I6bP0b8q9",
 			"flareCategory": "WHITE",
 			"inGameID": 37588
 		},
@@ -4972,6 +5383,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "kimp",
+			"ddrSongHash": "Q10PdOD6bDD9QPQQqiO11669bb0lQ189",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37589
 		},
@@ -4984,6 +5396,7 @@
 		"artist": "Brenda Burch",
 		"data": {
 			"basename": "shlo",
+			"ddrSongHash": "9P16o1bO16PDDObloibo1Il8IIDdo869",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37590
 		},
@@ -4996,6 +5409,7 @@
 		"artist": "NAOKI feat. Aleisha G",
 		"data": {
 			"basename": "abri",
+			"ddrSongHash": "dQoqo68881IiO9i00bP0q1lOD6i1PdD8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37595
 		},
@@ -5008,6 +5422,7 @@
 		"artist": "Tommie Sunshine",
 		"data": {
 			"basename": "bene2",
+			"ddrSongHash": "oQQqlb666o69DDOQoboOI1b1q09lQ9P6",
 			"flareCategory": "WHITE",
 			"inGameID": 37596
 		},
@@ -5020,6 +5435,7 @@
 		"artist": "NM feat. Anjanette Mickelsen",
 		"data": {
 			"basename": "yyou",
+			"ddrSongHash": "D0qloQo0bQliQqooQ609IP8i09old99D",
 			"flareCategory": "WHITE",
 			"inGameID": 37597
 		},
@@ -5032,6 +5448,7 @@
 		"artist": "jun feat. Sonnet",
 		"data": {
 			"basename": "thni",
+			"ddrSongHash": "qQl6O8IdiI6991IiqDqidO96bll1qPDl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37599
 		},
@@ -5044,6 +5461,7 @@
 		"artist": "NMR runners",
 		"data": {
 			"basename": "geba",
+			"ddrSongHash": "olIo8PdO8dq16QqDIQboQq6oPqDO9qoo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37600
 		},
@@ -5056,6 +5474,7 @@
 		"artist": "U1 /F Anneliese",
 		"data": {
 			"basename": "theh",
+			"ddrSongHash": "0q8b6O0qOlDql0oP80OI8i8i1088qbIb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37601
 		},
@@ -5068,6 +5487,7 @@
 		"artist": "NAOKI feat. Aleisha G",
 		"data": {
 			"basename": "goda",
+			"ddrSongHash": "lqOQbO0ql96IdDdD689o9PI1iI8Q1Ibi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37602
 		},
@@ -5116,6 +5536,7 @@
 		"artist": "NAOKI feat. Anna Kaelin",
 		"data": {
 			"basename": "youa",
+			"ddrSongHash": "0qOPDqq0qld66bll9ob9iIqiiQPiQIDQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37613
 		},
@@ -5128,6 +5549,7 @@
 		"artist": "Preston Powis",
 		"data": {
 			"basename": "seul",
+			"ddrSongHash": "qbl10iqqdO1Do1dIq181Pl6oi8QilQo1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37614
 		},
@@ -5140,6 +5562,7 @@
 		"artist": "Cheryl Horrocks",
 		"data": {
 			"basename": "lali",
+			"ddrSongHash": "b6l6qPPdiOqqPqqII0IPqI981bolOqIb",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37615
 		},
@@ -5152,6 +5575,7 @@
 		"artist": "Philip Webb",
 		"data": {
 			"basename": "unen",
+			"ddrSongHash": "89O8qIII0QPO0Q0l10P6dl19PlQ9d0oO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37616
 		},
@@ -5164,6 +5588,7 @@
 		"artist": "NAOKI feat. Brenda Burch",
 		"data": {
 			"basename": "letg",
+			"ddrSongHash": "id0i6dQId1D9l1P9bq9iP9608Ioi9iq8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37617
 		},
@@ -5176,6 +5601,7 @@
 		"artist": "Carlos Coco Garcia",
 		"data": {
 			"basename": "larc",
+			"ddrSongHash": "IDPbb8oiQl0od6b8OqlPDo08o0QDo6iQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37618
 		},
@@ -5188,6 +5614,7 @@
 		"artist": "D-crew with VAL TIATIA",
 		"data": {
 			"basename": "crco",
+			"ddrSongHash": "1DD68qQdqQ0i6bQ61ddQ06ql1D6O1l6P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37623
 		},
@@ -5212,6 +5639,7 @@
 		"artist": "DJ YOSHITAKA-G feat.Michael a la mode",
 		"data": {
 			"basename": "goru",
+			"ddrSongHash": "ib8o1iD68il66olQ1lddIPi0lIb9dd1I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37638
 		},
@@ -5224,6 +5652,7 @@
 		"artist": "StripE",
 		"data": {
 			"basename": "fifi",
+			"ddrSongHash": "0ibD9Oio99IlQ0di916lId0bi08IPD9b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37639
 		},
@@ -5236,6 +5665,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "smoo",
+			"ddrSongHash": "1l01billdl6oPP96Pq8d0lbbblQI8i8l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37640
 		},
@@ -5248,6 +5678,7 @@
 		"artist": "Remixed by DJ Command",
 		"data": {
 			"basename": "dada2",
+			"ddrSongHash": "69l8lOiooPPPqb9Io9Il01dPD0Q988Iq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37641
 		},
@@ -5260,6 +5691,7 @@
 		"artist": "HHH",
 		"data": {
 			"basename": "dada",
+			"ddrSongHash": "IPdDlblblqO1do9IQbDoi0iOoPDoiDlI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37642
 		},
@@ -5272,6 +5704,7 @@
 		"artist": "Amuro vs Killer",
 		"data": {
 			"basename": "meii",
+			"ddrSongHash": "iqiqod1l08DlDql98QOi10oibldd8b86",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37643
 		},
@@ -5284,6 +5717,7 @@
 		"artist": "Zektbach",
 		"data": {
 			"basename": "zeta",
+			"ddrSongHash": "96QPqq0q6Id0Ii0QbD1bQqPbiDqb0lPo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37644
 		},
@@ -5296,6 +5730,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "seco",
+			"ddrSongHash": "9bI0dQdb01Dl1bQq1Pq998i0l096D99P",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37645
 		},
@@ -5308,6 +5743,7 @@
 		"artist": "朱雀",
 		"data": {
 			"basename": "vane",
+			"ddrSongHash": "6d6bqoOlqi8ooqOdlqdPblqol88b68QP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37646
 		},
@@ -5320,6 +5756,7 @@
 		"artist": "Risk Junk",
 		"data": {
 			"basename": "huch",
+			"ddrSongHash": "i8O81i0iQdqiI8qqP0oo8IPl9IoId1bO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37647
 		},
@@ -5332,6 +5769,7 @@
 		"artist": "SUPER STAR 満-MITSURU-",
 		"data": {
 			"basename": "shei",
+			"ddrSongHash": "0qDb0d9oIoQPP1Ql0o0OOPoPDbQ699Iq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37648
 		},
@@ -5344,6 +5782,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "poss",
+			"ddrSongHash": "q6di1DQbi88i9QlPol1iIPbb8lP1qP1b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37649
 		},
@@ -5356,6 +5795,7 @@
 		"artist": "Latenighters",
 		"data": {
 			"basename": "cgpr",
+			"ddrSongHash": "qD8Q180QlIi11o1IiI6DPoqolqoD61Ib",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37650
 		},
@@ -5368,6 +5808,7 @@
 		"artist": "Orbit1 & Milo",
 		"data": {
 			"basename": "anti",
+			"ddrSongHash": "D89QP18016o01qoOi60I6Q19dlOQPbdo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37651
 		},
@@ -5380,6 +5821,7 @@
 		"artist": "kors k feat.ЯIRE",
 		"data": {
 			"basename": "allm",
+			"ddrSongHash": "PQP1l9qDilqbD0qOqiD8dd86qboI8bob",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37652
 		},
@@ -5392,6 +5834,7 @@
 		"artist": "Remixed by DJ Command",
 		"data": {
 			"basename": "issk2",
+			"ddrSongHash": "QdIl6D808iDoDQi0Qii99Do6do8DOdQO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37653
 		},
@@ -5404,6 +5847,7 @@
 		"artist": "Y&Co.",
 		"data": {
 			"basename": "whro",
+			"ddrSongHash": "QQbiq1qQd8d1blOldi889OdQd9P1106Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37654
 		},
@@ -5416,6 +5860,7 @@
 		"artist": "J-Mi & Midi-D feat. Hanna Stockzell",
 		"data": {
 			"basename": "tpch",
+			"ddrSongHash": "l9i996ld6PbbiO1911OoOI8lIPQ06ID8",
 			"flareCategory": "WHITE",
 			"inGameID": 37655
 		},
@@ -5428,6 +5873,7 @@
 		"artist": "DKC Crew",
 		"data": {
 			"basename": "rthm",
+			"ddrSongHash": "P8IQ8blOl1i08oP18i06Oq1iP9biP6Do",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37657
 		},
@@ -5440,6 +5886,7 @@
 		"artist": "Sota F. feat.Anna",
 		"data": {
 			"basename": "skyi",
+			"ddrSongHash": "08IP8i1qIbQIoP9DiP11IdP190Q98lil",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37659
 		},
@@ -5452,6 +5899,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "newd",
+			"ddrSongHash": "o0l1Qioq1i9iQl6b9q6il0iqi1b1OQ9b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37660
 		},
@@ -5464,6 +5912,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "pose2",
+			"ddrSongHash": "qD6q1PD0lIDP89DPDbOOIdq0Pi8iIdD6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37661
 		},
@@ -5476,6 +5925,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "sasu",
+			"ddrSongHash": "6lD1ooDi8Pdl0OlO0QoIioI8119I0PPq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37662
 		},
@@ -5488,6 +5938,7 @@
 		"artist": "JAKAZiD feat. K.N.",
 		"data": {
 			"basename": "pier",
+			"ddrSongHash": "DD6olq00PD91odbO9QbldDb0bQ18oqo1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37663
 		},
@@ -5500,6 +5951,7 @@
 		"artist": "kors k Vs. dj TAKA",
 		"data": {
 			"basename": "tako",
+			"ddrSongHash": "il0QbI6IOIidllO108olqd8i9Pb1Oq8Q",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37664
 		},
@@ -5512,6 +5964,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "ropp4",
+			"ddrSongHash": "l8q6diIod06OdP11P6I8oIddiPo16DPd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37665
 		},
@@ -5524,6 +5977,7 @@
 		"artist": "dj TAKA feat.Kanako Hoshino",
 		"data": {
 			"basename": "droo",
+			"ddrSongHash": "ObiIq6PDlOiPd0d1oP8IIQbqiq09IDII",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37666
 		},
@@ -5536,6 +5990,7 @@
 		"artist": "ピンクターボ",
 		"data": {
 			"basename": "shng",
+			"ddrSongHash": "006ob1iI9b1I8dDl0dq1bqIOP8886li1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37667
 		},
@@ -5548,6 +6003,7 @@
 		"artist": "杏野はるな",
 		"data": {
 			"basename": "sday",
+			"ddrSongHash": "0ol981b18biO0610IqPi9l6Db86PbIQ9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37668
 		},
@@ -5572,6 +6028,7 @@
 		"artist": "Spriggan",
 		"data": {
 			"basename": "valk",
+			"ddrSongHash": "186dd6DQq891Ib9Ilq8Qbo8lIqb0Qoll",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37684
 		},
@@ -5584,6 +6041,7 @@
 		"artist": "CAPACITY GATE",
 		"data": {
 			"basename": "shwo",
+			"ddrSongHash": "b6ldDOq9qi1IiIIdiIl1108q1iQ9O6d6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37685
 		},
@@ -5596,6 +6054,7 @@
 		"artist": "SHIN SOUND DESIGN feat.Naomi Koizumi",
 		"data": {
 			"basename": "batf",
+			"ddrSongHash": "9ib91bdq6i11l69d081qDD989Q0qO0qI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37686
 		},
@@ -5608,6 +6067,7 @@
 		"artist": "colors",
 		"data": {
 			"basename": "goup",
+			"ddrSongHash": "dqPDQ8Pb68iib8bIIPld10Q0oD8l600o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37687
 		},
@@ -5620,6 +6080,7 @@
 		"artist": "seiya-murai meets “eimy”",
 		"data": {
 			"basename": "lvng",
+			"ddrSongHash": "6bO0Dq60bboi009iDbO8o9Q9999PiiDP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37688
 		},
@@ -5632,6 +6093,7 @@
 		"artist": "DJ YOSHITAKA feat. 星野奏子",
 		"data": {
 			"basename": "maxl",
+			"ddrSongHash": "l6999IbQI61IO9qQbllobqo68lqobibq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37689
 		},
@@ -5644,6 +6106,7 @@
 		"artist": "Noria",
 		"data": {
 			"basename": "melo",
+			"ddrSongHash": "6i189o0bl000608OPdOIODOOibq6QoPI",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37690
 		},
@@ -5656,6 +6119,7 @@
 		"artist": "DJ TECHNORCH",
 		"data": {
 			"basename": "thr8",
+			"ddrSongHash": "id9oObq9P6Q6Pq6lQPqI88OP1DD8D0O1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37691
 		},
@@ -5668,6 +6132,7 @@
 		"artist": "DM Ashura",
 		"data": {
 			"basename": "aftr",
+			"ddrSongHash": "o6qi6idD9oqIdi81ldQlODqIqIiqlD1d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37692
 		},
@@ -5680,6 +6145,7 @@
 		"artist": "DM Ashura",
 		"data": {
 			"basename": "delt",
+			"ddrSongHash": "QQldo10ObPPQPlliODiDIIl0Q1oPoo61",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37693
 		},
@@ -5692,6 +6158,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "dirt",
+			"ddrSongHash": "I8b69IdbID0Di06ldo6o1lb1IdI89Iqo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37694
 		},
@@ -5704,6 +6171,7 @@
 		"artist": "RAM",
 		"data": {
 			"basename": "dumm",
+			"ddrSongHash": "PP9q1DDi0liP1P00lqIoIbbqo9QqlIqP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37695
 		},
@@ -5716,6 +6184,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "sak2",
+			"ddrSongHash": "ib19PQ61bi0lI8qi98IQ8dOqOoP91olq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37696
 		},
@@ -5728,6 +6197,7 @@
 		"artist": "DM Ashura feat. kors k",
 		"data": {
 			"basename": "yoan",
+			"ddrSongHash": "oiIob81i6d6P6qbddOP6Q0d0obQ0PID9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37697
 		},
@@ -5740,6 +6210,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "oarf",
+			"ddrSongHash": "DbQbDQOl0lII16ib1081d6ddIodD0P9I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37698
 		},
@@ -5752,6 +6223,7 @@
 		"artist": "jun & NRG Factory feat. Anna Kaelin",
 		"data": {
 			"basename": "dree",
+			"ddrSongHash": "b08D1ODPP0IqlIl91dDDdD1d0lD8bP1d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37731
 		},
@@ -5764,6 +6236,7 @@
 		"artist": "TOMOSUKE feat. Crystal Paloa",
 		"data": {
 			"basename": "sson",
+			"ddrSongHash": "loP08P1PPi990lPD0O060d888O9o6qb8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37733
 		},
@@ -5776,6 +6249,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "urlv",
+			"ddrSongHash": "i0dqDPqDll9il0b6qoDPd19OQ0qO9qDO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37734
 		},
@@ -5788,6 +6262,7 @@
 		"artist": "D-crew with Melissa Petty",
 		"data": {
 			"basename": "oslv",
+			"ddrSongHash": "OQb96d6qD9bPdD819QO0b88blIllldoi",
 			"flareCategory": "WHITE",
 			"inGameID": 37735
 		},
@@ -5800,6 +6275,7 @@
 		"artist": "Lea Drop feat. Katie Dellenbach",
 		"data": {
 			"basename": "mprd",
+			"ddrSongHash": "odD0Ql6iQbidDlqdPIdo8iQO09OoIbD0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37736
 		},
@@ -5812,6 +6288,7 @@
 		"artist": "ＴЁЯＲＡ",
 		"data": {
 			"basename": "snow2",
+			"ddrSongHash": "OqIlb9PQIo0Io90PIQi6q86dO8iP19Oi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37740
 		},
@@ -5824,6 +6301,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "imso",
+			"ddrSongHash": "90lolio9qd6qo6Pl8oo69iqi81oiiQib",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37749
 		},
@@ -5836,6 +6314,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "toet",
+			"ddrSongHash": "Oq9QIlI8l11ddqbbDoQ1ql61OqlIi9lo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37750
 		},
@@ -5848,6 +6327,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "hien1",
+			"ddrSongHash": "D6IQ1O1D00D1o8IQq0O9qqIibqDiiO0i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37752
 		},
@@ -5860,6 +6340,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "hien2",
+			"ddrSongHash": "OlDo09P8l0d6d80i8qD0qQddbi0QQD8b",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37753
 		},
@@ -5872,6 +6353,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "hien3",
+			"ddrSongHash": "09looidO89Q9DiDdqQiDPlIQDoiobobQ",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37754
 		},
@@ -5884,6 +6366,7 @@
 		"artist": "jun feat. Sarah-Jane",
 		"data": {
 			"basename": "ublv",
+			"ddrSongHash": "I6dI99IOolDD6l6Q1ooPIiDO8Odq0QIP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37755
 		},
@@ -5896,6 +6379,7 @@
 		"artist": "jun feat. DJ Silver vs Milo ft. Becca Hossany",
 		"data": {
 			"basename": "arms",
+			"ddrSongHash": "bqqIiO96di90bdP0QD1biD8DoDQIddOD",
 			"flareCategory": "WHITE",
 			"inGameID": 37756
 		},
@@ -5908,6 +6392,7 @@
 		"artist": "DKC Crew",
 		"data": {
 			"basename": "ptay",
+			"ddrSongHash": "QbI1i8Q8o06qQQIqllQ6091l998D0qIi",
 			"flareCategory": "WHITE",
 			"inGameID": 37758
 		},
@@ -5920,6 +6405,7 @@
 		"artist": "J-Mi & Midi-D",
 		"data": {
 			"basename": "angl",
+			"ddrSongHash": "blI8D10Q1IDQ8Q19bi0IDlD80oD0bloi",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37762
 		},
@@ -5932,6 +6418,7 @@
 		"artist": "U1 ft. Becca Hossany",
 		"data": {
 			"basename": "srdr",
+			"ddrSongHash": "bo8DPdi09odO8oq9ql0iI8booOioOqi0",
 			"flareCategory": "GOLD",
 			"inGameID": 37763
 		},
@@ -5944,6 +6431,7 @@
 		"artist": "Lazy U1 ft. Fraz & Chalk E",
 		"data": {
 			"basename": "ftsy",
+			"ddrSongHash": "loD6oi96869O8ilii1QPOPDoP91l1PQQ",
 			"flareCategory": "WHITE",
 			"inGameID": 37764
 		},
@@ -5956,6 +6444,7 @@
 		"artist": "NAOKI feat. Becca Hossany",
 		"data": {
 			"basename": "hrtb",
+			"ddrSongHash": "iq6QI06oQlloO9Db9dbI8IDoi91dD8d9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37765
 		},
@@ -5968,6 +6457,7 @@
 		"artist": "nc ft SAK.",
 		"data": {
 			"basename": "fndw",
+			"ddrSongHash": "liiPP608Oqbbb1Do88DPolOlQiq0Di60",
 			"flareCategory": "WHITE",
 			"inGameID": 37767
 		},
@@ -5980,6 +6470,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "dids",
+			"ddrSongHash": "19b01l0QPiDlDQb6lqd0dQ8Qlld6Dl6l",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37775
 		},
@@ -5992,6 +6483,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "hbfo",
+			"ddrSongHash": "1l8ibdlb0O0q00o6l9Pq1ibdbIQqqOb1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37776
 		},
@@ -6004,6 +6496,7 @@
 		"artist": "CLIMAX of MAXX 360",
 		"data": {
 			"basename": "pavo",
+			"ddrSongHash": "606b9d6OiliId69bO9Odi6qq8o8Qd0dq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37777
 		},
@@ -6016,6 +6509,7 @@
 		"artist": "DE-JAVU",
 		"data": {
 			"basename": "trvo",
+			"ddrSongHash": "8O6b1D9PDO0ll1IO9d1ODDPPo0QPQbob",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37778
 		},
@@ -6028,6 +6522,7 @@
 		"artist": "L.E.D.-G",
 		"data": {
 			"basename": "neph",
+			"ddrSongHash": "DI91q6O00bliOldqO6DqDdqib86iqPPP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37779
 		},
@@ -6040,6 +6535,7 @@
 		"artist": "Lucky Vacuum",
 		"data": {
 			"basename": "bere",
+			"ddrSongHash": "Qb1db18qP1Ib6liPI1668Pq8QPb0QO09",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37780
 		},
@@ -6052,6 +6548,7 @@
 		"artist": "seiya-murai meets “eimy”",
 		"data": {
 			"basename": "rebo",
+			"ddrSongHash": "8qPoPbql190Pi9086ildIlQOqlPoQdP9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37781
 		},
@@ -6064,6 +6561,7 @@
 		"artist": "Mystic Moon",
 		"data": {
 			"basename": "amal",
+			"ddrSongHash": "dbD8PlibPqqdI99901obObb6odqD8qDl",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37782
 		},
@@ -6076,6 +6574,7 @@
 		"artist": "Sota Fujimori",
 		"data": {
 			"basename": "newb",
+			"ddrSongHash": "08PO96OlIoQqPdq91Q1Qqlo8lPidbPP8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37783
 		},
@@ -6088,6 +6587,7 @@
 		"artist": "Sota F. feat. Carol Gadsden",
 		"data": {
 			"basename": "feve",
+			"ddrSongHash": "qOdib0OIO1qOdiQiOi9qIiQiO91idbQq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37784
 		},
@@ -6100,6 +6600,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "trbe",
+			"ddrSongHash": "PlIiPiPoI9DIbPdIPoqQlIq61Pd8QIDo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37785
 		},
@@ -6112,6 +6613,7 @@
 		"artist": "Dormir",
 		"data": {
 			"basename": "dorm",
+			"ddrSongHash": "PbQ8Q9ol09I18IIb0d6iO8i9ODID10iO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37786
 		},
@@ -6124,6 +6626,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "ioio",
+			"ddrSongHash": "q9oQ1Pid9OiIDO66Pd19blOi09019i98",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37787
 		},
@@ -6136,6 +6639,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "prog",
+			"ddrSongHash": "Pld9iO6oi9qlDD08l8QDdIi6d6Q6iDd1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37788
 		},
@@ -6148,6 +6652,7 @@
 		"artist": "2.1MB underground",
 		"data": {
 			"basename": "toho1",
+			"ddrSongHash": "OddDoQ6dqi0QdQDDOO6qlO08d8bPbli1",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37789
 		},
@@ -6160,6 +6665,7 @@
 		"artist": "NM",
 		"data": {
 			"basename": "litp",
+			"ddrSongHash": "6dqPOId9Od11Il90QO0q9iQI6d68IolD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37793
 		},
@@ -6172,6 +6678,7 @@
 		"artist": "Cream puff",
 		"data": {
 			"basename": "merm",
+			"ddrSongHash": "61QQi8i9Iliq66IOq1ib888b666o08O8",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37794
 		},
@@ -6184,6 +6691,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "sigs",
+			"ddrSongHash": "qoDOoP99lq8bd19iqiloObQDqD8QbOq0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37795
 		},
@@ -6196,6 +6704,7 @@
 		"artist": "TЁЯRA",
 		"data": {
 			"basename": "tenj",
+			"ddrSongHash": "OQbPdOIo6dPPIq6d8qid6DbPP0q991i6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37796
 		},
@@ -6208,6 +6717,7 @@
 		"artist": "あさき",
 		"data": {
 			"basename": "shiz",
+			"ddrSongHash": "oQ8oqddQOObiq0ldo68i1d6o1IidObi6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37797
 		},
@@ -6220,6 +6730,7 @@
 		"artist": "dj TAKA feat.flare",
 		"data": {
 			"basename": "mesg",
+			"ddrSongHash": "1OlD9Iqb9Oqol09dDi6iiQ9Iod1oP0il",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37798
 		},
@@ -6232,6 +6743,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "fwer",
+			"ddrSongHash": "q08PbOPPbPobob0OII096bP9iil9908D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37799
 		},
@@ -6244,6 +6756,7 @@
 		"artist": "seiya-murai feat.ALT",
 		"data": {
 			"basename": "sumi",
+			"ddrSongHash": "ibI69PPO1iP0D1IlI0bb11QOq6081POo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37800
 		},
@@ -6256,6 +6769,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "alst",
+			"ddrSongHash": "8bQQ0lP96186D8Ibo8IoOd6o16qioiIo",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37801
 		},
@@ -6268,6 +6782,7 @@
 		"artist": "ギラギラメガネ団",
 		"data": {
 			"basename": "ryor",
+			"ddrSongHash": "oQ9QDQ6I9oo9DP8Oi86id61o9Pbbl9bD",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37802
 		},
@@ -6280,6 +6795,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "chro",
+			"ddrSongHash": "P8DQP9QIioPdi9IO6q0100PlQOIl86I9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37803
 		},
@@ -6304,6 +6820,7 @@
 		"artist": "Another Infinity feat. Mayumi Morinaga",
 		"data": {
 			"basename": "cbtm",
+			"ddrSongHash": "ilqiIlDdiQQ0oOIP8bPobDQqP0O90Q08",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37810
 		},
@@ -6316,6 +6833,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "toky1",
+			"ddrSongHash": "DIDd9l0dbi1QdQ89I6Do9bolDqdb1dPO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37811
 		},
@@ -6328,6 +6846,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "toky2",
+			"ddrSongHash": "i0b0118q8D1QlQbIbli0P0IQ0QP08QdO",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37812
 		},
@@ -6340,6 +6859,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"basename": "toky3",
+			"ddrSongHash": "6OOd69q0oP8iblIIb08OQO9dq9oIq8i6",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37813
 		},
@@ -6352,6 +6872,7 @@
 		"artist": "NC underground",
 		"data": {
 			"basename": "nyev1",
+			"ddrSongHash": "II68b0dooOIOlOiq0iQO18blDd6b9O9D",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37814
 		},
@@ -6364,6 +6885,7 @@
 		"artist": "NC underground",
 		"data": {
 			"basename": "nyev2",
+			"ddrSongHash": "61P0I66id16QIi08Q1918PlldOOiooql",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37815
 		},
@@ -6376,6 +6898,7 @@
 		"artist": "NC underground",
 		"data": {
 			"basename": "nyev3",
+			"ddrSongHash": "Od8ld9bQQPDddIqDQ1PloOOdQ0IQo0O9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37816
 		},
@@ -6388,6 +6911,7 @@
 		"artist": "Harmony Machine",
 		"data": {
 			"basename": "suca",
+			"ddrSongHash": "P8od0Q9DO8i9dl881oPQQIOIIq1Q9Oi9",
 			"flareCategory": "WHITE",
 			"inGameID": 37827
 		},
@@ -6400,6 +6924,7 @@
 		"artist": "Harmony Machine",
 		"data": {
 			"basename": "chil",
+			"ddrSongHash": "dd80OooqdOIi9O60i91PDdIPIbIiiD66",
 			"flareCategory": "WHITE",
 			"inGameID": 37828
 		},
@@ -6412,6 +6937,7 @@
 		"artist": "TOMOSUKE feat. Alexa Slaymaker",
 		"data": {
 			"basename": "dimo",
+			"ddrSongHash": "QD6b8i08P1IQloIPOPiqlIPoDlPi9DPI",
 			"flareCategory": "WHITE",
 			"inGameID": 37829
 		},
@@ -6424,6 +6950,7 @@
 		"artist": "Design-MAD crew",
 		"data": {
 			"basename": "sumf",
+			"ddrSongHash": "i90o9Q0D91bb0Q6qIQ1OiDqqiPPP98oI",
 			"flareCategory": "WHITE",
 			"inGameID": 37834
 		},
@@ -6436,6 +6963,7 @@
 		"artist": "Des-ROW Ft. Maxi Priest",
 		"data": {
 			"basename": "saya",
+			"ddrSongHash": "8QPioDo6lIDdq861DDooq1O9dqdOOPiD",
 			"flareCategory": "GOLD",
 			"inGameID": 37836
 		},
@@ -6448,6 +6976,7 @@
 		"artist": "jun",
 		"data": {
 			"basename": "twin",
+			"ddrSongHash": "lo6bOoq86d9od6qQ9PiPibOioOQb96lP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37840
 		},
@@ -6460,6 +6989,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "revo",
+			"ddrSongHash": "O0Id19qQlDibiDdIP90o81bOo16qbQ0o",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37859
 		},
@@ -6472,6 +7002,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "gofo",
+			"ddrSongHash": "11dQb0qIdbO098ObDqOQQ8Ili9Il0lOd",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37860
 		},
@@ -6484,6 +7015,7 @@
 		"artist": "N.M.R",
 		"data": {
 			"basename": "keyc",
+			"ddrSongHash": "88o0qb8Ii1ldPlDQQdoq90dOd0PoO99d",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37861
 		},
@@ -6496,6 +7028,7 @@
 		"artist": "UZI-LAY",
 		"data": {
 			"basename": "puda",
+			"ddrSongHash": "bllQi9boq8qobOQDOD6QDio9lii8109i",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37862
 		},
@@ -6508,6 +7041,7 @@
 		"artist": "DE-SIRE",
 		"data": {
 			"basename": "trxa",
+			"ddrSongHash": "l9OQPi0do19dQPO8ilq0QDbll8P8Ib6O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37863
 		},
@@ -6520,6 +7054,7 @@
 		"artist": "NAOKI",
 		"data": {
 			"basename": "brak",
+			"ddrSongHash": "6l0iQ18D0I00P89lIqI8bl9biIOi018O",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37864
 		},
@@ -6532,6 +7067,7 @@
 		"artist": "180",
 		"data": {
 			"basename": "paks",
+			"ddrSongHash": "dQPPd10QO9d8IiOiIi8iDD1Qdq8lQli0",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37865
 		},
@@ -6544,6 +7080,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "anot",
+			"ddrSongHash": "9O1O0o8O1qbQ08Q961Ib1iOIDPQid109",
 			"flareCategory": "WHITE",
 			"inGameID": 37866
 		},
@@ -6556,6 +7093,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "sota",
+			"ddrSongHash": "8IdlOq1qI8OO1PP88I6olPiI6IqqqIIO",
 			"flareCategory": "WHITE",
 			"inGameID": 37867
 		},
@@ -6568,6 +7106,7 @@
 		"artist": "S-C-U",
 		"data": {
 			"basename": "scho",
+			"ddrSongHash": "DibOOIOD1id66O0DqOQ61O6I9bIIQQ0q",
 			"flareCategory": "WHITE",
 			"inGameID": 37868
 		},
@@ -6580,6 +7119,7 @@
 		"artist": "猫叉Master+",
 		"data": {
 			"basename": "nblw",
+			"ddrSongHash": "ib0l98Q00O1Do9oQq1IQOOqQOOb80bIo",
 			"flareCategory": "WHITE",
 			"inGameID": 37869
 		},
@@ -6592,6 +7132,7 @@
 		"artist": "REDALiCE feat. anporin",
 		"data": {
 			"basename": "bedr",
+			"ddrSongHash": "d18DI8bO1lql60Ol1dqQlI8qIobl191P",
 			"flareCategory": "WHITE",
 			"inGameID": 37870
 		},
@@ -6604,6 +7145,7 @@
 		"artist": "Remo-con",
 		"data": {
 			"basename": "yaco",
+			"ddrSongHash": "1Ol1i86OQd61IlqPb9O1060l0OQDoDQI",
 			"flareCategory": "WHITE",
 			"inGameID": 37871
 		},
@@ -6616,6 +7158,7 @@
 		"artist": "Qrispy Joybox",
 		"data": {
 			"basename": "snpr",
+			"ddrSongHash": "OQbdD9iD898Q01oIddDliq8q9D1QlQ1I",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37881
 		},
@@ -6628,6 +7171,7 @@
 		"artist": "PON",
 		"data": {
 			"basename": "koen",
+			"ddrSongHash": "bo9l0Dl0PbqQQQ16Qq6bOOi68o0996Pq",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37882
 		},
@@ -6640,6 +7184,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "cosh",
+			"ddrSongHash": "dO9b8Id9QQ8DOO69Q0lqi6O9QlDPIPl9",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37883
 		},
@@ -6652,6 +7197,7 @@
 		"artist": "2B-Waves",
 		"data": {
 			"basename": "rens",
+			"ddrSongHash": "lOb8O16P9P81olPdI1o1Dl9I6QQoIqIP",
 			"flareCategory": "CLASSIC",
 			"inGameID": 37884
 		},
@@ -6664,6 +7210,7 @@
 		"artist": "ロマンチック♡Prim姫",
 		"data": {
 			"basename": "yama",
+			"ddrSongHash": "Q8Q6d00DoIiPolOb9PIO0Pll96O0I1qD",
 			"flareCategory": "WHITE",
 			"inGameID": 37885
 		},
@@ -6676,6 +7223,7 @@
 		"artist": "Darwin",
 		"data": {
 			"basename": "airh",
+			"ddrSongHash": "6obQo6d0oQ6QoQql0I60b81IO8IOl1IO",
 			"flareCategory": "WHITE",
 			"inGameID": 37886
 		},
@@ -6688,6 +7236,7 @@
 		"artist": "nc ft. NRG Factory",
 		"data": {
 			"basename": "elys",
+			"ddrSongHash": "b60odbPO1IQd6d0qPIi1dQODq16i9811",
 			"flareCategory": "WHITE",
 			"inGameID": 37887
 		},
@@ -6700,6 +7249,7 @@
 		"artist": "DJ UTO vs. Starving Trancer feat. Mayumi Morinaga",
 		"data": {
 			"basename": "zutt",
+			"ddrSongHash": "80d8obPdlobP9qlqiDb01999o01q6DdP",
 			"flareCategory": "WHITE",
 			"inGameID": 37889
 		},
@@ -6736,6 +7286,7 @@
 		"artist": "Mutsuhiko Izumi",
 		"data": {
 			"basename": "span",
+			"ddrSongHash": "bo6PqbbPQ6D096OIP6dDPbPPiDi88609",
 			"flareCategory": "WHITE",
 			"inGameID": 37893
 		},
@@ -6748,6 +7299,7 @@
 		"artist": "阿部靖広 feat. Strawberry Wink",
 		"data": {
 			"basename": "chew",
+			"ddrSongHash": "lIQ1608o9O6bdoPO0ooi8io8i6q6bO1b",
 			"flareCategory": "WHITE",
 			"inGameID": 37894
 		},
@@ -6760,6 +7312,7 @@
 		"artist": "Starving Trancer",
 		"data": {
 			"basename": "negr",
+			"ddrSongHash": "PdqQ0oO8lIOi800i69I9100olb9Q6D8Q",
 			"flareCategory": "WHITE",
 			"inGameID": 37895
 		},
@@ -6772,6 +7325,7 @@
 		"artist": "矢鴇つかさ feat. 三澤秋",
 		"data": {
 			"basename": "stoa",
+			"ddrSongHash": "oDD1DQ161816dd9Dl8IioOoi9OQdO01O",
 			"flareCategory": "WHITE",
 			"inGameID": 37896
 		},
@@ -6784,6 +7338,7 @@
 		"artist": "Wall5",
 		"data": {
 			"basename": "soth",
+			"ddrSongHash": "i86bPlP6ioldqb1OqPqidboqqQ8dQqdl",
 			"flareCategory": "WHITE",
 			"inGameID": 37897
 		},
@@ -6808,6 +7363,7 @@
 		"artist": "Royz",
 		"data": {
 			"basename": "sthe",
+			"ddrSongHash": "oQPdiPPdQO1Ob6DqDi0l0q0PDP06QlO0",
 			"flareCategory": "WHITE",
 			"inGameID": 37900
 		},
@@ -6820,6 +7376,7 @@
 		"artist": "Royz",
 		"data": {
 			"basename": "acwo",
+			"ddrSongHash": "o81iq91q6lI6OODP9Pb9OboDlQD9Q08d",
 			"flareCategory": "WHITE",
 			"inGameID": 37901
 		},
@@ -6832,6 +7389,7 @@
 		"artist": "Royz",
 		"data": {
 			"basename": "joke",
+			"ddrSongHash": "bQI1dIlIObIIQood96O9q9iO8li11OO9",
 			"flareCategory": "WHITE",
 			"inGameID": 37902
 		},
@@ -6856,6 +7414,7 @@
 		"artist": "world sequence",
 		"data": {
 			"basename": "mura",
+			"ddrSongHash": "diDO6qoqo9li6qDdidDiqO9bi8lOP8ib",
 			"flareCategory": "WHITE",
 			"inGameID": 37905
 		},
@@ -6868,6 +7427,7 @@
 		"artist": "Mystic Moon",
 		"data": {
 			"basename": "iman",
+			"ddrSongHash": "Q8qb1oQobdqDqi0i19qqb11P1oDoiD8O",
 			"flareCategory": "WHITE",
 			"inGameID": 37906
 		},
@@ -6880,6 +7440,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "mobu",
+			"ddrSongHash": "bD1DbibPIq9IIlQd0OIIl0o91QI1il69",
 			"flareCategory": "WHITE",
 			"inGameID": 37907
 		},
@@ -6892,6 +7453,7 @@
 		"artist": "Tatsh",
 		"data": {
 			"basename": "wisi",
+			"ddrSongHash": "I81iP0Io9o1l9li0Iq99P1091O8DoDOd",
 			"flareCategory": "WHITE",
 			"inGameID": 37908
 		},
@@ -6904,6 +7466,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "meum",
+			"ddrSongHash": "db1DlQ9qqI8PiqPD6q88O1P8PDbP11dq",
 			"flareCategory": "WHITE",
 			"inGameID": 37910
 		},
@@ -6916,6 +7479,7 @@
 		"artist": "dj TAKA meets DJ YOSHITAKA",
 		"data": {
 			"basename": "elem",
+			"ddrSongHash": "OiIOPd80d9PQQIbidO6ObioboO88OD9l",
 			"flareCategory": "WHITE",
 			"inGameID": 37912
 		},
@@ -6928,6 +7492,7 @@
 		"artist": "Mutsuhiko Izumi & S-C-U",
 		"data": {
 			"basename": "raki",
+			"ddrSongHash": "0bDqIO9Q0PPIPlPll1D8Pbol9O6DlPdb",
 			"flareCategory": "WHITE",
 			"inGameID": 37913
 		},
@@ -6940,6 +7505,7 @@
 		"artist": "TOMOSUKE × seiya-murai feat. ALT",
 		"data": {
 			"basename": "seit",
+			"ddrSongHash": "I8diIQiPO90qDD60oQ0o669I99dI69DD",
 			"flareCategory": "WHITE",
 			"inGameID": 37914
 		},
@@ -6952,6 +7518,7 @@
 		"artist": "MAX MAXIMIZER VS DJ TOTTO",
 		"data": {
 			"basename": "stul",
+			"ddrSongHash": "oo6iiQQbqQ98D9oP6OQPibIqIPd66Qb0",
 			"flareCategory": "WHITE",
 			"inGameID": 37915
 		},
@@ -6964,6 +7531,7 @@
 		"artist": "Akhuta y OJ",
 		"data": {
 			"basename": "niji",
+			"ddrSongHash": "Dl690bPIlIq0Ol1PdPbb9QO0I66lIqO0",
 			"flareCategory": "WHITE",
 			"inGameID": 37916
 		},
@@ -6976,6 +7544,7 @@
 		"artist": "大日本鉄倶楽部【あさき＆９６】",
 		"data": {
 			"basename": "okom",
+			"ddrSongHash": "9I00D9Id61iD6QP8i8Dd6698PoQ9bdi9",
 			"flareCategory": "WHITE",
 			"inGameID": 37917
 		},
@@ -6988,6 +7557,7 @@
 		"artist": "PON+wac",
 		"data": {
 			"basename": "sous",
+			"ddrSongHash": "9obIQOP8O1l0PQ0Oi1oPQI198o0Pd81o",
 			"flareCategory": "WHITE",
 			"inGameID": 37918
 		},
@@ -7000,6 +7570,7 @@
 		"artist": "TAG×U1-ASAMi",
 		"data": {
 			"basename": "synf",
+			"ddrSongHash": "b9IoO68b1Qd9I6O8qqoo6q1o8DQ8l9lo",
 			"flareCategory": "WHITE",
 			"inGameID": 37919
 		},
@@ -7012,6 +7583,7 @@
 		"artist": "Sota÷Des",
 		"data": {
 			"basename": "empa",
+			"ddrSongHash": "1i10oIqlooQbOqO9qiodbIliilP1I06b",
 			"flareCategory": "WHITE",
 			"inGameID": 37920
 		},
@@ -7024,6 +7596,7 @@
 		"artist": "猫叉L.E.D.Master+",
 		"data": {
 			"basename": "gaia",
+			"ddrSongHash": "idIibqoooOlQ1DId8lOidd6il0bdoql8",
 			"flareCategory": "WHITE",
 			"inGameID": 37921
 		},
@@ -7060,6 +7633,7 @@
 		"artist": "Ryu☆ feat.Mayumi Morinaga",
 		"data": {
 			"basename": "dind",
+			"ddrSongHash": "1i81dQboQ91QbdO9d6bQ1Pi00dPP01li",
 			"flareCategory": "WHITE",
 			"inGameID": 37926
 		},
@@ -7072,6 +7646,7 @@
 		"artist": "ki☆ki",
 		"data": {
 			"basename": "kara",
+			"ddrSongHash": "id1lodDbo0Iq9088Qd19d1OlDPP01D8o",
 			"flareCategory": "WHITE",
 			"inGameID": 37927
 		},
@@ -7084,6 +7659,7 @@
 		"artist": "達見 恵 featured by 佐野宏晃",
 		"data": {
 			"basename": "kike",
+			"ddrSongHash": "i89IO1PPOl0boOol0bQI19Q9liQ0l6O1",
 			"flareCategory": "WHITE",
 			"inGameID": 37928
 		},
@@ -7096,6 +7672,7 @@
 		"artist": "Mutsuhiko Izumi",
 		"data": {
 			"basename": "chin",
+			"ddrSongHash": "P8obb0oQq1lbb6Do01PPDI1o8ooO6Pb0",
 			"flareCategory": "WHITE",
 			"inGameID": 37929
 		},
@@ -7108,6 +7685,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "rryu",
+			"ddrSongHash": "q11d0oiQIlbP91dqqddPq9D80lbODbDi",
 			"flareCategory": "WHITE",
 			"inGameID": 37930
 		},
@@ -7120,6 +7698,7 @@
 		"artist": "TЁЯRA",
 		"data": {
 			"basename": "revn",
+			"ddrSongHash": "IPq8dO1lD8qidDlI0ObboI9IIldQO6IQ",
 			"flareCategory": "WHITE",
 			"inGameID": 37931
 		},
@@ -7132,6 +7711,7 @@
 		"artist": "夏色ビキニのPrim",
 		"data": {
 			"basename": "nagi",
+			"ddrSongHash": "q0QIob1PDI6IP86dlPb6I6il9d6bP606",
 			"flareCategory": "WHITE",
 			"inGameID": 37932
 		},
@@ -7144,6 +7724,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "pran",
+			"ddrSongHash": "P0iOob80dDPqI8oIqq1dOiDd9qilQqDl",
 			"flareCategory": "WHITE",
 			"inGameID": 37933
 		},
@@ -7156,6 +7737,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "twog",
+			"ddrSongHash": "Dbdi9P91PQl660llPQO0l86oDqi1O9Ob",
 			"flareCategory": "WHITE",
 			"inGameID": 37934
 		},
@@ -7168,6 +7750,7 @@
 		"artist": "Y&Co. feat. Karin",
 		"data": {
 			"basename": "swra",
+			"ddrSongHash": "DbibObDP860iqI11POiqQDD0i8PPOibd",
 			"flareCategory": "WHITE",
 			"inGameID": 37935
 		},
@@ -7180,6 +7763,7 @@
 		"artist": "Sota Fujimori",
 		"data": {
 			"basename": "magn",
+			"ddrSongHash": "18l0blb188Oqqi8I68o8oq91Qbq86QDi",
 			"flareCategory": "WHITE",
 			"inGameID": 37936
 		},
@@ -7192,6 +7776,7 @@
 		"artist": "Nanako",
 		"data": {
 			"basename": "fuuf",
+			"ddrSongHash": "0Qb8PDoQ06Q66obPI1P988oI61ioPb6l",
 			"flareCategory": "WHITE",
 			"inGameID": 37937
 		},
@@ -7204,6 +7789,7 @@
 		"artist": "小野秀幸",
 		"data": {
 			"basename": "sola",
+			"ddrSongHash": "dPbOQdio1OI8OOI6OlOIqI1Ii18i8ID0",
 			"flareCategory": "WHITE",
 			"inGameID": 37938
 		},
@@ -7216,6 +7802,7 @@
 		"artist": "Triumvirate",
 		"data": {
 			"basename": "ostt",
+			"ddrSongHash": "lDOPd60Q9obl6D0q8qqdQi9lioblD1db",
 			"flareCategory": "WHITE",
 			"inGameID": 37939
 		},
@@ -7228,6 +7815,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "ckpp",
+			"ddrSongHash": "biqbD9I9q9D16i0i1Idb9d111l1QDq86",
 			"flareCategory": "WHITE",
 			"inGameID": 37940
 		},
@@ -7240,6 +7828,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "rint2",
+			"ddrSongHash": "o91qiqqDi9b6d6l1dQ6qO6oO0QDIlPql",
 			"flareCategory": "WHITE",
 			"inGameID": 37941
 		},
@@ -7252,6 +7841,7 @@
 		"artist": "VENUS",
 		"data": {
 			"basename": "wwve",
+			"ddrSongHash": "Qo1qdD0Q9d11d9Id6o09P9id8lPbOQ6o",
 			"flareCategory": "WHITE",
 			"inGameID": 37942
 		},
@@ -7264,6 +7854,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "wifa",
+			"ddrSongHash": "8bI68oIq08d99P880bDPQ9D80O099Q10",
 			"flareCategory": "WHITE",
 			"inGameID": 37943
 		},
@@ -7276,6 +7867,7 @@
 		"artist": "Qrispy Joybox",
 		"data": {
 			"basename": "prte",
+			"ddrSongHash": "1PoOQPd0D01Q9O0doiQQQ8D8Q096bDq9",
 			"flareCategory": "WHITE",
 			"inGameID": 37944
 		},
@@ -7300,6 +7892,7 @@
 		"artist": "Akhuta Philharmonic Orchestra",
 		"data": {
 			"basename": "stel",
+			"ddrSongHash": "OPQQo1idQoqOq88lIPOQo6DooiP8QO9d",
 			"flareCategory": "WHITE",
 			"inGameID": 37946
 		},
@@ -7312,6 +7905,7 @@
 		"artist": "96 with メカショッチョー",
 		"data": {
 			"basename": "miga",
+			"ddrSongHash": "0ddPq801D8PiiqO1oqoQbdOIQ9lQl11o",
 			"flareCategory": "WHITE",
 			"inGameID": 37947
 		},
@@ -7324,6 +7918,7 @@
 		"artist": "TAG×PON",
 		"data": {
 			"basename": "puni",
+			"ddrSongHash": "IIDiDdQ1d6bIqbld9IdO106POdiPO6PO",
 			"flareCategory": "WHITE",
 			"inGameID": 37948
 		},
@@ -7336,6 +7931,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"basename": "hyen",
+			"ddrSongHash": "6Oi66iq9bqi8bDI6l6lPdqDObo1i9lDl",
 			"flareCategory": "WHITE",
 			"inGameID": 37949
 		},
@@ -7348,6 +7944,7 @@
 		"artist": "あべにゅうぷろじぇくと feat.佐倉紗織 produced by ave;new",
 		"data": {
 			"basename": "koih",
+			"ddrSongHash": "qilOP8l6bDPi98lqDbO6O1obOi068QOQ",
 			"flareCategory": "WHITE",
 			"inGameID": 37950
 		},
@@ -7360,6 +7957,7 @@
 		"artist": "dj TAKA feat.AiMEE",
 		"data": {
 			"basename": "trbl",
+			"ddrSongHash": "D9lq0DioIl9D6ll0d61990DP9qPPb1dP",
 			"flareCategory": "WHITE",
 			"inGameID": 37951
 		},
@@ -7372,6 +7970,7 @@
 		"artist": "Lucky Vacuum",
 		"data": {
 			"basename": "dail",
+			"ddrSongHash": "ldlqDQ0bb8d9do86o898P0qo1OlD88qD",
 			"flareCategory": "WHITE",
 			"inGameID": 37952
 		},
@@ -7384,6 +7983,7 @@
 		"artist": "REDALiCE",
 		"data": {
 			"basename": "vega",
+			"ddrSongHash": "d1dPPII1o69IlI0d0DlPi1i1idbdPD6O",
 			"flareCategory": "WHITE",
 			"inGameID": 37953
 		},
@@ -7396,6 +7996,7 @@
 		"artist": "猫叉Masterβ2",
 		"data": {
 			"basename": "deba",
+			"ddrSongHash": "lQ86Pod1b9oI8OiDDoId099di9OI8d9I",
 			"flareCategory": "WHITE",
 			"inGameID": 37954
 		},
@@ -7408,6 +8009,7 @@
 		"artist": "VENUS feat. Mutsuhiko Izumi",
 		"data": {
 			"basename": "sque",
+			"ddrSongHash": "D9I8d1PDOQ8QqP1o1IIi0o8d6660ddOQ",
 			"flareCategory": "WHITE",
 			"inGameID": 37955
 		},
@@ -7420,6 +8022,7 @@
 		"artist": "あさき大監督",
 		"data": {
 			"basename": "yaky",
+			"ddrSongHash": "1dq6Oq918dIQb1doqQdbiPPPO9lIdl0P",
 			"flareCategory": "WHITE",
 			"inGameID": 37956
 		},
@@ -7432,6 +8035,7 @@
 		"artist": "ダイナミック野球兄弟 v.s. クロスファイヤーPrim",
 		"data": {
 			"basename": "todo",
+			"ddrSongHash": "II8Dlo69PoPOII9P88qdlQPP8I61DlDo",
 			"flareCategory": "WHITE",
 			"inGameID": 37957
 		},
@@ -7444,6 +8048,7 @@
 		"artist": "dj TAKA VS DJ TOTTO feat.藍",
 		"data": {
 			"basename": "ixix",
+			"ddrSongHash": "00obPO6oPIPOoD9qb0dIl6q6D8P6o9bI",
 			"flareCategory": "WHITE",
 			"inGameID": 37958
 		},
@@ -7456,6 +8061,7 @@
 		"artist": "小野秀幸",
 		"data": {
 			"basename": "hosh",
+			"ddrSongHash": "dP88i6I9b9QPQDPPO90POOIo0Il6QloI",
 			"flareCategory": "WHITE",
 			"inGameID": 37959
 		},
@@ -7468,6 +8074,7 @@
 		"artist": "ZUKI",
 		"data": {
 			"basename": "disp",
+			"ddrSongHash": "6i000qlo9PD9oi9I9Qb990D6D9i19699",
 			"flareCategory": "WHITE",
 			"inGameID": 37960
 		},
@@ -7480,6 +8087,7 @@
 		"artist": "Ryu☆ ∞ Des-ROW",
 		"data": {
 			"basename": "engr",
+			"ddrSongHash": "lb19I8d0DPb88QDQlP616lDqoboli90O",
 			"flareCategory": "WHITE",
 			"inGameID": 37961
 		},
@@ -7492,6 +8100,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "rola",
+			"ddrSongHash": "iQqbdqOlqlPP11d1qI8lO6iQb19dO991",
 			"flareCategory": "WHITE",
 			"inGameID": 37962
 		},
@@ -7504,6 +8113,7 @@
 		"artist": "TAG meets “eimy”",
 		"data": {
 			"basename": "reve",
+			"ddrSongHash": "qPDQbQ6lOqqbI9Plb6o9lld0ddIP8oiP",
 			"flareCategory": "WHITE",
 			"inGameID": 37963
 		},
@@ -7516,6 +8126,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "aeth",
+			"ddrSongHash": "l6d0ibbliQPQDdb1lP18D9qbPDi1698b",
 			"flareCategory": "WHITE",
 			"inGameID": 37964
 		},
@@ -7528,6 +8139,7 @@
 		"artist": "TAG feat. ERi",
 		"data": {
 			"basename": "doth",
+			"ddrSongHash": "lPDqbq6OIb810i8bqIo1i1olol1OlP9l",
 			"flareCategory": "WHITE",
 			"inGameID": 37965
 		},
@@ -7540,6 +8152,7 @@
 		"artist": "柊木りお",
 		"data": {
 			"basename": "dete",
+			"ddrSongHash": "QPol19bIb009IDOPildbi1QPdPlO0dq9",
 			"flareCategory": "WHITE",
 			"inGameID": 37982
 		},
@@ -7552,6 +8165,7 @@
 		"artist": "水戸ご当地アイドル(仮)",
 		"data": {
 			"basename": "miku",
+			"ddrSongHash": "Db9DllQooo6lqQdl6Q6OD6q066i1IdOO",
 			"flareCategory": "WHITE",
 			"inGameID": 37986
 		},
@@ -7564,6 +8178,7 @@
 		"artist": "水戸ご当地アイドル(仮)",
 		"data": {
 			"basename": "miso",
+			"ddrSongHash": "IPOq96Qo911IdQbdqIo0I816i6O86ioO",
 			"flareCategory": "WHITE",
 			"inGameID": 37987
 		},
@@ -7576,6 +8191,7 @@
 		"artist": "Last Note. feat. GUMI",
 		"data": {
 			"basename": "setu",
+			"ddrSongHash": "IQ0ID09qD6O1oOdIq0oilI8I8l9DlP9b",
 			"flareCategory": "WHITE",
 			"inGameID": 37988
 		},
@@ -7588,6 +8204,7 @@
 		"artist": "cosMo＠暴走P feat.GUMI",
 		"data": {
 			"basename": "raku",
+			"ddrSongHash": "D08qoOdPd8iOO916bOPIIIdqPP6O00iP",
 			"flareCategory": "WHITE",
 			"inGameID": 37989
 		},
@@ -7600,6 +8217,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"basename": "bamb",
+			"ddrSongHash": "160Oo1q8DolI6068lQi66OQbQ9Q8ODQI",
 			"flareCategory": "WHITE",
 			"inGameID": 37990
 		},
@@ -7612,6 +8230,7 @@
 		"artist": "Last Note.",
 		"data": {
 			"basename": "gens",
+			"ddrSongHash": "QlID98Ddoi6O8lP8IQd6iid610011l60",
 			"flareCategory": "WHITE",
 			"inGameID": 37991
 		},
@@ -7624,6 +8243,7 @@
 		"artist": "iconoclasm feat.GUMI",
 		"data": {
 			"basename": "idol",
+			"ddrSongHash": "1I9ODbQ81qi1006QoQI6d6dbd9iiPD9O",
 			"flareCategory": "WHITE",
 			"inGameID": 37992
 		},
@@ -7636,6 +8256,7 @@
 		"artist": "流星トラップボーイズ",
 		"data": {
 			"basename": "dkdk",
+			"ddrSongHash": "QoId0biOD18610ii0DDP61QqOl6qq86q",
 			"flareCategory": "WHITE",
 			"inGameID": 37993
 		},
@@ -7648,6 +8269,7 @@
 		"artist": "Spacelectro",
 		"data": {
 			"basename": "ssst",
+			"ddrSongHash": "d1bQ1iIb0I1PoPOQqliIo9PiQQb1119d",
 			"flareCategory": "WHITE",
 			"inGameID": 37995
 		},
@@ -7660,6 +8282,7 @@
 		"artist": "ピラミッ℃",
 		"data": {
 			"basename": "cleo",
+			"ddrSongHash": "d91lIllbboPd668QP88I06Q6QqooQiO1",
 			"flareCategory": "WHITE",
 			"inGameID": 37996
 		},
@@ -7672,6 +8295,7 @@
 		"artist": "昇天家族",
 		"data": {
 			"basename": "osen",
+			"ddrSongHash": "ilD80b8QQl9Qo0PP0lQ00b8bO9Oqoobo",
 			"flareCategory": "WHITE",
 			"inGameID": 37997
 		},
@@ -7684,6 +8308,7 @@
 		"artist": "くふおー",
 		"data": {
 			"basename": "cody",
+			"ddrSongHash": "Qq8bbbqO6qQ1DPODd16oi1QDQoQ9b8DO",
 			"flareCategory": "WHITE",
 			"inGameID": 37998
 		},
@@ -7696,6 +8321,7 @@
 		"artist": "HHH×MM×ST",
 		"data": {
 			"basename": "foto",
+			"ddrSongHash": "ObI1oo6QlO981880DDDOlo8bQobI0I9P",
 			"flareCategory": "WHITE",
 			"inGameID": 37999
 		},
@@ -7708,6 +8334,7 @@
 		"artist": "VENUS",
 		"data": {
 			"basename": "fuji",
+			"ddrSongHash": "I0Ql0Di1qD6i0Qq1ql0qPb19q0IQ6iO9",
 			"flareCategory": "WHITE",
 			"inGameID": 38000
 		},
@@ -7720,6 +8347,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "adul",
+			"ddrSongHash": "IQ6I61i1b0Ob01QiQlld8o09iIQPoPOl",
 			"flareCategory": "WHITE",
 			"inGameID": 38001
 		},
@@ -7732,6 +8360,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "noil",
+			"ddrSongHash": "iI96000Ib9DlIOPlDQIO00oDiO9DbPI0",
 			"flareCategory": "WHITE",
 			"inGameID": 38002
 		},
@@ -7744,6 +8373,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "joma",
+			"ddrSongHash": "dDQqqIQlDQ9POd90OPl9Dd1i106odDl0",
 			"flareCategory": "WHITE",
 			"inGameID": 38003
 		},
@@ -7756,6 +8386,7 @@
 		"artist": "金獅子",
 		"data": {
 			"basename": "nage",
+			"ddrSongHash": "Pi69o0idP1obO9QDqIDbPdqlb90q8Dq8",
 			"flareCategory": "WHITE",
 			"inGameID": 38004
 		},
@@ -7768,6 +8399,7 @@
 		"artist": "DJ Mass MAD Izm*",
 		"data": {
 			"basename": "syak",
+			"ddrSongHash": "6dO6i9qq601D8ild9QIlbO8bodbiQ1Pl",
 			"flareCategory": "WHITE",
 			"inGameID": 38010
 		},
@@ -7780,6 +8412,7 @@
 		"artist": "U1 ミライダガッキ連と矢印連",
 		"data": {
 			"basename": "awao",
+			"ddrSongHash": "1d9lDIl6iiiD0D0d8qd6dlDlq6P8o0QI",
 			"flareCategory": "WHITE",
 			"inGameID": 38011
 		},
@@ -7792,6 +8425,7 @@
 		"artist": "Lucky Vacuum",
 		"data": {
 			"basename": "ssca",
+			"ddrSongHash": "9DI8iOP0660lb968I6Oiiid6DQ68IbOO",
 			"flareCategory": "WHITE",
 			"inGameID": 38012
 		},
@@ -7804,6 +8438,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "mine2",
+			"ddrSongHash": "l666Dd0bIO9O69boPd898b19bPDo1IdO",
 			"flareCategory": "WHITE",
 			"inGameID": 38013
 		},
@@ -7816,6 +8451,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "stfa",
+			"ddrSongHash": "bb9lOdO0Pbb1qOIb1oQq8lPlI9i6IP8q",
 			"flareCategory": "WHITE",
 			"inGameID": 38014
 		},
@@ -7828,6 +8464,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "endr",
+			"ddrSongHash": "oQolO9oOO01ll0I8969i8O1IQliloDqP",
 			"flareCategory": "WHITE",
 			"inGameID": 38015
 		},
@@ -7840,6 +8477,7 @@
 		"artist": "PON",
 		"data": {
 			"basename": "eltr",
+			"ddrSongHash": "li0IboIqq8qddDP0Oi1Q9i8OPoD88IQl",
 			"flareCategory": "WHITE",
 			"inGameID": 38016
 		},
@@ -7852,6 +8490,7 @@
 		"artist": "VENUS",
 		"data": {
 			"basename": "xmas",
+			"ddrSongHash": "IPDid8ii1iQb19lb6iqOi91O0il018Ql",
 			"flareCategory": "WHITE",
 			"inGameID": 38017
 		},
@@ -7864,6 +8503,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "peit",
+			"ddrSongHash": "6oI9d9lO6Q0iDD8dIIO08qIODiqiIqDl",
 			"flareCategory": "WHITE",
 			"inGameID": 38018
 		},
@@ -7876,6 +8516,7 @@
 		"artist": "工藤吉三（ベイシスケイプ）",
 		"data": {
 			"basename": "czgt",
+			"ddrSongHash": "q6iD8idqo69qIPl00IQidoq1o1o1d1b9",
 			"flareCategory": "WHITE",
 			"inGameID": 38019
 		},
@@ -7888,6 +8529,7 @@
 		"artist": "兎々",
 		"data": {
 			"basename": "wada",
+			"ddrSongHash": "P0IoP69l6q08q8DoPD1Q8bqq099Pi1iP",
 			"flareCategory": "WHITE",
 			"inGameID": 38020
 		},
@@ -7900,6 +8542,7 @@
 		"artist": "P*Light",
 		"data": {
 			"basename": "fksb",
+			"ddrSongHash": "9i6dOd608qb0IlqoDIPb8q1o8q1ddQQd",
 			"flareCategory": "WHITE",
 			"inGameID": 38021
 		},
@@ -7912,6 +8555,7 @@
 		"artist": "ZERO+ZIBA",
 		"data": {
 			"basename": "rema",
+			"ddrSongHash": "qo6l9dbb8D0iDQI1odo0Qb9O1ibDdoIb",
 			"flareCategory": "WHITE",
 			"inGameID": 38022
 		},
@@ -7924,6 +8568,7 @@
 		"artist": "Akhuta",
 		"data": {
 			"basename": "akhu",
+			"ddrSongHash": "bilO9D91P1lo81oIDP6qOoqdDdQdoDlP",
 			"flareCategory": "WHITE",
 			"inGameID": 38023
 		},
@@ -7936,6 +8581,7 @@
 		"artist": "松下feat.Sota & wac",
 		"data": {
 			"basename": "gogo",
+			"ddrSongHash": "DPo0bi8Dibli118P6D981oQIPPQI01lo",
 			"flareCategory": "WHITE",
 			"inGameID": 38024
 		},
@@ -7948,6 +8594,7 @@
 		"artist": "TAG underground",
 		"data": {
 			"basename": "poss2",
+			"ddrSongHash": "o1Od8IPqddIP0oIPod81PDodPo1qo88o",
 			"flareCategory": "WHITE",
 			"inGameID": 38025
 		},
@@ -7960,6 +8607,7 @@
 		"artist": "猫叉Master+",
 		"data": {
 			"basename": "chea",
+			"ddrSongHash": "1iQIIPdQQOOlP9l90oPdIi60D9OOlqoQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38026
 		},
@@ -7972,6 +8620,7 @@
 		"artist": "96",
 		"data": {
 			"basename": "kuro",
+			"ddrSongHash": "9iOoPoQ998qD66DoOOOqD9oDQD88P8I0",
 			"flareCategory": "WHITE",
 			"inGameID": 38027
 		},
@@ -7984,6 +8633,7 @@
 		"artist": "肥塚良彦",
 		"data": {
 			"basename": "sabl",
+			"ddrSongHash": "QiQi666Qd9I6d1899iii80PdQdDlO1i1",
 			"flareCategory": "WHITE",
 			"inGameID": 38028
 		},
@@ -7996,6 +8646,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "sedm",
+			"ddrSongHash": "9dD6dlq01qd80loD6OOQb60ql6P6068O",
 			"flareCategory": "WHITE",
 			"inGameID": 38029
 		},
@@ -8008,6 +8659,7 @@
 		"artist": "DJ ミラクル☆ストーン",
 		"data": {
 			"basename": "hlye",
+			"ddrSongHash": "ol6IDd019O0qq8dblPQ96ol1oPbI990b",
 			"flareCategory": "WHITE",
 			"inGameID": 38030
 		},
@@ -8020,6 +8672,7 @@
 		"artist": "U1 High-Speed",
 		"data": {
 			"basename": "egoi",
+			"ddrSongHash": "9i0q91lPPiO61b9P891O1i86iOP1I08O",
 			"flareCategory": "WHITE",
 			"inGameID": 38031
 		},
@@ -8032,6 +8685,7 @@
 		"artist": "TAG underground overlay",
 		"data": {
 			"basename": "ovtp",
+			"ddrSongHash": "6bid6d9qPQ80DOqiidQQ891o6Od8801l",
 			"flareCategory": "WHITE",
 			"inGameID": 38032
 		},
@@ -8044,6 +8698,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "orrs",
+			"ddrSongHash": "i91q8l0bbi8qll000ob6qDiQP891iiql",
 			"flareCategory": "WHITE",
 			"inGameID": 38033
 		},
@@ -8056,6 +8711,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "niko",
+			"ddrSongHash": "Qq6D900bD60PddqqbdQb96Pd60918100",
 			"flareCategory": "WHITE",
 			"inGameID": 38034
 		},
@@ -8068,6 +8724,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "mrps",
+			"ddrSongHash": "811o6o1QPP0lPiolI1ObiD99l08o1dQl",
 			"flareCategory": "WHITE",
 			"inGameID": 38035
 		},
@@ -8080,6 +8737,7 @@
 		"artist": "TAG (Realtime Remix by U1)",
 		"data": {
 			"basename": "hbfo2",
+			"ddrSongHash": "qObI8DOldoqob8OQD6Dqdiob0dIb0ll9",
 			"flareCategory": "WHITE",
 			"inGameID": 38036
 		},
@@ -8092,6 +8750,7 @@
 		"artist": "underground & overground",
 		"data": {
 			"basename": "pran2",
+			"ddrSongHash": "D8q1ObblD0i6liQ0OD6OdD0qIo9oPldb",
 			"flareCategory": "WHITE",
 			"inGameID": 38037
 		},
@@ -8104,6 +8763,7 @@
 		"artist": "U1 overground feat.TAG",
 		"data": {
 			"basename": "stfa2",
+			"ddrSongHash": "1QqObIQPDOq6bI6iOqDiiI66oDQQidlb",
 			"flareCategory": "WHITE",
 			"inGameID": 38038
 		},
@@ -8116,6 +8776,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "asai",
+			"ddrSongHash": "918oPDQDoPlD1OlqlqQI08I6dD9iqoil",
 			"flareCategory": "WHITE",
 			"inGameID": 38039
 		},
@@ -8128,6 +8789,7 @@
 		"artist": "Ryu☆ feat.MAYU",
 		"data": {
 			"basename": "mayu",
+			"ddrSongHash": "o96i9P9iO9o0DdbPb9bbQ66DqDq88Db1",
 			"flareCategory": "WHITE",
 			"inGameID": 38040
 		},
@@ -8140,6 +8802,7 @@
 		"artist": "Sota Fujimori",
 		"data": {
 			"basename": "onna",
+			"ddrSongHash": "0Ib6qIb0iPOoQqqDIl90dP0PI0o9QlDd",
 			"flareCategory": "WHITE",
 			"inGameID": 38041
 		},
@@ -8152,6 +8815,7 @@
 		"artist": "柊木りお featured by TAG",
 		"data": {
 			"basename": "awak",
+			"ddrSongHash": "lQ1QDdooiOO9QPo8q91iD1IqI8Po9ODl",
 			"flareCategory": "WHITE",
 			"inGameID": 38042
 		},
@@ -8164,6 +8828,7 @@
 		"artist": "REDALiCE feat. Ayumi Nomiya",
 		"data": {
 			"basename": "scar",
+			"ddrSongHash": "oQ1PPlOd8Ilb8I1I6biqO0lQPIoOldP1",
 			"flareCategory": "WHITE",
 			"inGameID": 38043
 		},
@@ -8176,6 +8841,7 @@
 		"artist": "Masayoshi Minoshima(ALR)",
 		"data": {
 			"basename": "strg",
+			"ddrSongHash": "1idIoi66ll806D8ddldOQi8bdiDO0Oil",
 			"flareCategory": "WHITE",
 			"inGameID": 38044
 		},
@@ -8188,6 +8854,7 @@
 		"artist": "P*Light feat. mow*2",
 		"data": {
 			"basename": "home",
+			"ddrSongHash": "DoQi6oPoD9DlO0898oo0ol0qoo6891Db",
 			"flareCategory": "WHITE",
 			"inGameID": 38045
 		},
@@ -8200,6 +8867,7 @@
 		"artist": "DJ TOTTO feat.3L",
 		"data": {
 			"basename": "ayak",
+			"ddrSongHash": "06O0ObdQobq86lPDo6P18dQ1QPdilIQO",
 			"flareCategory": "WHITE",
 			"inGameID": 38046
 		},
@@ -8212,6 +8880,7 @@
 		"artist": "日向美ビタースイーツ♪ & ここなつ",
 		"data": {
 			"basename": "choc",
+			"ddrSongHash": "iQP6PI8oDQi1OPQObDQO1IIP9I8i0I1o",
 			"flareCategory": "WHITE",
 			"inGameID": 38047
 		},
@@ -8224,6 +8893,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "bibi",
+			"ddrSongHash": "1qdb8P8il9li6DOdPolq9d0d9Q6898oi",
 			"flareCategory": "WHITE",
 			"inGameID": 38048
 		},
@@ -8236,6 +8906,7 @@
 		"artist": "ARM feat. ななひら",
 		"data": {
 			"basename": "baku",
+			"ddrSongHash": "lO8O011qIqioPDi9d0oib09DDDPIbqOI",
 			"flareCategory": "WHITE",
 			"inGameID": 38049
 		},
@@ -8248,6 +8919,7 @@
 		"artist": "山本椛 (monotone)",
 		"data": {
 			"basename": "totu",
+			"ddrSongHash": "q1qI0QibDDP6oPdl8DlIlPo80DqDd66P",
 			"flareCategory": "WHITE",
 			"inGameID": 38050
 		},
@@ -8260,6 +8932,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "dopa",
+			"ddrSongHash": "QoODOoqDli0bOoqqDo8ODo1lDI9llblo",
 			"flareCategory": "WHITE",
 			"inGameID": 38051
 		},
@@ -8272,6 +8945,7 @@
 		"artist": "ヒゲドライバー join. shully & Nimo",
 		"data": {
 			"basename": "papi",
+			"ddrSongHash": "668Q8qQdqoIQQiIQOilDqd8lDOOQ8bDQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38052
 		},
@@ -8284,6 +8958,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "sakm",
+			"ddrSongHash": "QQd9l19POblQdPdd61OD808DQ1qOQ9dl",
 			"flareCategory": "WHITE",
 			"inGameID": 38053
 		},
@@ -8296,6 +8971,7 @@
 		"artist": "S-C-U × U1 overground",
 		"data": {
 			"basename": "tenk",
+			"ddrSongHash": "D68PQib86POo9D6O8Q0qO8bD6bDb1bdl",
 			"flareCategory": "WHITE",
 			"inGameID": 38054
 		},
@@ -8308,6 +8984,7 @@
 		"artist": "96 & Sota ft. Mayumi Morinaga",
 		"data": {
 			"basename": "intb",
+			"ddrSongHash": "o1dbD61Qi98O60liQQ91d8O16I86dqDd",
 			"flareCategory": "WHITE",
 			"inGameID": 38055
 		},
@@ -8320,6 +8997,7 @@
 		"artist": "猫叉王子 feat. TAG",
 		"data": {
 			"basename": "sumd",
+			"ddrSongHash": "iIPq9q8PQDDObo610oQoi0ob96PDi8li",
 			"flareCategory": "WHITE",
 			"inGameID": 38057
 		},
@@ -8332,6 +9010,7 @@
 		"artist": "PON×U1",
 		"data": {
 			"basename": "ondo",
+			"ddrSongHash": "l6oP66ODld89Q99o0lDPP90qdbo11PPQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38058
 		},
@@ -8344,6 +9023,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "yaoy",
+			"ddrSongHash": "Dd98lDdo8Ob698d9qbO9iD0PqO19oQbI",
 			"flareCategory": "WHITE",
 			"inGameID": 38059
 		},
@@ -8356,6 +9036,7 @@
 		"artist": "柊木りお featured by TAG",
 		"data": {
 			"basename": "tsub",
+			"ddrSongHash": "o9Ib8bob6b9qIDq1d09bq8q1I06Odi90",
 			"flareCategory": "WHITE",
 			"inGameID": 38060
 		},
@@ -8368,6 +9049,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "nekn",
+			"ddrSongHash": "Po09DbIQ9QPoboQi0900lbbOqDoPbIod",
 			"flareCategory": "WHITE",
 			"inGameID": 38061
 		},
@@ -8380,6 +9062,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "geki",
+			"ddrSongHash": "Pd1d96Q91oiboqb86DdddD68dbq81Pdo",
 			"flareCategory": "WHITE",
 			"inGameID": 38062
 		},
@@ -8392,6 +9075,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "shik",
+			"ddrSongHash": "OoQoQIP06Doq1d88dDQQdlQ8i68Do9DO",
 			"flareCategory": "WHITE",
 			"inGameID": 38063
 		},
@@ -8404,6 +9088,7 @@
 		"artist": "A応P",
 		"data": {
 			"basename": "hnmr",
+			"ddrSongHash": "6doo1dQ16Ol86oIbQ19PPldI8lIbP0OI",
 			"flareCategory": "WHITE",
 			"inGameID": 38064
 		},
@@ -8416,6 +9101,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "tiho",
+			"ddrSongHash": "91dD6iqPO066do99169POPbQPbo9o6oq",
 			"flareCategory": "WHITE",
 			"inGameID": 38065
 		},
@@ -8428,6 +9114,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "edsm",
+			"ddrSongHash": "96Qo1idlD9o8q9qIdiDl18l0O06Qo108",
 			"flareCategory": "WHITE",
 			"inGameID": 38067
 		},
@@ -8440,6 +9127,7 @@
 		"artist": "CLUB SPICE",
 		"data": {
 			"basename": "yeye",
+			"ddrSongHash": "8OPDQ1oQIOPdqqD18oo0lQ8OQOIbbDoP",
 			"flareCategory": "WHITE",
 			"inGameID": 38068
 		},
@@ -8452,6 +9140,7 @@
 		"artist": "U1",
 		"data": {
 			"basename": "huia",
+			"ddrSongHash": "8OIqIi996QI18Oo0q8iiiO8bbb6dI1l6",
 			"flareCategory": "WHITE",
 			"inGameID": 38069
 		},
@@ -8464,6 +9153,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "strn",
+			"ddrSongHash": "ooo6qID66I6191bQib1QQdlPoio6Iodl",
 			"flareCategory": "WHITE",
 			"inGameID": 38070
 		},
@@ -8476,6 +9166,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "strn2",
+			"ddrSongHash": "oqPii6QDdPOI6lDDQ96DOI8ill61bobd",
 			"flareCategory": "WHITE",
 			"inGameID": 38071
 		},
@@ -8488,6 +9179,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "newc",
+			"ddrSongHash": "o068b00O6QD8lo9O1i9PbQlqO6IQOidD",
 			"flareCategory": "WHITE",
 			"inGameID": 38072
 		},
@@ -8500,6 +9192,7 @@
 		"artist": "uno(IOSYS)",
 		"data": {
 			"basename": "sans",
+			"ddrSongHash": "Q96Qo0qbQ81odQoqPOOQ98oDbo6Pb1IO",
 			"flareCategory": "WHITE",
 			"inGameID": 38073
 		},
@@ -8512,6 +9205,7 @@
 		"artist": "かめりあ feat. ななひら",
 		"data": {
 			"basename": "edmj",
+			"ddrSongHash": "61oIP0QIlO90d18ObDP1Dii6PoIQoOD8",
 			"flareCategory": "WHITE",
 			"inGameID": 38074
 		},
@@ -8524,6 +9218,7 @@
 		"artist": "Starving Trancer feat. Mayumi Morinaga",
 		"data": {
 			"basename": "tnaw",
+			"ddrSongHash": "0Ob1601118Dii9Qdii9lPbioPP6qoi1I",
 			"flareCategory": "WHITE",
 			"inGameID": 38075
 		},
@@ -8536,6 +9231,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "pooc",
+			"ddrSongHash": "O6q0qIQdII9086d9q6o0D1PO06liQ9iO",
 			"flareCategory": "WHITE",
 			"inGameID": 38076
 		},
@@ -8548,6 +9244,7 @@
 		"artist": "東雲夏陽(from ここなつ)",
 		"data": {
 			"basename": "sayo",
+			"ddrSongHash": "1P9bqO00bIQ0q8d1Q80l0Dq8oi6boqb0",
 			"flareCategory": "WHITE",
 			"inGameID": 38077
 		},
@@ -8560,6 +9257,7 @@
 		"artist": "東雲心菜(from ここなつ)",
 		"data": {
 			"basename": "tama",
+			"ddrSongHash": "8i9llqdbQ6qP611I90lldPq1o1oQl69o",
 			"flareCategory": "WHITE",
 			"inGameID": 38078
 		},
@@ -8572,6 +9270,7 @@
 		"artist": "Sota Fujimori",
 		"data": {
 			"basename": "daan",
+			"ddrSongHash": "Oi1DI99DO6i6llQ8DDD6oDqOQqiP118d",
 			"flareCategory": "WHITE",
 			"inGameID": 38079
 		},
@@ -8584,6 +9283,7 @@
 		"artist": "Nhato",
 		"data": {
 			"basename": "sttr",
+			"ddrSongHash": "I1DiOI16Id0qdlqbQ6ObPlilDP1oiI98",
 			"flareCategory": "WHITE",
 			"inGameID": 38080
 		},
@@ -8596,6 +9296,7 @@
 		"artist": "かめりあ feat. ななひら",
 		"data": {
 			"basename": "bass",
+			"ddrSongHash": "qD6P1ldl09Dqq8QP01bbid0b9IdqobPl",
 			"flareCategory": "WHITE",
 			"inGameID": 38081
 		},
@@ -8608,6 +9309,7 @@
 		"artist": "Eagle",
 		"data": {
 			"basename": "sick",
+			"ddrSongHash": "QOPioi8P81q9l0QiP6q06b06bdOO8b1O",
 			"flareCategory": "WHITE",
 			"inGameID": 38082
 		},
@@ -8620,6 +9322,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "tech",
+			"ddrSongHash": "qdbDo1oP6D9ioODd1dQO0QObObidilbP",
 			"flareCategory": "WHITE",
 			"inGameID": 38083
 		},
@@ -8632,6 +9335,7 @@
 		"artist": "Alstroemeria Records",
 		"data": {
 			"basename": "bada",
+			"ddrSongHash": "8Q8dP1odl1D9lIbiIO86OPPIoq6qPP1l",
 			"flareCategory": "WHITE",
 			"inGameID": 38084
 		},
@@ -8644,6 +9348,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "fare",
+			"ddrSongHash": "9QlqQb9qO008DIPbq8DOlP60P110DPi1",
 			"flareCategory": "WHITE",
 			"inGameID": 38085
 		},
@@ -8656,6 +9361,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "fare2",
+			"ddrSongHash": "bIloQ900Iq01ql6ddP9idIb6iQ11i9D6",
 			"flareCategory": "WHITE",
 			"inGameID": 38086
 		},
@@ -8668,6 +9374,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "basb",
+			"ddrSongHash": "18id0bi1Q6lbl0091iP0QoOIq9DDPo9I",
 			"flareCategory": "WHITE",
 			"inGameID": 38087
 		},
@@ -8680,6 +9387,7 @@
 		"artist": "L.E.D.-G",
 		"data": {
 			"basename": "risi",
+			"ddrSongHash": "60P9IPOdi1OIbD61D8i0D9ODoq6QOIPO",
 			"flareCategory": "WHITE",
 			"inGameID": 38088
 		},
@@ -8692,6 +9400,7 @@
 		"artist": "Zodiac Fall",
 		"data": {
 			"basename": "seiz",
+			"ddrSongHash": "lIlold9IQbDb0d6IdP6600DOQIDb9dOP",
 			"flareCategory": "WHITE",
 			"inGameID": 38089
 		},
@@ -8704,6 +9413,7 @@
 		"artist": "SUPER HEROINE 彩香-AYAKA-",
 		"data": {
 			"basename": "almh",
+			"ddrSongHash": "oIPb0iPd8OdDD181dQd8OI18OQDl01QO",
 			"flareCategory": "WHITE",
 			"inGameID": 38090
 		},
@@ -8716,6 +9426,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "daif",
+			"ddrSongHash": "ddOqqDI91bqqiOoll6I0i16i1P18019q",
 			"flareCategory": "WHITE",
 			"inGameID": 38091
 		},
@@ -8728,6 +9439,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "hall",
+			"ddrSongHash": "l6qQi9qlO8diPd18dl6DdqPid01P91iQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38092
 		},
@@ -8740,6 +9452,7 @@
 		"artist": "Qrispy Joybox feat.Sana",
 		"data": {
 			"basename": "twiw",
+			"ddrSongHash": "91Qdq6DbPDlQOiOq08di0IQo8IP8PPqQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38093
 		},
@@ -8752,6 +9465,7 @@
 		"artist": "ヒゲドライバー join. SELEN",
 		"data": {
 			"basename": "dddd",
+			"ddrSongHash": "DDDiQOd1IQQ6QIIq09PDqdQdDIll6bQI",
 			"flareCategory": "WHITE",
 			"inGameID": 38094
 		},
@@ -8764,6 +9478,7 @@
 		"artist": "TAG meets “eimy”",
 		"data": {
 			"basename": "aozo",
+			"ddrSongHash": "qbbPQoqqqiPd98d61P0qDd0iDId6OqoQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38095
 		},
@@ -8776,6 +9491,7 @@
 		"artist": "Captain KING",
 		"data": {
 			"basename": "sibe",
+			"ddrSongHash": "qq8qDqqPQdP0loDI6DDO9d6dQ601iOID",
 			"flareCategory": "WHITE",
 			"inGameID": 38096
 		},
@@ -8788,6 +9504,7 @@
 		"artist": "Musical Cosmology",
 		"data": {
 			"basename": "shkk",
+			"ddrSongHash": "P869didbP8Q69IQ0dIqo1ibOb0bb99Q1",
 			"flareCategory": "WHITE",
 			"inGameID": 38097
 		},
@@ -8800,6 +9517,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "astr",
+			"ddrSongHash": "6QdIl8odooDQ0oOQ0IObQqo1lO986PP6",
 			"flareCategory": "WHITE",
 			"inGameID": 38098
 		},
@@ -8812,6 +9530,7 @@
 		"artist": "HHH×MM×ST",
 		"data": {
 			"basename": "obor",
+			"ddrSongHash": "I96dOqqqQIi9oiqbqDPbQ8I8PQbqOb1o",
 			"flareCategory": "WHITE",
 			"inGameID": 38099
 		},
@@ -8824,6 +9543,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "shio",
+			"ddrSongHash": "Dbd0o8iob1D0990DDIOIIQ6bQqdDQ6ID",
 			"flareCategory": "WHITE",
 			"inGameID": 38100
 		},
@@ -8836,6 +9556,7 @@
 		"artist": "松下feat.Sota & wac",
 		"data": {
 			"basename": "kyun",
+			"ddrSongHash": "QIDd80o0OqobODP00ldQ1D9dl81qQi0d",
 			"flareCategory": "WHITE",
 			"inGameID": 38101
 		},
@@ -8848,6 +9569,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "grip",
+			"ddrSongHash": "I90bd6obO890P0d1iiPD0dol8o8QloQD",
 			"flareCategory": "WHITE",
 			"inGameID": 38102
 		},
@@ -8860,6 +9582,7 @@
 		"artist": "ビートまりお(COOL&CREATE)",
 		"data": {
 			"basename": "nofn",
+			"ddrSongHash": "liq91ddlPQ16iooqDDQ86qlodIO10Qb1",
 			"flareCategory": "WHITE",
 			"inGameID": 38103
 		},
@@ -8872,6 +9595,7 @@
 		"artist": "ARM(IOSYS)",
 		"data": {
 			"basename": "mtni",
+			"ddrSongHash": "PloPqd6Q19Q990dl16I0Qi06i0l8o168",
 			"flareCategory": "WHITE",
 			"inGameID": 38104
 		},
@@ -8884,6 +9608,7 @@
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
 			"basename": "help",
+			"ddrSongHash": "9dDOQo8bQ6blDdd989l1QIO8liDq9O0q",
 			"flareCategory": "WHITE",
 			"inGameID": 38105
 		},
@@ -8896,6 +9621,7 @@
 		"artist": "幽閉サテライト feat. senya",
 		"data": {
 			"basename": "iroh",
+			"ddrSongHash": "16IqQ680IioldO69QD61liQod0DQ8boQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38107
 		},
@@ -8920,6 +9646,7 @@
 		"artist": "EasyPop",
 		"data": {
 			"basename": "haps",
+			"ddrSongHash": "l1bDOIlb6ddI6od0q1llI0I6blq9oP0l",
 			"flareCategory": "WHITE",
 			"inGameID": 38109
 		},
@@ -8932,6 +9659,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "kuka",
+			"ddrSongHash": "16oDDIlP8bIODQ6Ql0881d9Qqdb19b98",
 			"flareCategory": "WHITE",
 			"inGameID": 38110
 		},
@@ -9052,6 +9780,7 @@
 		"artist": "ARM (IOSYS) feat. Nicole Curry",
 		"data": {
 			"basename": "coli",
+			"ddrSongHash": "oIII9lI0q6i9Q0b18ldoI6o0PQ0qqD01",
 			"flareCategory": "WHITE",
 			"inGameID": 38120
 		},
@@ -9064,6 +9793,7 @@
 		"artist": "kors k feat. Suzuyo Miyamoto",
 		"data": {
 			"basename": "speo",
+			"ddrSongHash": "D9odQ60DDolq9QI9DDl98DIobdPPIil9",
 			"flareCategory": "WHITE",
 			"inGameID": 38121
 		},
@@ -9076,6 +9806,7 @@
 		"artist": "164",
 		"data": {
 			"basename": "aman",
+			"ddrSongHash": "16bl8D8lOddP9Obq0OIlOI6q8Pi1l9O0",
 			"flareCategory": "WHITE",
 			"inGameID": 38122
 		},
@@ -9088,6 +9819,7 @@
 		"artist": "Neru",
 		"data": {
 			"basename": "lost",
+			"ddrSongHash": "Q6b1odD8q99D190oP6ol01DolQPD0OdD",
 			"flareCategory": "WHITE",
 			"inGameID": 38123
 		},
@@ -9100,6 +9832,7 @@
 		"artist": "DJ TOTTO feat.anporin",
 		"data": {
 			"basename": "hapk",
+			"ddrSongHash": "Q86b6I1Qi6Q918l6iOoOQl866oQoIQOi",
 			"flareCategory": "WHITE",
 			"inGameID": 38124
 		},
@@ -9124,6 +9857,7 @@
 		"artist": "日向美ビタースイーツ♪＆ひなちくん",
 		"data": {
 			"basename": "kura",
+			"ddrSongHash": "8Q8OiP8QPbl8bqID1loQq896ldPQd99o",
 			"flareCategory": "WHITE",
 			"inGameID": 38126
 		},
@@ -9136,6 +9870,7 @@
 		"artist": "SHAMDEL",
 		"data": {
 			"basename": "towa",
+			"ddrSongHash": "l66Io69ob00OoOiDOI9lIqlidbDoDq89",
 			"flareCategory": "WHITE",
 			"inGameID": 38127
 		},
@@ -9148,6 +9883,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"basename": "cyto",
+			"ddrSongHash": "ibl00b69Oli68l96d6o1P1ob8QPillbO",
 			"flareCategory": "WHITE",
 			"inGameID": 38128
 		},
@@ -9160,6 +9896,7 @@
 		"artist": "U1-ASAMi",
 		"data": {
 			"basename": "ifca",
+			"ddrSongHash": "1Ob1I0do8Iq6QqP6PQIiddD18dqDP9oo",
 			"flareCategory": "WHITE",
 			"inGameID": 38129
 		},
@@ -9172,6 +9909,7 @@
 		"artist": "PON",
 		"data": {
 			"basename": "emer",
+			"ddrSongHash": "OdlOPPblPlbbldOdqblI06Dd1q00PPo9",
 			"flareCategory": "WHITE",
 			"inGameID": 38130
 		},
@@ -9184,6 +9922,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"basename": "anje",
+			"ddrSongHash": "9Q081Q0Do0IDDqQi9O61P111QIQd0oQ6",
 			"flareCategory": "WHITE",
 			"inGameID": 38131
 		},
@@ -9196,6 +9935,7 @@
 		"artist": "削除",
 		"data": {
 			"basename": "strc",
+			"ddrSongHash": "li6dD9b8dboOd9bbqli886lDl08IPQ00",
 			"flareCategory": "WHITE",
 			"inGameID": 38132
 		},
@@ -9208,6 +9948,7 @@
 		"artist": "xi",
 		"data": {
 			"basename": "gran",
+			"ddrSongHash": "Ib01P6O8OPl8qqQi9QO6dii18ID69I8P",
 			"flareCategory": "WHITE",
 			"inGameID": 38133
 		},
@@ -9220,6 +9961,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"basename": "seph",
+			"ddrSongHash": "Qbbqd9O98bl0DobQ9l6blO8iOPP8QdDd",
 			"flareCategory": "WHITE",
 			"inGameID": 38134
 		},
@@ -9232,6 +9974,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "zeph",
+			"ddrSongHash": "I61ioI01IOPDPbP1OO0l98PD0iDbid0D",
 			"flareCategory": "WHITE",
 			"inGameID": 38135
 		},
@@ -9244,6 +9987,7 @@
 		"artist": "DJ YOSHITAKA meets dj TAKA",
 		"data": {
 			"basename": "trco",
+			"ddrSongHash": "d810q0I8q6d0l1POlIO6d66bOPb96dql",
 			"flareCategory": "WHITE",
 			"inGameID": 38136
 		},
@@ -9256,6 +10000,7 @@
 		"artist": "Sota F.",
 		"data": {
 			"basename": "nday",
+			"ddrSongHash": "l08bl1dddob81IP1IbQqbDbiPo9l069l",
 			"flareCategory": "WHITE",
 			"inGameID": 38137
 		},
@@ -9268,6 +10013,7 @@
 		"artist": "柊木りお featured by SOTAG",
 		"data": {
 			"basename": "hope",
+			"ddrSongHash": "90qP0000qoO8o8dIidlO611ilO11Oo9Q",
 			"flareCategory": "WHITE",
 			"inGameID": 38138
 		},
@@ -9280,6 +10026,7 @@
 		"artist": "劇団レコード",
 		"data": {
 			"basename": "isht",
+			"ddrSongHash": "bPb96lbDP9OdI0Oi1189iOPPdllPIDQb",
 			"flareCategory": "WHITE",
 			"inGameID": 38139
 		},
@@ -9292,6 +10039,7 @@
 		"artist": "Qrispy Joybox",
 		"data": {
 			"basename": "outo",
+			"ddrSongHash": "I6qdO8Di181P6Q9Ooq0d8d0DOdq1dOOQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38140
 		},
@@ -9304,6 +10052,7 @@
 		"artist": "BEMANI Sound Team \"Metal Stepper\"",
 		"data": {
 			"basename": "firs",
+			"ddrSongHash": "9Di9ODOOl8PDQiO1O6o8lD16QlI609ob",
 			"flareCategory": "WHITE",
 			"inGameID": 38141
 		},
@@ -9316,6 +10065,7 @@
 		"artist": "Prim",
 		"data": {
 			"basename": "kouc",
+			"ddrSongHash": "Q9Q088PPd0bPi9QQ8iil1lQqPdiQP69D",
 			"flareCategory": "WHITE",
 			"inGameID": 38142
 		},
@@ -9328,6 +10078,7 @@
 		"artist": "NU-KO",
 		"data": {
 			"basename": "rena",
+			"ddrSongHash": "iP8ll9I0dd8d689PPqlI9008d06io09q",
 			"flareCategory": "WHITE",
 			"inGameID": 38143
 		},
@@ -9340,6 +10091,7 @@
 		"artist": "HuΣeR",
 		"data": {
 			"basename": "neut",
+			"ddrSongHash": "lO91bIQ0Q990PqPbPIq88b9I9PI6ID0Q",
 			"flareCategory": "WHITE",
 			"inGameID": 38144
 		},
@@ -9352,6 +10104,7 @@
 		"artist": "nc ft.NRGFactory",
 		"data": {
 			"basename": "resk",
+			"ddrSongHash": "POq8OPlOO9199i11Od0P00801Qo01DQo",
 			"flareCategory": "WHITE",
 			"inGameID": 38145
 		},
@@ -9364,6 +10117,7 @@
 		"artist": "SYUNN",
 		"data": {
 			"basename": "cosy",
+			"ddrSongHash": "9QIo1lbD1ldlqPO0iD68io69Pd8b01Do",
 			"flareCategory": "WHITE",
 			"inGameID": 38146
 		},
@@ -9376,6 +10130,7 @@
 		"artist": "白澤亮（noisycroak）",
 		"data": {
 			"basename": "purs",
+			"ddrSongHash": "bl90QbiqoOlDI6iQQQdo0Iol6PIdQblP",
 			"flareCategory": "WHITE",
 			"inGameID": 38147
 		},
@@ -9388,6 +10143,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "flyf",
+			"ddrSongHash": "Dq8b8DPD06Q8qob8OOiQIlOdD8QQD0q9",
 			"flareCategory": "WHITE",
 			"inGameID": 38148
 		},
@@ -9400,6 +10156,7 @@
 		"artist": "fallen shepherd ft. RabbiTon Strings",
 		"data": {
 			"basename": "endy",
+			"ddrSongHash": "PO9Pl1q896bDDl89qQb98D80DQoPio1I",
 			"flareCategory": "WHITE",
 			"inGameID": 38149
 		},
@@ -9412,6 +10169,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"",
 		"data": {
 			"basename": "chro2",
+			"ddrSongHash": "d18bbq1l699OP9Di6q8oqD9oPb1o1P6I",
 			"flareCategory": "WHITE",
 			"inGameID": 38150
 		},
@@ -9424,6 +10182,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "algo",
+			"ddrSongHash": "ddq1DldlQ990iidO6O99q61bI1966Q0I",
 			"flareCategory": "WHITE",
 			"inGameID": 38151
 		},
@@ -9436,6 +10195,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "exmo",
+			"ddrSongHash": "80PdqQ0iiOQb9i91lIliodiO9PI8O609",
 			"flareCategory": "WHITE",
 			"inGameID": 38152
 		},
@@ -9448,6 +10208,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "lonh",
+			"ddrSongHash": "9O8bq8b1Pi6Dl08OiPq10OddOdol1qOi",
 			"flareCategory": "WHITE",
 			"inGameID": 38153
 		},
@@ -9460,6 +10221,7 @@
 		"artist": "ARM (IOSYS) feat. Nicole Curry",
 		"data": {
 			"basename": "nevl",
+			"ddrSongHash": "1iDPo19Pb9ooi8OqiidbqPb06DDdqiqo",
 			"flareCategory": "GOLD",
 			"inGameID": 38154
 		},
@@ -9472,6 +10234,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "orca",
+			"ddrSongHash": "99OQb9b0IQ98P6IQdPOiqi8q16o16iqP",
 			"flareCategory": "GOLD",
 			"inGameID": 38155
 		},
@@ -9484,6 +10247,7 @@
 		"artist": "TAG×U1",
 		"data": {
 			"basename": "acef",
+			"ddrSongHash": "ld6P1lbb0bPO9doqbbPOoPb8qoDo8id0",
 			"flareCategory": "WHITE",
 			"inGameID": 38156
 		},
@@ -9496,6 +10260,7 @@
 		"artist": "cosMo＠暴走P feat. 初音ミク",
 		"data": {
 			"basename": "hmss",
+			"ddrSongHash": "QlQ9Qb00bI0ob9oDIiPqO1QdQ0o6O0O6",
 			"flareCategory": "WHITE",
 			"inGameID": 38157
 		},
@@ -9508,6 +10273,7 @@
 		"artist": "うたたP feat. 結月ゆかり",
 		"data": {
 			"basename": "shia",
+			"ddrSongHash": "D11ldIqD8dQIi9oQQIIo86QOI8D9olP8",
 			"flareCategory": "WHITE",
 			"inGameID": 38158
 		},
@@ -9532,6 +10298,7 @@
 		"artist": "ARM・まろん (IOSYS) × ランコ・パプリカ (豚乙女)",
 		"data": {
 			"basename": "hims",
+			"ddrSongHash": "I6Dd0QIi086il1918dQI6dq0l1d9ibD0",
 			"flareCategory": "WHITE",
 			"inGameID": 38160
 		},
@@ -9544,6 +10311,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "ding",
+			"ddrSongHash": "8bqd0Oibbo8q81QdODqdl1OOi1l99O88",
 			"flareCategory": "WHITE",
 			"inGameID": 38161
 		},
@@ -9556,6 +10324,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "haru",
+			"ddrSongHash": "ibdIdIO60b880i8oPOdQD9qIqldOdDl8",
 			"flareCategory": "WHITE",
 			"inGameID": 38167
 		},
@@ -9568,6 +10337,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "tata",
+			"ddrSongHash": "P8DoiO0QO6Qb8iiP9D1IQ080lQQPD6ll",
 			"flareCategory": "WHITE",
 			"inGameID": 38168
 		},
@@ -9580,6 +10350,7 @@
 		"artist": "ときめきアイドル project Rhythmixxx",
 		"data": {
 			"basename": "koin",
+			"ddrSongHash": "i9il1DIDl91Db0OdllOddIqO600Pl89q",
 			"flareCategory": "WHITE",
 			"inGameID": 38169
 		},
@@ -9592,6 +10363,7 @@
 		"artist": "ときめきアイドル project 結城秋葉",
 		"data": {
 			"basename": "shre",
+			"ddrSongHash": "0d8Q9I86lo8oDlQiPd81ll66ob0qli89",
 			"flareCategory": "WHITE",
 			"inGameID": 38170
 		},
@@ -9604,6 +10376,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "twme",
+			"ddrSongHash": "Po1D6bo0dQbdl91bPOl86lo8DbP9biiO",
 			"flareCategory": "WHITE",
 			"inGameID": 38171
 		},
@@ -9616,6 +10389,7 @@
 		"artist": "ときめきアイドル project クッキーパラダイス",
 		"data": {
 			"basename": "stch",
+			"ddrSongHash": "0i68q1iQblI1Pb8QqoQ90i6ddPiqdq8b",
 			"flareCategory": "WHITE",
 			"inGameID": 38172
 		},
@@ -9628,6 +10402,7 @@
 		"artist": "ときめきアイドル project 月島美奈都",
 		"data": {
 			"basename": "inra",
+			"ddrSongHash": "6DQoDoliDO6P96P8D1POoOd8q9QbOibQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38173
 		},
@@ -9640,6 +10415,7 @@
 		"artist": "A応P",
 		"data": {
 			"basename": "kuns",
+			"ddrSongHash": "IbDoODD9qb66Iqd6DbOQiOoDll1DqiO9",
 			"flareCategory": "WHITE",
 			"inGameID": 38174
 		},
@@ -9652,6 +10428,7 @@
 		"artist": "ARM＋夕野ヨシミ feat. miko",
 		"data": {
 			"basename": "sans0",
+			"ddrSongHash": "P66d8iQQIIQO96qoDdIqi9l19i69D9Dq",
 			"flareCategory": "WHITE",
 			"inGameID": 38175
 		},
@@ -9664,6 +10441,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "jewe",
+			"ddrSongHash": "qOD6OPbP6b0l0ODOiObiQbl1DbPqOi9I",
 			"flareCategory": "WHITE",
 			"inGameID": 38176
 		},
@@ -9676,6 +10454,7 @@
 		"artist": "中島由貴",
 		"data": {
 			"basename": "beah",
+			"ddrSongHash": "dOb880lOloIIod00PQ1iQOQqlOOQ0Ql0",
 			"flareCategory": "WHITE",
 			"inGameID": 38177
 		},
@@ -9712,6 +10491,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "lumi",
+			"ddrSongHash": "dqOoPll1qlDdo6Pd6O0DPPO6l16OIdD1",
 			"flareCategory": "WHITE",
 			"inGameID": 38180
 		},
@@ -9736,6 +10516,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "lumo",
+			"ddrSongHash": "qIqbqPblQIIObd9166bbDiioOIiIq991",
 			"flareCategory": "WHITE",
 			"inGameID": 38182
 		},
@@ -9748,6 +10529,7 @@
 		"artist": "常盤ゆう",
 		"data": {
 			"basename": "chop",
+			"ddrSongHash": "ioDOIO9iP8qqPiP9io9Ib1I91OoQ0q0O",
 			"flareCategory": "WHITE",
 			"inGameID": 38183
 		},
@@ -9760,6 +10542,7 @@
 		"artist": "DJ YOSHITAKA feat.DWP",
 		"data": {
 			"basename": "hisc",
+			"ddrSongHash": "811qq00Il1Q681068l8dQbPO60l0oD1l",
 			"flareCategory": "WHITE",
 			"inGameID": 38184
 		},
@@ -9772,6 +10555,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "kois",
+			"ddrSongHash": "I1qd16dPdqPi96ql0lP10OQDbo11D89P",
 			"flareCategory": "WHITE",
 			"inGameID": 38185
 		},
@@ -9784,6 +10568,7 @@
 		"artist": "そらまふうらさか",
 		"data": {
 			"basename": "rpgg",
+			"ddrSongHash": "DOQbd61o6P0oq968Po0oqP01qPQ8lPdq",
 			"flareCategory": "WHITE",
 			"inGameID": 38186
 		},
@@ -9796,6 +10581,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"basename": "alal",
+			"ddrSongHash": "bd8oD0iqDQ8Qobd1oIqi8981QbD6I6Iq",
 			"flareCategory": "WHITE",
 			"inGameID": 38187
 		},
@@ -9808,6 +10594,7 @@
 		"artist": "iroha",
 		"data": {
 			"basename": "rosi",
+			"ddrSongHash": "1OQd9o01Oq6Q018POOdlqodQ6bqDPOob",
 			"flareCategory": "WHITE",
 			"inGameID": 38188
 		},
@@ -9820,6 +10607,7 @@
 		"artist": "みきとP",
 		"data": {
 			"basename": "iaru",
+			"ddrSongHash": "Oq900IIl1Ob8qoIPqDP0PD6blbqIqlP1",
 			"flareCategory": "WHITE",
 			"inGameID": 38189
 		},
@@ -9832,6 +10620,7 @@
 		"artist": "USAO",
 		"data": {
 			"basename": "boss",
+			"ddrSongHash": "QbD9QQP9bqoD00bQQl8obibP9PloQ9Qo",
 			"flareCategory": "WHITE",
 			"inGameID": 38190
 		},
@@ -9844,6 +10633,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "blow",
+			"ddrSongHash": "dlqPb1iqPo81qI89816QIoi01b1b0P06",
 			"flareCategory": "WHITE",
 			"inGameID": 38191
 		},
@@ -9856,6 +10646,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "sarf",
+			"ddrSongHash": "0Pq6o89llQl10dl8O0DdP6lIO0ib6Doq",
 			"flareCategory": "WHITE",
 			"inGameID": 38192
 		},
@@ -9868,6 +10659,7 @@
 		"artist": "北沢綾香",
 		"data": {
 			"basename": "etsu",
+			"ddrSongHash": "Qb6PqOQO8Qd8i91D018olPiD01PbQ061",
 			"flareCategory": "WHITE",
 			"inGameID": 38193
 		},
@@ -9880,6 +10672,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "senn",
+			"ddrSongHash": "D0Qb898oqblPoP68PPq1o9i9dI9o0D9i",
 			"flareCategory": "WHITE",
 			"inGameID": 38194
 		},
@@ -9892,6 +10685,7 @@
 		"artist": "PHQUASE",
 		"data": {
 			"basename": "pure",
+			"ddrSongHash": "dDlDPddq08iD8IOb9I1PbODP9696966D",
 			"flareCategory": "WHITE",
 			"inGameID": 38195
 		},
@@ -9904,6 +10698,7 @@
 		"artist": "HHH×MM×ST",
 		"data": {
 			"basename": "obor2",
+			"ddrSongHash": "oPP1Pdl6Qdlb8oq10PP1doDibdbbl9bl",
 			"flareCategory": "WHITE",
 			"inGameID": 38196
 		},
@@ -9916,6 +10711,7 @@
 		"artist": "BEMANI Sound Team \"L.E.D.-G\" feat. Mayumi Morinaga",
 		"data": {
 			"basename": "inbe",
+			"ddrSongHash": "bdQ6IobP6II86I1io686Il9qQ69dOod1",
 			"flareCategory": "WHITE",
 			"inGameID": 38197
 		},
@@ -9928,6 +10724,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"",
 		"data": {
 			"basename": "vanq",
+			"ddrSongHash": "891b0OdIdO8b9obi69b6PQlPIqDI01dO",
 			"flareCategory": "WHITE",
 			"inGameID": 38198
 		},
@@ -9940,6 +10737,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "snsn",
+			"ddrSongHash": "D1I09111OiQPiDi9doqP9b1PlO1PqII8",
 			"flareCategory": "WHITE",
 			"inGameID": 38199
 		},
@@ -9952,6 +10750,7 @@
 		"artist": "BEMANI Sound Team \"DJ TOTTO feat.MarL\"",
 		"data": {
 			"basename": "seik",
+			"ddrSongHash": "ld8lOqloqD6lOl880ldDo819bDb9q1Qi",
 			"flareCategory": "WHITE",
 			"inGameID": 38200
 		},
@@ -9964,6 +10763,7 @@
 		"artist": "BEMANI Sound Team \"person09\"",
 		"data": {
 			"basename": "pube",
+			"ddrSongHash": "99q8i8bPldDbio919ob0DPi0bqdIoobi",
 			"flareCategory": "WHITE",
 			"inGameID": 38201
 		},
@@ -9976,6 +10776,7 @@
 		"artist": "BEMANI Sound Team \"猫叉Master\"",
 		"data": {
 			"basename": "life",
+			"ddrSongHash": "dqb09QD6o0O8PooiqbqQOdqQ1l80o691",
 			"flareCategory": "WHITE",
 			"inGameID": 38202
 		},
@@ -9988,6 +10789,7 @@
 		"artist": "BEMANI Sound Team \"U1 overground\"",
 		"data": {
 			"basename": "suss",
+			"ddrSongHash": "Id8IPlqQodD01dPiq8oPPQoPQq6booi0",
 			"flareCategory": "WHITE",
 			"inGameID": 38203
 		},
@@ -10000,6 +10802,7 @@
 		"artist": "BEMANI Sound Team \"劇団レコード\"feat.結良まり",
 		"data": {
 			"basename": "frin",
+			"ddrSongHash": "oOI18qilo91qPQl9Q0l9iliO96Pi6DIi",
 			"flareCategory": "WHITE",
 			"inGameID": 38204
 		},
@@ -10012,6 +10815,7 @@
 		"artist": "BEMANI Sound Team \"Dustup\"",
 		"data": {
 			"basename": "prey",
+			"ddrSongHash": "i916bDibPI9l869o9IIQb8DbO9bPDi6q",
 			"flareCategory": "WHITE",
 			"inGameID": 38205
 		},
@@ -10024,6 +10828,7 @@
 		"artist": "BEMANI Sound Team \"HuΣeR feat.PON\"",
 		"data": {
 			"basename": "rejo",
+			"ddrSongHash": "ll6iQl0PoiDob8Oi6dlOQ069061doqbq",
 			"flareCategory": "WHITE",
 			"inGameID": 38206
 		},
@@ -10036,6 +10841,7 @@
 		"artist": "kradness",
 		"data": {
 			"basename": "bura",
+			"ddrSongHash": "id0QqdbI8oloO9l08IqI9q1D0819OQID",
 			"flareCategory": "WHITE",
 			"inGameID": 38207
 		},
@@ -10048,6 +10854,7 @@
 		"artist": "ときめきアイドル project",
 		"data": {
 			"basename": "smpa",
+			"ddrSongHash": "odliP8d18DQi0b8lPbPI1PdoQ0PDd0IP",
 			"flareCategory": "WHITE",
 			"inGameID": 38208
 		},
@@ -10060,6 +10867,7 @@
 		"artist": "松下",
 		"data": {
 			"basename": "oneg",
+			"ddrSongHash": "qdQoQli1d8DP0Obb919I6P1Odilib1Dd",
 			"flareCategory": "WHITE",
 			"inGameID": 38209
 		},
@@ -10084,6 +10892,7 @@
 		"artist": "BEMANI Sound Team \"DJ TOTTO\"",
 		"data": {
 			"basename": "doup",
+			"ddrSongHash": "lldPQPDP0qq8iqQ910l8b8PoQ6O668Q0",
 			"flareCategory": "GOLD",
 			"inGameID": 38211
 		},
@@ -10096,6 +10905,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"basename": "drtb",
+			"ddrSongHash": "08PiiDq6b1oQ8OIIbDql0bDbIID0b1iP",
 			"flareCategory": "GOLD",
 			"inGameID": 38212
 		},
@@ -10108,6 +10918,7 @@
 		"artist": "ARM (IOSYS) feat. 一ノ瀬月琉 (monotone)",
 		"data": {
 			"basename": "suns2",
+			"ddrSongHash": "qi9qP1dPd6PPDlldbb8OIlD08Pbd9006",
 			"flareCategory": "WHITE",
 			"inGameID": 38213
 		},
@@ -10120,6 +10931,7 @@
 		"artist": "DDR",
 		"data": {
 			"basename": "ddrm",
+			"ddrSongHash": "8dbiodDo1i6IolDQdqdOoqDDD90q6liQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38214
 		},
@@ -10132,6 +10944,7 @@
 		"artist": "BEMANI Sound Team \"TAG\" feat. 柊木りお",
 		"data": {
 			"basename": "show",
+			"ddrSongHash": "6oolbQ0QiO90Dd0DQbb1D86d8q88id86",
 			"flareCategory": "WHITE",
 			"inGameID": 38215
 		},
@@ -10144,6 +10957,7 @@
 		"artist": "BEMANI Sound Team \"Sota Fujimori 2nd Season\"",
 		"data": {
 			"basename": "poss3",
+			"ddrSongHash": "19q96Q8l1oqbD0OQq6biDbO6O1oqqb6O",
 			"flareCategory": "WHITE",
 			"inGameID": 38216
 		},
@@ -10156,6 +10970,7 @@
 		"artist": "ARM (IOSYS)",
 		"data": {
 			"basename": "chao2",
+			"ddrSongHash": "b16OP1o9qb6bQd66qOl98iq0boiQP919",
 			"flareCategory": "WHITE",
 			"inGameID": 38217
 		},
@@ -10168,6 +10983,7 @@
 		"artist": "BEMANI Sound Team \"[Ⓧ]\"",
 		"data": {
 			"basename": "maxx2",
+			"ddrSongHash": "1Dl19idl0i0qiqidbDIIbQddiP6o11PP",
 			"flareCategory": "WHITE",
 			"inGameID": 38218
 		},
@@ -10180,6 +10996,7 @@
 		"artist": "USAO",
 		"data": {
 			"basename": "avng",
+			"ddrSongHash": "9DoD10OPQ999IlP0doo69olbOQ680q09",
 			"flareCategory": "GOLD",
 			"inGameID": 38219
 		},
@@ -10192,6 +11009,7 @@
 		"artist": "Cait Sith",
 		"data": {
 			"basename": "syur",
+			"ddrSongHash": "DIiQbd09D0PoIiPl9iP1q8qldOOqol8i",
 			"flareCategory": "WHITE",
 			"inGameID": 38220
 		},
@@ -10204,6 +11022,7 @@
 		"artist": "BEMANI Sound Team \"U1 overground\"",
 		"data": {
 			"basename": "anni",
+			"ddrSongHash": "Pq1O0qIiQII9PP1Qi6dbi9Pdo88dO8Dq",
 			"flareCategory": "WHITE",
 			"inGameID": 38221
 		},
@@ -10216,6 +11035,7 @@
 		"artist": "DDR ALL FANS",
 		"data": {
 			"basename": "ourm",
+			"ddrSongHash": "QD8D6IQ1QoOPIPIIbI10QDOdd96OPIQi",
 			"flareCategory": "WHITE",
 			"inGameID": 38222
 		},
@@ -10228,6 +11048,7 @@
 		"artist": "中島由貴",
 		"data": {
 			"basename": "caof",
+			"ddrSongHash": "P6id8qqolbP0oqO060OOqbl60DI9iQoQ",
 			"flareCategory": "WHITE",
 			"inGameID": 38223
 		},
@@ -10312,6 +11133,7 @@
 		"artist": "BEMANI Sound Team \"U1 overground\"",
 		"data": {
 			"basename": "seta",
+			"ddrSongHash": "D0Q0oIDDqoQd0IQddi1IiD16dO16O88o",
 			"flareCategory": "GOLD",
 			"inGameID": 38230
 		},
@@ -10324,6 +11146,7 @@
 		"artist": "Shoichiro Hirata",
 		"data": {
 			"basename": "thbe",
+			"ddrSongHash": "PdPdbdQ1lDI18O90Q0li8QI0bo99bidd",
 			"flareCategory": "GOLD",
 			"inGameID": 38231
 		},
@@ -10336,6 +11159,7 @@
 		"artist": "DJ Genki feat. Mayumi Morinaga",
 		"data": {
 			"basename": "stsk",
+			"ddrSongHash": "80OqPo1D6lD616lIDI1IPq0oPllld6b1",
 			"flareCategory": "GOLD",
 			"inGameID": 38232
 		},
@@ -10348,6 +11172,7 @@
 		"artist": "Maozon",
 		"data": {
 			"basename": "dehe",
+			"ddrSongHash": "6iO8d9ld00I6lDIO6qbOldP99oqloqb9",
 			"flareCategory": "GOLD",
 			"inGameID": 38233
 		},
@@ -10360,6 +11185,7 @@
 		"artist": "nc ft.NRG Factory",
 		"data": {
 			"basename": "wati",
+			"ddrSongHash": "PPQb966D6Ql6Q8iPo68810PdDiI6D0bl",
 			"flareCategory": "GOLD",
 			"inGameID": 38234
 		},
@@ -10372,6 +11198,7 @@
 		"artist": "DJ Noriken",
 		"data": {
 			"basename": "dots",
+			"ddrSongHash": "0DODq0P9Qi6i6q8QPoPPOiOi6ib0188b",
 			"flareCategory": "GOLD",
 			"inGameID": 38235
 		},
@@ -10384,6 +11211,7 @@
 		"artist": "xac",
 		"data": {
 			"basename": "heli",
+			"ddrSongHash": "OPdooDlO9iO09lI1ODP00660loDiiodi",
 			"flareCategory": "GOLD",
 			"inGameID": 38236
 		},
@@ -10396,6 +11224,7 @@
 		"artist": "矢鴇つかさ",
 		"data": {
 			"basename": "proc",
+			"ddrSongHash": "1DPD60Q8D1qD8i80P160bqDQ81DObDlP",
 			"flareCategory": "GOLD",
 			"inGameID": 38237
 		},
@@ -10408,6 +11237,7 @@
 		"artist": "Nhato",
 		"data": {
 			"basename": "skyw",
+			"ddrSongHash": "Dqb08DI0Ii8ilD0lioi9o9D1dodl6dO0",
 			"flareCategory": "GOLD",
 			"inGameID": 38238
 		},
@@ -10432,6 +11262,7 @@
 		"artist": "BEMANI Sound Team",
 		"data": {
 			"basename": "t501",
+			"ddrSongHash": "D0iDbio81PIbI8dD6QOIP9IidDOP0PDP",
 			"flareCategory": "GOLD",
 			"inGameID": 38240
 		},
@@ -10444,6 +11275,7 @@
 		"artist": "BEMANI Sound Team",
 		"data": {
 			"basename": "t502",
+			"ddrSongHash": "l1ODQ1bO9POQ6d8O0Iobbio11qb6O6bd",
 			"flareCategory": "GOLD",
 			"inGameID": 38241
 		},
@@ -10456,6 +11288,7 @@
 		"artist": "BEMANI Sound Team",
 		"data": {
 			"basename": "t503",
+			"ddrSongHash": "0IIO08bII0QQDOdobqbl8Ib8Q8O8q1li",
 			"flareCategory": "GOLD",
 			"inGameID": 38242
 		},
@@ -10468,6 +11301,7 @@
 		"artist": "BEMANI Sound Team",
 		"data": {
 			"basename": "t504",
+			"ddrSongHash": "bP10qq9dPDDqIl16lPIDDd8b00dIIP08",
 			"flareCategory": "GOLD",
 			"inGameID": 38243
 		},
@@ -10492,6 +11326,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "swet",
+			"ddrSongHash": "qoidddb08iIoDOo9DQoO0loPl8lPQ81o",
 			"flareCategory": "GOLD",
 			"inGameID": 38245
 		},
@@ -10504,6 +11339,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "hika",
+			"ddrSongHash": "1Q809666i9oblO8qO688OiD6OIbiP0Oq",
 			"flareCategory": "GOLD",
 			"inGameID": 38246
 		},
@@ -10516,6 +11352,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "bast",
+			"ddrSongHash": "ObbOibP0ll9I00di6i9oO1qlIQbdD0ql",
 			"flareCategory": "GOLD",
 			"inGameID": 38247
 		},
@@ -10528,6 +11365,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "kapa",
+			"ddrSongHash": "l1lO999PqIboPQOD86PDQo1ol1iIiiOi",
 			"flareCategory": "GOLD",
 			"inGameID": 38248
 		},
@@ -10540,6 +11378,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "neza",
+			"ddrSongHash": "P160qOD09PQoOPI6iIOO69qDoqQl1qDQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38249
 		},
@@ -10552,6 +11391,7 @@
 		"artist": "DJ Shimamura",
 		"data": {
 			"basename": "godf",
+			"ddrSongHash": "Pq0Qq0OQqlPDQOld8bddlIDPD89o8bO8",
 			"flareCategory": "GOLD",
 			"inGameID": 38250
 		},
@@ -10564,6 +11404,7 @@
 		"artist": "まろん（IOSYS）",
 		"data": {
 			"basename": "toyb",
+			"ddrSongHash": "ddIiQ90DblbOQQIQPIbQOdb9DdPoOQ9Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38251
 		},
@@ -10648,6 +11489,7 @@
 		"artist": "aran",
 		"data": {
 			"basename": "f4sh",
+			"ddrSongHash": "ObIOQ6id8DOdlQlil8819ObqoDQIIoiO",
 			"flareCategory": "GOLD",
 			"inGameID": 38258
 		},
@@ -10660,6 +11502,7 @@
 		"artist": "KO3",
 		"data": {
 			"basename": "soda",
+			"ddrSongHash": "8qd0DIiiQ6dPl1b6b0OqDob6i0d1dQP1",
 			"flareCategory": "GOLD",
 			"inGameID": 38259
 		},
@@ -10672,6 +11515,7 @@
 		"artist": "Relect",
 		"data": {
 			"basename": "givm",
+			"ddrSongHash": "d9llb88lDI1q0QI10P01lqIqlI6QO0Dl",
 			"flareCategory": "GOLD",
 			"inGameID": 38260
 		},
@@ -10684,6 +11528,7 @@
 		"artist": "DJ Shimamura",
 		"data": {
 			"basename": "ramp",
+			"ddrSongHash": "Ol8PPooqO8iOqQ6900o0q0QI9dPo0O0b",
 			"flareCategory": "GOLD",
 			"inGameID": 38261
 		},
@@ -10708,6 +11553,7 @@
 		"artist": "KAN TAKAHIKO",
 		"data": {
 			"basename": "rtrw",
+			"ddrSongHash": "1qPOO8o9089lI1qQIDIDi0lidob9i6lq",
 			"flareCategory": "GOLD",
 			"inGameID": 38263
 		},
@@ -10720,6 +11566,7 @@
 		"artist": "DJ TECHNORCH",
 		"data": {
 			"basename": "sais",
+			"ddrSongHash": "O9qDQOQO8dDDIiO9dPP0Pb8qQo9l89D9",
 			"flareCategory": "GOLD",
 			"inGameID": 38264
 		},
@@ -10732,6 +11579,7 @@
 		"artist": "CaZ",
 		"data": {
 			"basename": "ouso",
+			"ddrSongHash": "QI06q9lPIoo80DlI18Ooi6dbPl89bqi0",
 			"flareCategory": "GOLD",
 			"inGameID": 38265
 		},
@@ -10744,6 +11592,7 @@
 		"artist": "TORIENA",
 		"data": {
 			"basename": "levu",
+			"ddrSongHash": "D9ooldO1009Pq1dP6P88lD80P0Oi060P",
 			"flareCategory": "GOLD",
 			"inGameID": 38266
 		},
@@ -10756,6 +11605,7 @@
 		"artist": "Akira Complex",
 		"data": {
 			"basename": "woen",
+			"ddrSongHash": "b80qOO6l8060990qQPod1bOd8Q9d69qo",
 			"flareCategory": "GOLD",
 			"inGameID": 38267
 		},
@@ -10768,6 +11618,7 @@
 		"artist": "TeddyLoid",
 		"data": {
 			"basename": "cros",
+			"ddrSongHash": "Q0o8olIPb1iOo0loPPQI0PddI0qlb1Db",
 			"flareCategory": "GOLD",
 			"inGameID": 38268
 		},
@@ -10780,6 +11631,7 @@
 		"artist": "Ariana Grande",
 		"data": {
 			"basename": "ntlc",
+			"ddrSongHash": "Db6odqIqQ90PIDIlD1DIb8l09ol6qIDl",
 			"flareCategory": "GOLD",
 			"inGameID": 38269
 		},
@@ -10792,6 +11644,7 @@
 		"artist": "Dua Lipa",
 		"data": {
 			"basename": "newr",
+			"ddrSongHash": "Pqb60bq60o9QO0obI1Od9liQo9iIiOD0",
 			"flareCategory": "GOLD",
 			"inGameID": 38270
 		},
@@ -10804,6 +11657,7 @@
 		"artist": "The Chainsmokers & Coldplay",
 		"data": {
 			"basename": "sjlt",
+			"ddrSongHash": "6ObP9i0qi1ibbi9DOd6bOOOd6Q9dlPi6",
 			"flareCategory": "GOLD",
 			"inGameID": 38271
 		},
@@ -10816,6 +11670,7 @@
 		"artist": "Zedd feat. Foxes",
 		"data": {
 			"basename": "clar",
+			"ddrSongHash": "IO0IbQPOP6q8OddoiO99qq9I81l90D1i",
 			"flareCategory": "GOLD",
 			"inGameID": 38272
 		},
@@ -10840,6 +11695,7 @@
 		"artist": "AronChupa",
 		"data": {
 			"basename": "alba",
+			"ddrSongHash": "69b01qbo8Qdi6liOPq091bqo01i16oQ9",
 			"flareCategory": "GOLD",
 			"inGameID": 38274
 		},
@@ -10852,6 +11708,7 @@
 		"artist": "Marshmello",
 		"data": {
 			"basename": "alon",
+			"ddrSongHash": "bdbQoi98Dlb18DiPDPdD801DoOD8619O",
 			"flareCategory": "GOLD",
 			"inGameID": 38275
 		},
@@ -10864,6 +11721,7 @@
 		"artist": "LMFAO",
 		"data": {
 			"basename": "part",
+			"ddrSongHash": "09oIbO1bi8O8Q1o01q610ID0qPOqoQQP",
 			"flareCategory": "GOLD",
 			"inGameID": 38276
 		},
@@ -10876,6 +11734,7 @@
 		"artist": "Ujico*",
 		"data": {
 			"basename": "blst",
+			"ddrSongHash": "I9Ob6PlIiOQl6iQ6qO6QO0iQ1ld9DDO0",
 			"flareCategory": "GOLD",
 			"inGameID": 38277
 		},
@@ -10888,6 +11747,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "newe",
+			"ddrSongHash": "DdIo9DQ0ddDld99DQdiiqbPP06OI91I0",
 			"flareCategory": "GOLD",
 			"inGameID": 38278
 		},
@@ -10900,6 +11760,7 @@
 		"artist": "Akira Complex",
 		"data": {
 			"basename": "blja",
+			"ddrSongHash": "OO1oqdIPP80QdoP11QP61OdDb0lI1qIq",
 			"flareCategory": "GOLD",
 			"inGameID": 38279
 		},
@@ -10936,6 +11797,7 @@
 		"artist": "Cranky",
 		"data": {
 			"basename": "alpa",
+			"ddrSongHash": "6d8DiDl0i1oldbbo0o60PQ0q96d608Dq",
 			"flareCategory": "GOLD",
 			"inGameID": 38282
 		},
@@ -10948,6 +11810,7 @@
 		"artist": "seiya-murai",
 		"data": {
 			"basename": "mmdf",
+			"ddrSongHash": "D686d06lO9IID8D0boPq0Pd8P89idO99",
 			"flareCategory": "GOLD",
 			"inGameID": 38283
 		},
@@ -10960,6 +11823,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "aceo",
+			"ddrSongHash": "l61ldlPo1DQ081860O86D0Qo0qdOd0qP",
 			"flareCategory": "GOLD",
 			"inGameID": 38284
 		},
@@ -10984,6 +11848,7 @@
 		"artist": "Yooh",
 		"data": {
 			"basename": "crsh",
+			"ddrSongHash": "OdQqDiIDbD6ioi60ob6lDOlD8oio9l0b",
 			"flareCategory": "GOLD",
 			"inGameID": 38286
 		},
@@ -10996,6 +11861,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "smst",
+			"ddrSongHash": "OdldObODIdilOP0QqI0b1oO1diqdq61b",
 			"flareCategory": "GOLD",
 			"inGameID": 38287
 		},
@@ -11008,6 +11874,7 @@
 		"artist": "BEMANI Sound Team \"TAG underground\"",
 		"data": {
 			"basename": "spgo",
+			"ddrSongHash": "b1do8OI6qDDlQO0PI16868ql6bdbI886",
 			"flareCategory": "GOLD",
 			"inGameID": 38288
 		},
@@ -11020,6 +11887,7 @@
 		"artist": "BEMANI Sound Team \"猫叉劇団\"",
 		"data": {
 			"basename": "afda",
+			"ddrSongHash": "blld8o09oQo80PIIoIdbP9688DIqlbdb",
 			"flareCategory": "GOLD",
 			"inGameID": 38289
 		},
@@ -11032,6 +11900,7 @@
 		"artist": "BEMANI Sound Team \"PHQUASE\"",
 		"data": {
 			"basename": "vsss",
+			"ddrSongHash": "6DQ9D9oi66I8ODi8o0dPdOD1ibbIqIdI",
 			"flareCategory": "GOLD",
 			"inGameID": 38290
 		},
@@ -11044,6 +11913,7 @@
 		"artist": "BEMANI Sound Team \"Yvya × Mutsuhiko Izumi\"",
 		"data": {
 			"basename": "sspr",
+			"ddrSongHash": "D6o8lIiDQ80oi6iIbiP9DlOPIl0Q8d69",
 			"flareCategory": "GOLD",
 			"inGameID": 38291
 		},
@@ -11056,6 +11926,7 @@
 		"artist": "BEMANI Sound Team \"S-C-U & SYUNN\"",
 		"data": {
 			"basename": "tobo",
+			"ddrSongHash": "d9QO9odlI18i96I6DQPld1iiol8ODl0o",
 			"flareCategory": "GOLD",
 			"inGameID": 38292
 		},
@@ -11068,6 +11939,7 @@
 		"artist": "BEMANI Sound Team \"PON\" feat.NU-KO",
 		"data": {
 			"basename": "ohmy",
+			"ddrSongHash": "lqI8DD9Plq6IO8P8P6Pl8Di98DlI9oP8",
 			"flareCategory": "GOLD",
 			"inGameID": 38293
 		},
@@ -11080,6 +11952,7 @@
 		"artist": "BEMANI Sound Team \"dj TAKA\"",
 		"data": {
 			"basename": "tril",
+			"ddrSongHash": "0lIIil06b8q819P9lDil09o6qlqo9I1i",
 			"flareCategory": "GOLD",
 			"inGameID": 38294
 		},
@@ -11092,6 +11965,7 @@
 		"artist": "いちか",
 		"data": {
 			"basename": "midw",
+			"ddrSongHash": "06DO8bb0O891IQ9QP01diqOOl0D80QbO",
 			"flareCategory": "GOLD",
 			"inGameID": 38295
 		},
@@ -11104,6 +11978,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "mika",
+			"ddrSongHash": "96d9qiDD8l09DQq6O1DO6O6I1IdP8q0D",
 			"flareCategory": "GOLD",
 			"inGameID": 38296
 		},
@@ -11116,6 +11991,7 @@
 		"artist": "劇団レコード",
 		"data": {
 			"basename": "swho",
+			"ddrSongHash": "obd0PDIDq8qqd9q9qdbDdqD98bd61I8D",
 			"flareCategory": "GOLD",
 			"inGameID": 38297
 		},
@@ -11128,6 +12004,7 @@
 		"artist": "Dormir",
 		"data": {
 			"basename": "unem",
+			"ddrSongHash": "8q68D8iP6lIdiP8bo9PoOib8lb9loIob",
 			"flareCategory": "GOLD",
 			"inGameID": 38298
 		},
@@ -11140,6 +12017,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "haum",
+			"ddrSongHash": "I0qiD6Ob86D1oQOib81lID6Dll8iOOOP",
 			"flareCategory": "GOLD",
 			"inGameID": 38299
 		},
@@ -11152,6 +12030,7 @@
 		"artist": "lapix",
 		"data": {
 			"basename": "glit",
+			"ddrSongHash": "9IdoP1ld9098PI90QQ6bP0Idl1ibo80D",
 			"flareCategory": "GOLD",
 			"inGameID": 38300
 		},
@@ -11164,6 +12043,7 @@
 		"artist": "CHEAP CREAM",
 		"data": {
 			"basename": "stev",
+			"ddrSongHash": "olDoq69qD008Q9bb8d9OOlPO160Qd0dq",
 			"flareCategory": "GOLD",
 			"inGameID": 38301
 		},
@@ -11176,6 +12056,7 @@
 		"artist": "Dustvoxx",
 		"data": {
 			"basename": "botr",
+			"ddrSongHash": "l81l981iPod0PDIIObIldoQb6Ol9o1Iq",
 			"flareCategory": "GOLD",
 			"inGameID": 38302
 		},
@@ -11188,6 +12069,7 @@
 		"artist": "BUNNY",
 		"data": {
 			"basename": "iron",
+			"ddrSongHash": "lq9iPP06O8qiP1iooiboPO910b86di19",
 			"flareCategory": "GOLD",
 			"inGameID": 38303
 		},
@@ -11200,6 +12082,7 @@
 		"artist": "FN2(Eurobeat Union)",
 		"data": {
 			"basename": "endl",
+			"ddrSongHash": "d8oDqIQOoD6DQoQbOIP9I6DPPOl89lo6",
 			"flareCategory": "GOLD",
 			"inGameID": 38304
 		},
@@ -11212,6 +12095,7 @@
 		"artist": "BEMANI Sound Team \"U1×TAG\"",
 		"data": {
 			"basename": "hist",
+			"ddrSongHash": "Q8bIDb60oPo890oi0l0O9PQd9lOb8o1Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38305
 		},
@@ -11224,6 +12108,7 @@
 		"artist": "Blacklolita",
 		"data": {
 			"basename": "cyco",
+			"ddrSongHash": "1qPIiqqQo0P9dD90I11q90b0ooIidbPO",
 			"flareCategory": "GOLD",
 			"inGameID": 38306
 		},
@@ -11236,6 +12121,7 @@
 		"artist": "BADMYTH",
 		"data": {
 			"basename": "dest",
+			"ddrSongHash": "Pi81dQi00lo9i1Pib91lQ01i0biIbPIP",
 			"flareCategory": "GOLD",
 			"inGameID": 38307
 		},
@@ -11248,6 +12134,7 @@
 		"artist": "BEMANI Sound Team \"劇団レコード\" ft.Lisa - paint with stars",
 		"data": {
 			"basename": "stis",
+			"ddrSongHash": "bbiPqbo0lQq9P19i06q690blI91dbbq6",
 			"flareCategory": "GOLD",
 			"inGameID": 38308
 		},
@@ -11260,6 +12147,7 @@
 		"artist": "ハレトキドキ",
 		"data": {
 			"basename": "dilu",
+			"ddrSongHash": "0dOOOolo0P6180OQDo16DdO6o6D8O8lQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38309
 		},
@@ -11272,6 +12160,7 @@
 		"artist": "Zekk",
 		"data": {
 			"basename": "gola",
+			"ddrSongHash": "dIdDQD1Q8oPQ90Q1DPbiQI661qD9oi6I",
 			"flareCategory": "GOLD",
 			"inGameID": 38310
 		},
@@ -11284,6 +12173,7 @@
 		"artist": "TANUKI",
 		"data": {
 			"basename": "hytw",
+			"ddrSongHash": "0bq9qI9PoPIlQl89bDO60o9q8I1iIP66",
 			"flareCategory": "GOLD",
 			"inGameID": 38311
 		},
@@ -11296,6 +12186,7 @@
 		"artist": "かねこちはる",
 		"data": {
 			"basename": "lach",
+			"ddrSongHash": "bIlqP91O9ld1lqlq6qoq9OiPdqIDPP0l",
 			"flareCategory": "GOLD",
 			"inGameID": 38312
 		},
@@ -11308,6 +12199,7 @@
 		"artist": "ETIA.",
 		"data": {
 			"basename": "fist",
+			"ddrSongHash": "qqDOddP66Ol1q1IIOb1OPO68DP1ood1i",
 			"flareCategory": "GOLD",
 			"inGameID": 38313
 		},
@@ -11320,6 +12212,7 @@
 		"artist": "BlackY",
 		"data": {
 			"basename": "ovso",
+			"ddrSongHash": "P1boP1O60bdI16i6lqqd1Q8ioiPbolqd",
 			"flareCategory": "GOLD",
 			"inGameID": 38314
 		},
@@ -11332,6 +12225,7 @@
 		"artist": "中島由貴 × いちか",
 		"data": {
 			"basename": "rank",
+			"ddrSongHash": "D08lqQOPdOO6D6ll690Qd6PdbO111011",
 			"flareCategory": "GOLD",
 			"inGameID": 38315
 		},
@@ -11344,6 +12238,7 @@
 		"artist": "Ryunosuke Kudo",
 		"data": {
 			"basename": "drsa",
+			"ddrSongHash": "D6ll81qoDDPIq0d89O69dIQIldQdQoId",
 			"flareCategory": "GOLD",
 			"inGameID": 38316
 		},
@@ -11356,6 +12251,7 @@
 		"artist": "Hylen",
 		"data": {
 			"basename": "myth",
+			"ddrSongHash": "lbD8DodiOiP8D61lidIi88DIiPqi8o6P",
 			"flareCategory": "GOLD",
 			"inGameID": 38317
 		},
@@ -11368,6 +12264,7 @@
 		"artist": "Yunosuke",
 		"data": {
 			"basename": "hybo",
+			"ddrSongHash": "Di8lP6PobQ6l8do0llO9IIqQ6iqqiqDo",
 			"flareCategory": "GOLD",
 			"inGameID": 38318
 		},
@@ -11380,6 +12277,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "hnbn",
+			"ddrSongHash": "q8i11qPbo9iq8lQb9d08di81Q88q8P9o",
 			"flareCategory": "GOLD",
 			"inGameID": 38319
 		},
@@ -11392,6 +12290,7 @@
 		"artist": "O/iviA",
 		"data": {
 			"basename": "ilov",
+			"ddrSongHash": "1900DdoIl00b88q6Qq9ob9D6lQ8IQiPb",
 			"flareCategory": "GOLD",
 			"inGameID": 38320
 		},
@@ -11404,6 +12303,7 @@
 		"artist": "TAG feat. ERi",
 		"data": {
 			"basename": "rege",
+			"ddrSongHash": "ODdoiODodb0ddIP06IqDQdl100q0dIP6",
 			"flareCategory": "GOLD",
 			"inGameID": 38321
 		},
@@ -11416,6 +12316,7 @@
 		"artist": "ひまわり＊パンチ",
 		"data": {
 			"basename": "dokv",
+			"ddrSongHash": "Dlq6qdP1bOPDObbbQQ6b8iPbd1ODq69P",
 			"flareCategory": "GOLD",
 			"inGameID": 38322
 		},
@@ -11440,6 +12341,7 @@
 		"artist": "Paisley Parks",
 		"data": {
 			"basename": "stma",
+			"ddrSongHash": "d6OoI6oOd1l99DIoodI9lIDI0bidDP00",
 			"flareCategory": "GOLD",
 			"inGameID": 38324
 		},
@@ -11452,6 +12354,7 @@
 		"artist": "PSYQUI",
 		"data": {
 			"basename": "inpa",
+			"ddrSongHash": "8oP1ibbO9qdP19d9lQoi1q16P69b1II9",
 			"flareCategory": "GOLD",
 			"inGameID": 38325
 		},
@@ -11464,6 +12367,7 @@
 		"artist": "Moe Shop",
 		"data": {
 			"basename": "hypd",
+			"ddrSongHash": "ID00liOPPd6PiDb09608dQbOIDlQ68qo",
 			"flareCategory": "GOLD",
 			"inGameID": 38326
 		},
@@ -11476,6 +12380,7 @@
 		"artist": "ビートまりお(COOL&CREATE)",
 		"data": {
 			"basename": "flan",
+			"ddrSongHash": "i0P1O6lbP1oDd6q6b08iPPoq6iPdI818",
 			"flareCategory": "GOLD",
 			"inGameID": 38331
 		},
@@ -11488,6 +12393,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "nofn2",
+			"ddrSongHash": "IlbI1QQOPI0o0IdoPI6QPldqQob16DOq",
 			"flareCategory": "GOLD",
 			"inGameID": 38332
 		},
@@ -11500,6 +12406,7 @@
 		"artist": "HiBiKi",
 		"data": {
 			"basename": "pani",
+			"ddrSongHash": "bIio1d6QOPlqlDOqoIQoPIbIbb0iQIil",
 			"flareCategory": "GOLD",
 			"inGameID": 38333
 		},
@@ -11512,6 +12419,7 @@
 		"artist": "M-Project",
 		"data": {
 			"basename": "raac",
+			"ddrSongHash": "DodQ1I1DiPIqDQP0PqO6PIQ1iPQd6O8d",
 			"flareCategory": "GOLD",
 			"inGameID": 38334
 		},
@@ -11524,6 +12432,7 @@
 		"artist": "Tanukichi",
 		"data": {
 			"basename": "lisp",
+			"ddrSongHash": "bqi9QiQ0lbi8id6lOi88iIi9lo6Pdd90",
 			"flareCategory": "GOLD",
 			"inGameID": 38335
 		},
@@ -11536,6 +12445,7 @@
 		"artist": "KOTONOHOUSE",
 		"data": {
 			"basename": "tahi",
+			"ddrSongHash": "0088dOQPiD0Qb0Dl8ol09D98IOllI1id",
 			"flareCategory": "GOLD",
 			"inGameID": 38336
 		},
@@ -11548,6 +12458,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "mida",
+			"ddrSongHash": "ll0O8PlqQd0iOO8ib61lO6iDiliQdiPP",
 			"flareCategory": "GOLD",
 			"inGameID": 38337
 		},
@@ -11560,6 +12471,7 @@
 		"artist": "kors k feat.福島蘭世",
 		"data": {
 			"basename": "dran",
+			"ddrSongHash": "9PoQqIP0D6lPIq9obl1db9IqD0D09i80",
 			"flareCategory": "GOLD",
 			"inGameID": 38338
 		},
@@ -11572,6 +12484,7 @@
 		"artist": "MK&Kanae Asaba",
 		"data": {
 			"basename": "cbme",
+			"ddrSongHash": "O8oPP6D8OQq1Q6Q860dqlOi6609bO1lD",
 			"flareCategory": "GOLD",
 			"inGameID": 38339
 		},
@@ -11584,6 +12497,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "lasc",
+			"ddrSongHash": "891iilD9Pq1lPQd6diqiP0dd611dOPPl",
 			"flareCategory": "GOLD",
 			"inGameID": 38340
 		},
@@ -11596,6 +12510,7 @@
 		"artist": "Mameyudoufu",
 		"data": {
 			"basename": "gohy",
+			"ddrSongHash": "6Obi001oi9Qd1966dOd6d6Qo66dbbill",
 			"flareCategory": "GOLD",
 			"inGameID": 38341
 		},
@@ -11608,6 +12523,7 @@
 		"artist": "KOTONOHOUSE",
 		"data": {
 			"basename": "iwtd",
+			"ddrSongHash": "dIbPlPdo09i8oOlOQ1OOq166Q8iP8Oqi",
 			"flareCategory": "GOLD",
 			"inGameID": 38342
 		},
@@ -11620,6 +12536,7 @@
 		"artist": "SOUND HOLIC Vs. Eurobeat Union feat. Nana Takahashi",
 		"data": {
 			"basename": "guil",
+			"ddrSongHash": "QbdQold98oq9lODoIloIbPiIqld6i0Qb",
 			"flareCategory": "GOLD",
 			"inGameID": 38343
 		},
@@ -11632,6 +12549,7 @@
 		"artist": "SOUND HOLIC Vs. Eurobeat Union feat. Nana Takahashi",
 		"data": {
 			"basename": "nolq",
+			"ddrSongHash": "I9P1dbOqD1qIP8bd9O80Ooo869bldobD",
 			"flareCategory": "GOLD",
 			"inGameID": 38344
 		},
@@ -11644,6 +12562,7 @@
 		"artist": "A-One  feat.Napoleon",
 		"data": {
 			"basename": "feid",
+			"ddrSongHash": "DDPPI6IIi0i9looibDbiODoOPOl6ID8i",
 			"flareCategory": "GOLD",
 			"inGameID": 38345
 		},
@@ -11656,6 +12575,7 @@
 		"artist": "DiGiTAL WiNG with 空音",
 		"data": {
 			"basename": "tgmw",
+			"ddrSongHash": "POdll6oPi1dd68q19q8ID6iQ6d08bl99",
 			"flareCategory": "GOLD",
 			"inGameID": 38346
 		},
@@ -11668,6 +12588,7 @@
 		"artist": "NJK Record feat.nachi",
 		"data": {
 			"basename": "crho",
+			"ddrSongHash": "dq6b0b6OD9DbDPQOO608oDo8Q80ODIqO",
 			"flareCategory": "GOLD",
 			"inGameID": 38347
 		},
@@ -11680,6 +12601,7 @@
 		"artist": "Vanitas Lacrimosa",
 		"data": {
 			"basename": "shij",
+			"ddrSongHash": "qlPqO10q6PliDQDbd01IP0b6iqO0bDb6",
 			"flareCategory": "GOLD",
 			"inGameID": 38348
 		},
@@ -11692,6 +12614,7 @@
 		"artist": "夜叉姫神楽",
 		"data": {
 			"basename": "otog",
+			"ddrSongHash": "I606oqOODOdQoP0IQOdP6b0DPdb86ddO",
 			"flareCategory": "GOLD",
 			"inGameID": 38349
 		},
@@ -11704,6 +12627,7 @@
 		"artist": "Blanc Bunny Bandit",
 		"data": {
 			"basename": "room",
+			"ddrSongHash": "ODd6QDIIdi6ild0O8lqIdl0oiQ98669l",
 			"flareCategory": "GOLD",
 			"inGameID": 38350
 		},
@@ -11716,6 +12640,7 @@
 		"artist": "メリー・バッド・メルヘン",
 		"data": {
 			"basename": "saka",
+			"ddrSongHash": "llo89P08I1PlID9DO8lqdbbq69O8Qiib",
 			"flareCategory": "GOLD",
 			"inGameID": 38351
 		},
@@ -11728,6 +12653,7 @@
 		"artist": "立秋 feat.ちょこ",
 		"data": {
 			"basename": "biii",
+			"ddrSongHash": "QD9Ib18D9lIO10O19d16PbPb68q1190d",
 			"flareCategory": "GOLD",
 			"inGameID": 38352
 		},
@@ -11740,6 +12666,7 @@
 		"artist": "DÉ DÉ MOUSE",
 		"data": {
 			"basename": "sill",
+			"ddrSongHash": "Q8bIddo10ilqbd6I8QOq1bod1OO8dqlO",
 			"flareCategory": "GOLD",
 			"inGameID": 38353
 		},
@@ -11752,6 +12679,7 @@
 		"artist": "BEMANI Sound Team \"HuΣeR × MarL × SYUNN\"",
 		"data": {
 			"basename": "hosi",
+			"ddrSongHash": "IDP9ldQoD8bdQ6d9Q0oI6QlI9b6Db9Oo",
 			"flareCategory": "GOLD",
 			"inGameID": 38354
 		},
@@ -11764,6 +12692,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\" feat.いちか",
 		"data": {
 			"basename": "losp",
+			"ddrSongHash": "loii6b8OODDOl9q0OD88Ibb9I0qO0PPo",
 			"flareCategory": "GOLD",
 			"inGameID": 38355
 		},
@@ -11776,6 +12705,7 @@
 		"artist": "BEMANI Sound Team \"Qrispy Joybox\" feat.いちか",
 		"data": {
 			"basename": "spsm",
+			"ddrSongHash": "8i61Oi09bOIP0lOldI668b8IPbIq8l0Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38356
 		},
@@ -11788,6 +12718,7 @@
 		"artist": "DJ TECHNORCH feat.宇宙★海月 vs BEMANI Sound Team \"U1-ASAMi\"",
 		"data": {
 			"basename": "tosh",
+			"ddrSongHash": "oQ868oOio6O90i9qO1o8I96P1do11ID0",
 			"flareCategory": "GOLD",
 			"inGameID": 38357
 		},
@@ -11800,6 +12731,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "digr",
+			"ddrSongHash": "dqQbQ9oPlIi6bDdi18d9qPlDb0PiDddi",
 			"flareCategory": "GOLD",
 			"inGameID": 38358
 		},
@@ -11812,6 +12744,7 @@
 		"artist": "Dirty Androids",
 		"data": {
 			"basename": "cnsl",
+			"ddrSongHash": "6OiD0q6O8qi6oDbQ18Ilo8do8biDD1ll",
 			"flareCategory": "GOLD",
 			"inGameID": 38359
 		},
@@ -11824,6 +12757,7 @@
 		"artist": "TAG",
 		"data": {
 			"basename": "riot",
+			"ddrSongHash": "I9Oood9l9li0D08Q6d6DQPiIQiloidO6",
 			"flareCategory": "GOLD",
 			"inGameID": 38360
 		},
@@ -11836,6 +12770,7 @@
 		"artist": "BEMANI Sound Team \"劇団レコード\"",
 		"data": {
 			"basename": "ghok",
+			"ddrSongHash": "dQbolPiDiiObioli96DlOo9OlP9DoDIi",
 			"flareCategory": "GOLD",
 			"inGameID": 38361
 		},
@@ -11848,6 +12783,7 @@
 		"artist": "Oyubi",
 		"data": {
 			"basename": "bang",
+			"ddrSongHash": "oloPOQPQ8Q8IQQoiO9bqdDOo8o6OQ6qI",
 			"flareCategory": "GOLD",
 			"inGameID": 38362
 		},
@@ -11860,6 +12796,7 @@
 		"artist": "C-Show",
 		"data": {
 			"basename": "mutk",
+			"ddrSongHash": "d10d86DQqqd6QDlQlOI1bQi9do66l8Od",
 			"flareCategory": "GOLD",
 			"inGameID": 38363
 		},
@@ -11872,6 +12809,7 @@
 		"artist": "fu_mou",
 		"data": {
 			"basename": "wolf",
+			"ddrSongHash": "qPDO188oQ0i1b8b1b9OPoO0I10lPbQbi",
 			"flareCategory": "GOLD",
 			"inGameID": 38364
 		},
@@ -11884,6 +12822,7 @@
 		"artist": "Hylen feat. VGYO",
 		"data": {
 			"basename": "vert",
+			"ddrSongHash": "PibQ18qDb06Doq99boODIDQODqiDQIbP",
 			"flareCategory": "GOLD",
 			"inGameID": 38365
 		},
@@ -11896,6 +12835,7 @@
 		"artist": "Vanitas Lacrimosa",
 		"data": {
 			"basename": "hang",
+			"ddrSongHash": "QiboqIool99ol9Q0d08b68OIIiD89qqO",
 			"flareCategory": "GOLD",
 			"inGameID": 38366
 		},
@@ -11908,6 +12848,7 @@
 		"artist": "メリー・バッド・メルヘン",
 		"data": {
 			"basename": "alsi",
+			"ddrSongHash": "D6IIDqlO8idioiPo8l61Ob11D6Di0DiQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38367
 		},
@@ -11920,6 +12861,7 @@
 		"artist": "夜叉姫神楽",
 		"data": {
 			"basename": "haor",
+			"ddrSongHash": "8DO0DbDioIid8qDQiQdOdOPOo0PO0906",
 			"flareCategory": "GOLD",
 			"inGameID": 38368
 		},
@@ -11932,6 +12874,7 @@
 		"artist": "Blanc Bunny Bandit",
 		"data": {
 			"basename": "tuio",
+			"ddrSongHash": "Od08diDbdbl1Pi90QdO0ibqq8D111q9b",
 			"flareCategory": "GOLD",
 			"inGameID": 38369
 		},
@@ -11944,6 +12887,7 @@
 		"artist": "movies (moimoi×Xceon×Dai.)",
 		"data": {
 			"basename": "aoga",
+			"ddrSongHash": "6d10P0Pd1PiD1l6DPQdoPD1Q8DP0QlqQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38370
 		},
@@ -11956,6 +12900,7 @@
 		"artist": "lapix",
 		"data": {
 			"basename": "ourl",
+			"ddrSongHash": "PoP6o0Db8odIO9oOqddodd8IlPl1iDli",
 			"flareCategory": "GOLD",
 			"inGameID": 38371
 		},
@@ -11968,6 +12913,7 @@
 		"artist": "cosMo@暴走P",
 		"data": {
 			"basename": "latw",
+			"ddrSongHash": "PllDll9di16l8ild6b688l6OP6olQid8",
 			"flareCategory": "GOLD",
 			"inGameID": 38372
 		},
@@ -11980,6 +12926,7 @@
 		"artist": "BEMANI Sound Team \"HuΣeR Vs. SYUNN\" feat.いちか",
 		"data": {
 			"basename": "kyos",
+			"ddrSongHash": "Dooii0960OioP6Q1l0qi68Q8Dbd9OO91",
 			"flareCategory": "GOLD",
 			"inGameID": 38373
 		},
@@ -11992,6 +12939,7 @@
 		"artist": "BEMANI Sound Team \"U1 overground\"",
 		"data": {
 			"basename": "nole",
+			"ddrSongHash": "8Qd118IPdqld06Qd1q10iQd06bDdbdQI",
 			"flareCategory": "GOLD",
 			"inGameID": 38374
 		},
@@ -12004,6 +12952,7 @@
 		"artist": "C-Show",
 		"data": {
 			"basename": "panh",
+			"ddrSongHash": "9IlP00lPi6oOQQqOl1DoI0o10bi1iid1",
 			"flareCategory": "GOLD",
 			"inGameID": 38375
 		},
@@ -12016,6 +12965,7 @@
 		"artist": "BEMANI Sound Team \"U1\" feat. Tammy S. Hansen",
 		"data": {
 			"basename": "taki2",
+			"ddrSongHash": "8IODdDQI6P8o0QobDPOldbQ06169b01o",
 			"flareCategory": "GOLD",
 			"inGameID": 38376
 		},
@@ -12028,6 +12978,7 @@
 		"artist": "AJURIKA",
 		"data": {
 			"basename": "habr",
+			"ddrSongHash": "Qb8P9PODDo68lPqQ0o6d80bIqDOiPD9Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38377
 		},
@@ -12040,6 +12991,7 @@
 		"artist": "U1 undefined behavior",
 		"data": {
 			"basename": "delo2",
+			"ddrSongHash": "i6bl89d6OOi1O00qlQOIl8b8Qld6IiQP",
 			"flareCategory": "GOLD",
 			"inGameID": 38378
 		},
@@ -12052,6 +13004,7 @@
 		"artist": "BEMANI Sound Team \"dj TAKA\" feat.のの",
 		"data": {
 			"basename": "jetc",
+			"ddrSongHash": "qD1I6qqll88q9dq9PoloD68lqddIDo6O",
 			"flareCategory": "GOLD",
 			"inGameID": 38379
 		},
@@ -12064,6 +13017,7 @@
 		"artist": "yama",
 		"data": {
 			"basename": "hart",
+			"ddrSongHash": "IObPQb9QlP0iIiboObPoPqIqDo0O11Qi",
 			"flareCategory": "GOLD",
 			"inGameID": 38380
 		},
@@ -12076,6 +13030,7 @@
 		"artist": "lapix (Remixed by Blacklolita)",
 		"data": {
 			"basename": "inne2",
+			"ddrSongHash": "9o6bIq98Qo8dOd11DI0d8boblOqO0I1i",
 			"flareCategory": "GOLD",
 			"inGameID": 38381
 		},
@@ -12088,6 +13043,7 @@
 		"artist": "Qrispy Joybox feat. mao",
 		"data": {
 			"basename": "umey",
+			"ddrSongHash": "bi9OolI1P9oI8dDPlbQiq01Dl080PQ61",
 			"flareCategory": "GOLD",
 			"inGameID": 38382
 		},
@@ -12100,6 +13056,7 @@
 		"artist": "Blanc Bunny Bandit",
 		"data": {
 			"basename": "hara",
+			"ddrSongHash": "16b91IPI881lPIo8Qq9Pl1IPiD8Ddodl",
 			"flareCategory": "GOLD",
 			"inGameID": 38383
 		},
@@ -12112,6 +13069,7 @@
 		"artist": "Vanitas Lacrimosa",
 		"data": {
 			"basename": "inos",
+			"ddrSongHash": "DQ1dqP1IoiD11QOPiI0Q8PqO0Qddo6q6",
 			"flareCategory": "GOLD",
 			"inGameID": 38384
 		},
@@ -12124,6 +13082,7 @@
 		"artist": "夜叉姫神楽",
 		"data": {
 			"basename": "usot",
+			"ddrSongHash": "q8iPi1DP6Do6D110OQiQDdPq06q80Qb0",
 			"flareCategory": "GOLD",
 			"inGameID": 38385
 		},
@@ -12136,6 +13095,7 @@
 		"artist": "メリー・バッド・メルヘン",
 		"data": {
 			"basename": "redc",
+			"ddrSongHash": "Qi1Q6I80b09Oq91OPldbO19080q0dd0b",
 			"flareCategory": "GOLD",
 			"inGameID": 38386
 		},
@@ -12148,6 +13108,7 @@
 		"artist": "BEMANI Sound Team \"Trance Liquid\"",
 		"data": {
 			"basename": "xray",
+			"ddrSongHash": "iIIDo60oO0lOdiQ9ibIPD0106I69098b",
 			"flareCategory": "GOLD",
 			"inGameID": 38388
 		},
@@ -12160,6 +13121,7 @@
 		"artist": "BEMANI Sound Team \"U1 overground\"",
 		"data": {
 			"basename": "nsya",
+			"ddrSongHash": "Q9QlQI6Dd09P6i1bP9d8q0IQlPoqiQ81",
 			"flareCategory": "GOLD",
 			"inGameID": 38389
 		},
@@ -12172,6 +13134,7 @@
 		"artist": "S.S.D. with ななっち",
 		"data": {
 			"basename": "brid",
+			"ddrSongHash": "91ioD99OdDD9db8qilod818OPqb88idQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38390
 		},
@@ -12184,6 +13147,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "yuni",
+			"ddrSongHash": "OIOdod8llPlO0lOlb6P8iIQ90qQqoDiP",
 			"flareCategory": "GOLD",
 			"inGameID": 38391
 		},
@@ -12196,6 +13160,7 @@
 		"artist": "栄免建設",
 		"data": {
 			"basename": "esco",
+			"ddrSongHash": "Q99q619i0lDqll6Q0lq8l1oQ0qPO8o6I",
 			"flareCategory": "GOLD",
 			"inGameID": 38392
 		},
@@ -12208,6 +13173,7 @@
 		"artist": "fazerock",
 		"data": {
 			"basename": "runs",
+			"ddrSongHash": "I189iqQI6iPDdIDbo81b1iD6lIQiI0Po",
 			"flareCategory": "GOLD",
 			"inGameID": 38393
 		},
@@ -12220,6 +13186,7 @@
 		"artist": "BEMANI Sound Team \"Sota Fujimori\"",
 		"data": {
 			"basename": "conn",
+			"ddrSongHash": "O11olQOQIOOqdo1IbPP8iDDqIP0b1Dl6",
 			"flareCategory": "GOLD",
 			"inGameID": 38394
 		},
@@ -12232,6 +13199,7 @@
 		"artist": "L.E.D.-G",
 		"data": {
 			"basename": "bich",
+			"ddrSongHash": "o9P816l0QQ1b9l1l6i1o6OD9bl9dP00l",
 			"flareCategory": "GOLD",
 			"inGameID": 38395
 		},
@@ -12244,6 +13212,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"basename": "were",
+			"ddrSongHash": "I6DdI9O1Oo8O9lo1D08ldOllo0o166I8",
 			"flareCategory": "GOLD",
 			"inGameID": 38396
 		},
@@ -12256,6 +13225,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"",
 		"data": {
 			"basename": "shyg",
+			"ddrSongHash": "l9QibD8IoooD9DIl1O8Q0lo89I9qdido",
 			"flareCategory": "GOLD",
 			"inGameID": 38397
 		},
@@ -12268,6 +13238,7 @@
 		"artist": "BEMANI Sound Team \"あさき隊\"",
 		"data": {
 			"basename": "kkkr",
+			"ddrSongHash": "DdQ1lQ1Qb1P1oPl1QOd0Q0O9qqidiI9q",
 			"flareCategory": "GOLD",
 			"inGameID": 38398
 		},
@@ -12304,6 +13275,7 @@
 		"artist": "Numb'n'dub",
 		"data": {
 			"basename": "reso",
+			"ddrSongHash": "Q88dlIQDd9lbiiiio0dddO6QP6O091lI",
 			"flareCategory": "GOLD",
 			"inGameID": 38401
 		},
@@ -12316,6 +13288,7 @@
 		"artist": "Dazsta",
 		"data": {
 			"basename": "drow",
+			"ddrSongHash": "b80oDO98iPDO1100IbOo8160bPdd898I",
 			"flareCategory": "GOLD",
 			"inGameID": 38402
 		},
@@ -12328,6 +13301,7 @@
 		"artist": "SYSTEM VALKYRIE:type-overdrive",
 		"data": {
 			"basename": "meda",
+			"ddrSongHash": "D1QDql1OQDl1dblId0P81Q999dO9POoP",
 			"flareCategory": "GOLD",
 			"inGameID": 38403
 		},
@@ -12340,6 +13314,7 @@
 		"artist": "kiraku",
 		"data": {
 			"basename": "actu",
+			"ddrSongHash": "i6P0dI11PdoIIQ19D6PQPidqd0bI6lqi",
 			"flareCategory": "GOLD",
 			"inGameID": 38404
 		},
@@ -12352,6 +13327,7 @@
 		"artist": "nana(Sevencolors) feat.ジゼル・クイン",
 		"data": {
 			"basename": "sadi",
+			"ddrSongHash": "Q8b91l6od9bq6IPqlddiP0bb0l1iqD8I",
 			"flareCategory": "GOLD",
 			"inGameID": 38405
 		},
@@ -12364,6 +13340,7 @@
 		"artist": "m1dy",
 		"data": {
 			"basename": "m1dy",
+			"ddrSongHash": "bll06Di6q1QOlddDlPDPiQDDI09bOOoP",
 			"flareCategory": "GOLD",
 			"inGameID": 38406
 		},
@@ -12376,6 +13353,7 @@
 		"artist": "nanobii",
 		"data": {
 			"basename": "stth",
+			"ddrSongHash": "8iiqQ9o1P089901DPIq8PDPOl6oDOl1P",
 			"flareCategory": "GOLD",
 			"inGameID": 38407
 		},
@@ -12388,6 +13366,7 @@
 		"artist": "JAKAZiD",
 		"data": {
 			"basename": "golo",
+			"ddrSongHash": "i9PQoDbQI0qqd6I00d19bQo6q9PoOIbO",
 			"flareCategory": "GOLD",
 			"inGameID": 38408
 		},
@@ -12400,6 +13379,7 @@
 		"artist": "MASAYOSHI IIMORI",
 		"data": {
 			"basename": "hede",
+			"ddrSongHash": "i8iPdIlP1IIDib96Qq080ibq6bblQqQD",
 			"flareCategory": "GOLD",
 			"inGameID": 38409
 		},
@@ -12412,6 +13392,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "evan",
+			"ddrSongHash": "P06O6iQbiPPqiIqOd0IQdqolbPbDId6Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38410
 		},
@@ -12424,6 +13405,7 @@
 		"artist": "BEMANI Sound Team \"L.E.D.\"",
 		"data": {
 			"basename": "sibu",
+			"ddrSongHash": "qQd06O6d19ODl0QP8l6Q8lPlloo69ddP",
 			"flareCategory": "GOLD",
 			"inGameID": 38411
 		},
@@ -12448,6 +13430,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "houu",
+			"ddrSongHash": "QiPiIb8I99loq8loIq91iP6l1OOoq8oq",
 			"flareCategory": "GOLD",
 			"inGameID": 38413
 		},
@@ -12472,6 +13455,7 @@
 		"artist": "DJ TOTTO feat.Annabel & 日山尚",
 		"data": {
 			"basename": "kana",
+			"ddrSongHash": "ilbQ0lq89DId9oDl89lbb8lQIPl6i0QO",
 			"flareCategory": "GOLD",
 			"inGameID": 38415
 		},
@@ -12532,6 +13516,7 @@
 		"artist": "Pa's Lam System",
 		"data": {
 			"basename": "ifif",
+			"ddrSongHash": "6ID160b99ibbd9OoblD0DPOl98lPbq6D",
 			"flareCategory": "GOLD",
 			"inGameID": 38420
 		},
@@ -12544,6 +13529,7 @@
 		"artist": "Akhuta",
 		"data": {
 			"basename": "jucu",
+			"ddrSongHash": "PPb6l1di1Pi0o8O08odqIDlbPll61QbQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38421
 		},
@@ -12556,6 +13542,7 @@
 		"artist": "Shouya Namai",
 		"data": {
 			"basename": "aure",
+			"ddrSongHash": "o8996Q8lQ08dQbOoqP0id80bi18lql9b",
 			"flareCategory": "GOLD",
 			"inGameID": 38422
 		},
@@ -12568,6 +13555,7 @@
 		"artist": "nana(Sevencolors)",
 		"data": {
 			"basename": "popi",
+			"ddrSongHash": "Q0dQDqillPqIId0Q81q01ooObQIlO1QI",
 			"flareCategory": "GOLD",
 			"inGameID": 38423
 		},
@@ -12580,6 +13568,7 @@
 		"artist": "SOUND HOLIC Vs. ZYTOKINE feat. Nana Takahashi",
 		"data": {
 			"basename": "onyx",
+			"ddrSongHash": "Dl91ldlb8PODoO96OI801DP0PPl8Plqi",
 			"flareCategory": "GOLD",
 			"inGameID": 38424
 		},
@@ -12592,6 +13581,7 @@
 		"artist": "sky_delta",
 		"data": {
 			"basename": "swor",
+			"ddrSongHash": "ddqO1b1ldlQd6OOoQ1boPdoboDQqd9D8",
 			"flareCategory": "GOLD",
 			"inGameID": 38425
 		},
@@ -12604,6 +13594,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "betm",
+			"ddrSongHash": "8dqQDblP6dPI10qq10qiPbqi1llQ06iP",
 			"flareCategory": "GOLD",
 			"inGameID": 38426
 		},
@@ -12628,6 +13619,7 @@
 		"artist": "Shouya Namai",
 		"data": {
 			"basename": "hilo",
+			"ddrSongHash": "ODli9liO1loIiqb9qIol6o1PO91DP8QQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38428
 		},
@@ -12640,6 +13632,7 @@
 		"artist": "Upper Cape Project",
 		"data": {
 			"basename": "yumo",
+			"ddrSongHash": "I1I0qd19DqIoI0qdqd6oPO68O8DDi6OI",
 			"flareCategory": "GOLD",
 			"inGameID": 38429
 		},
@@ -12652,6 +13645,7 @@
 		"artist": "Yucky",
 		"data": {
 			"basename": "papa",
+			"ddrSongHash": "lb01Qb1iOOIIobPO06Oob9ODilIDOQ6Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38430
 		},
@@ -12664,6 +13658,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "uhoh",
+			"ddrSongHash": "dI1Ii100bQ6006l89diod0d116diOl8D",
 			"flareCategory": "GOLD",
 			"inGameID": 38431
 		},
@@ -12676,6 +13671,7 @@
 		"artist": "BEMANI Sound Team \"TAG underground overlay UNLEASHED\"",
 		"data": {
 			"basename": "lada",
+			"ddrSongHash": "dQODIo01o98oPll086Qdol8bq9QP8d61",
 			"flareCategory": "GOLD",
 			"inGameID": 38432
 		},
@@ -12688,6 +13684,7 @@
 		"artist": "Jonny Dynamite!,Lisa - paint with stars -,Rio Hiiragi by BEMANI Sound Team \"U1-ASAMi\"",
 		"data": {
 			"basename": "movw",
+			"ddrSongHash": "19old9dq1q9DilPQDol88d19dI96blb6",
 			"flareCategory": "GOLD",
 			"inGameID": 38433
 		},
@@ -12700,6 +13697,7 @@
 		"artist": "神田沙也加",
 		"data": {
 			"basename": "roki",
+			"ddrSongHash": "1qPbqd11l6b8ibq1ODQ6di90PIo0D618",
 			"flareCategory": "GOLD",
 			"inGameID": 38434
 		},
@@ -12712,6 +13710,7 @@
 		"artist": "小寺可南子,ランコ,SARAH by BEMANI Sound Team \"Yvya\"",
 		"data": {
 			"basename": "itet",
+			"ddrSongHash": "Odb0b0ld6P80b8b6QD0IIO866iq8OQ0b",
 			"flareCategory": "GOLD",
 			"inGameID": 38435
 		},
@@ -12724,6 +13723,7 @@
 		"artist": "すわひでお,秋成,かぼちゃ,藍月なくる,NU-KO by BEMANI Sound Team \"八戸亀生羅\"",
 		"data": {
 			"basename": "suse",
+			"ddrSongHash": "boqo0IoO8DodOl99Q8P8qOi8PqDq11b1",
 			"flareCategory": "GOLD",
 			"inGameID": 38436
 		},
@@ -12736,6 +13736,7 @@
 		"artist": "koyomi,星野奏子 by BEMANI Sound Team \"TAKA\"",
 		"data": {
 			"basename": "liva",
+			"ddrSongHash": "ooiqoi6Q0dil6b10QOq8DiOIiq9iQb10",
 			"flareCategory": "GOLD",
 			"inGameID": 38437
 		},
@@ -12748,6 +13749,7 @@
 		"artist": "Sana,ATSUMI UEDA by BEMANI Sound Team \"PON\"",
 		"data": {
 			"basename": "glgl",
+			"ddrSongHash": "lilO9P0i1dlOl1PI6dQbiob1iP0dliOQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38438
 		},
@@ -12760,6 +13762,7 @@
 		"artist": "紫崎 雪,Risa Yuzuki,709sec. by BEMANI Sound Team \"PHQUASE & SYUNN\"",
 		"data": {
 			"basename": "yume",
+			"ddrSongHash": "IPid909iDid06d68IDo816OqbdQq8O0O",
 			"flareCategory": "GOLD",
 			"inGameID": 38439
 		},
@@ -12784,6 +13787,7 @@
 		"artist": "BEMANI Sound Team \"dj TAKA & DJ YOSHITAKA & SYUNN\"",
 		"data": {
 			"basename": "trcr",
+			"ddrSongHash": "IQqi9Q9qD0DDQIqQOb868QIOioqDqI01",
 			"flareCategory": "GOLD",
 			"inGameID": 38441
 		},
@@ -12796,6 +13800,7 @@
 		"artist": "DJ Mass MAD Izm*",
 		"data": {
 			"basename": "syak2",
+			"ddrSongHash": "l0OPoQ1O8q8DPDo0Iol6qD6DiIqdD9P9",
 			"flareCategory": "GOLD",
 			"inGameID": 38442
 		},
@@ -12808,6 +13813,7 @@
 		"artist": "あるふぁ",
 		"data": {
 			"basename": "swcl",
+			"ddrSongHash": "I0DDidl0PIo6bO6o8I08Q1Pq89IdP6Pb",
 			"flareCategory": "GOLD",
 			"inGameID": 38443
 		},
@@ -12820,6 +13826,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "pupu",
+			"ddrSongHash": "bI0oqdIDPPi8dDqlOO1Ii8qDQb1lq88o",
 			"flareCategory": "GOLD",
 			"inGameID": 38444
 		},
@@ -12832,6 +13839,7 @@
 		"artist": "BEMANI Sound Team \"Monolith vs. Nautilus\"",
 		"data": {
 			"basename": "lasu",
+			"ddrSongHash": "iOl86b6I00IP9Q9I881oq9qOIDPqqDoO",
 			"flareCategory": "GOLD",
 			"inGameID": 38445
 		},
@@ -12844,6 +13852,7 @@
 		"artist": "Yuta Imai",
 		"data": {
 			"basename": "stgo",
+			"ddrSongHash": "989od088q99DPIIq6IQidI1IQ1qQOlb6",
 			"flareCategory": "GOLD",
 			"inGameID": 38446
 		},
@@ -12856,6 +13865,7 @@
 		"artist": "TORIENA",
 		"data": {
 			"basename": "nopl",
+			"ddrSongHash": "Oq8ID68oq16I9QP9bio0ibD6PQiDbqqI",
 			"flareCategory": "GOLD",
 			"inGameID": 38447
 		},
@@ -12868,6 +13878,7 @@
 		"artist": "G-T-R",
 		"data": {
 			"basename": "shid",
+			"ddrSongHash": "9ldQqb9oqi60Q80iob61OiQbbDO6PID9",
 			"flareCategory": "GOLD",
 			"inGameID": 38448
 		},
@@ -12880,6 +13891,7 @@
 		"artist": "A.T.park",
 		"data": {
 			"basename": "blak",
+			"ddrSongHash": "b0dIdlPD6IDQ000l6lIoO9oD1IQiqQ6I",
 			"flareCategory": "GOLD",
 			"inGameID": 38449
 		},
@@ -12892,6 +13904,7 @@
 		"artist": "BlackY",
 		"data": {
 			"basename": "typh",
+			"ddrSongHash": "i0Q0o98q0DqbbiDd6966QIIoddlob6lI",
 			"flareCategory": "GOLD",
 			"inGameID": 38450
 		},
@@ -12904,6 +13917,7 @@
 		"artist": "Whac-A-Me",
 		"data": {
 			"basename": "lmsy",
+			"ddrSongHash": "99llllDoOQqlo68o089PPlO1oiq06d1D",
 			"flareCategory": "GOLD",
 			"inGameID": 38451
 		},
@@ -12916,6 +13930,7 @@
 		"artist": "Dubscribe",
 		"data": {
 			"basename": "gtit",
+			"ddrSongHash": "lb969IOOoI06P18PPq81o1lPD1b1OqqI",
 			"flareCategory": "GOLD",
 			"inGameID": 38452
 		},
@@ -12928,6 +13943,7 @@
 		"artist": "Dominant Space",
 		"data": {
 			"basename": "cbmf",
+			"ddrSongHash": "qi0lbbDIo8Qlo9IiD8oqqo69DIPQ1IIO",
 			"flareCategory": "GOLD",
 			"inGameID": 38453
 		},
@@ -12940,6 +13956,7 @@
 		"artist": "CHEAP CREAM",
 		"data": {
 			"basename": "drmh",
+			"ddrSongHash": "DqioIqbiolQ0lQlo19idi96Obi6DDl9D",
 			"flareCategory": "GOLD",
 			"inGameID": 38454
 		},
@@ -12952,6 +13969,7 @@
 		"artist": "Tatsunoshin",
 		"data": {
 			"basename": "telp",
+			"ddrSongHash": "0DDIQOo6Pl9961I8OiOb1i0OODDPlldl",
 			"flareCategory": "GOLD",
 			"inGameID": 38455
 		},
@@ -12964,6 +13982,7 @@
 		"artist": "nora2r feat. 和鳴るせ",
 		"data": {
 			"basename": "liks",
+			"ddrSongHash": "691bdoD0DIP6di9D6QoPiDbD19Ol0lqi",
 			"flareCategory": "GOLD",
 			"inGameID": 38456
 		},
@@ -12976,6 +13995,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"basename": "gsun",
+			"ddrSongHash": "0iII09bDqIbOQDDoo8lO8DOOQdiP1Iob",
 			"flareCategory": "GOLD",
 			"inGameID": 38457
 		},
@@ -12988,6 +14008,7 @@
 		"artist": "ZEOL",
 		"data": {
 			"basename": "lmkn",
+			"ddrSongHash": "IOb6Qdi861O00I8q969bDdd60I6I89oI",
 			"flareCategory": "GOLD",
 			"inGameID": 38458
 		},
@@ -13000,6 +14021,7 @@
 		"artist": "FLOXYTEK",
 		"data": {
 			"basename": "pers",
+			"ddrSongHash": "8o08l8DPiO01dlo1OI8DqQDq9lQ1bPq1",
 			"flareCategory": "GOLD",
 			"inGameID": 38459
 		},
@@ -13012,6 +14034,7 @@
 		"artist": "Stessie",
 		"data": {
 			"basename": "surf",
+			"ddrSongHash": "9qO16DoQPDODQI6IPD0lPD10b88Qqi1i",
 			"flareCategory": "GOLD",
 			"inGameID": 38460
 		},
@@ -13024,6 +14047,7 @@
 		"artist": "BEMANI Sound Team \"ZAQUVA\"",
 		"data": {
 			"basename": "anan",
+			"ddrSongHash": "1q6Qoi0lldP6qoQI9PI199d6P0Q96ld0",
 			"flareCategory": "GOLD",
 			"inGameID": 38461
 		},
@@ -13036,6 +14060,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "aiai",
+			"ddrSongHash": "OO1O10bDI6OP0O1OlOlI6qQDiPIdidbO",
 			"flareCategory": "GOLD",
 			"inGameID": 38462
 		},
@@ -13048,6 +14073,7 @@
 		"artist": "sky_delta",
 		"data": {
 			"basename": "unry",
+			"ddrSongHash": "boDqoIDqDlP1io6bQ0O10diDbbqOD96I",
 			"flareCategory": "GOLD",
 			"inGameID": 38463
 		},
@@ -13060,6 +14086,7 @@
 		"artist": "WATARU",
 		"data": {
 			"basename": "geyw",
+			"ddrSongHash": "8O9o9OPPdd1Db6996P99bq9oQI66P88o",
 			"flareCategory": "GOLD",
 			"inGameID": 38464
 		},
@@ -13072,6 +14099,7 @@
 		"artist": "BlackY feat. Risa Yuzuki",
 		"data": {
 			"basename": "antm",
+			"ddrSongHash": "oDiqd818i0IPPoIOddbb8DQiQqqqo098",
 			"flareCategory": "GOLD",
 			"inGameID": 38465
 		},
@@ -13084,6 +14112,7 @@
 		"artist": "D-wacrew",
 		"data": {
 			"basename": "hotu",
+			"ddrSongHash": "IdlqO9DoOq0qPQdDbOb80dOPDlb98l0l",
 			"flareCategory": "GOLD",
 			"inGameID": 38466
 		},
@@ -13096,6 +14125,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"",
 		"data": {
 			"basename": "mono",
+			"ddrSongHash": "10IOllioqPoOQ668PQqolDPiib0iIQql",
 			"flareCategory": "GOLD",
 			"inGameID": 38467
 		},
@@ -13108,6 +14138,7 @@
 		"artist": "DV-i",
 		"data": {
 			"basename": "envi",
+			"ddrSongHash": "1PQiP6D6IqP016dqb8qPq86Q1o8bQq6q",
 			"flareCategory": "GOLD",
 			"inGameID": 38468
 		},
@@ -13252,6 +14283,7 @@
 		"artist": "BEMANI Sound Team \"猫叉Master & あさき & Yvya\"",
 		"data": {
 			"basename": "aftm",
+			"ddrSongHash": "9IQoPbOidod8I0qQ989Ql60D09I99q1Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38481
 		},
@@ -13300,6 +14332,7 @@
 		"artist": "P*Light",
 		"data": {
 			"basename": "papo",
+			"ddrSongHash": "19Q9lQId91d9l8o09oI81OQqPd00dQ69",
 			"flareCategory": "GOLD",
 			"inGameID": 38485
 		},
@@ -13312,6 +14345,7 @@
 		"artist": "BEMANI Sound Team \"Captain KING\"",
 		"data": {
 			"basename": "daph",
+			"ddrSongHash": "oQ91qO6Dii66bO69I9ooIQD101Dl68Qi",
 			"flareCategory": "GOLD",
 			"inGameID": 38486
 		},
@@ -13324,6 +14358,7 @@
 		"artist": "U1 vs U1 overground",
 		"data": {
 			"basename": "wadi",
+			"ddrSongHash": "6l1l8D006lD8OoOi91QI0b10d19Did1O",
 			"flareCategory": "GOLD",
 			"inGameID": 38487
 		},
@@ -13336,6 +14371,7 @@
 		"artist": "TOMOSUKE feat. Three Berry Icecream",
 		"data": {
 			"basename": "jetg",
+			"ddrSongHash": "66b1Pibq019dqbdPOdlqDbdbbDdi9Q08",
 			"flareCategory": "GOLD",
 			"inGameID": 38488
 		},
@@ -13348,6 +14384,7 @@
 		"artist": "L.E.D.",
 		"data": {
 			"basename": "schw",
+			"ddrSongHash": "iq9qPoPlIlbIDqlD81DqO1110QI1qoOl",
 			"flareCategory": "GOLD",
 			"inGameID": 38489
 		},
@@ -13360,6 +14397,7 @@
 		"artist": "すりぃ feat.鏡音レン",
 		"data": {
 			"basename": "teca",
+			"ddrSongHash": "dbod1o098DoibO0PoiPIiQ11Pdlqdoo9",
 			"flareCategory": "GOLD",
 			"inGameID": 38490
 		},
@@ -13372,6 +14410,7 @@
 		"artist": "フレデリック",
 		"data": {
 			"basename": "saik",
+			"ddrSongHash": "o8IDq8P8lP9o8IIO6lPPqqQP91bo0ddl",
 			"flareCategory": "GOLD",
 			"inGameID": 38491
 		},
@@ -13384,6 +14423,7 @@
 		"artist": "BEMANI Sound Team \"Akhuta Works\"",
 		"data": {
 			"basename": "fleu",
+			"ddrSongHash": "iOql19lQibIoo1bObo0Q1DqQ9qOqI0oq",
 			"flareCategory": "GOLD",
 			"inGameID": 38492
 		},
@@ -13396,6 +14436,7 @@
 		"artist": "BEMANI Sound Team \"Coyaan\"",
 		"data": {
 			"basename": "deet",
+			"ddrSongHash": "1IQ16dPQPQ0Q1qdidld6lO1o86q98o69",
 			"flareCategory": "GOLD",
 			"inGameID": 38493
 		},
@@ -13408,6 +14449,7 @@
 		"artist": "S-C-U",
 		"data": {
 			"basename": "coco",
+			"ddrSongHash": "OqQ68Ooiqi80891QIPoioib11qdl0l9b",
 			"flareCategory": "GOLD",
 			"inGameID": 38494
 		},
@@ -13420,6 +14462,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "vall",
+			"ddrSongHash": "q8o866OdqqDPOQdO88D1DOdbqQo1q8Q1",
 			"flareCategory": "GOLD",
 			"inGameID": 38495
 		},
@@ -13432,6 +14475,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "wuvu",
+			"ddrSongHash": "6DPiPD9qDboDlP8qq61Q89qPP0dIO0OI",
 			"flareCategory": "GOLD",
 			"inGameID": 38496
 		},
@@ -13444,6 +14488,7 @@
 		"artist": "azuma feat. ななひら",
 		"data": {
 			"basename": "ysim",
+			"ddrSongHash": "IQ9ddqDqq908QqQl196DQODQD9Q6oOiQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38497
 		},
@@ -13492,6 +14537,7 @@
 		"artist": "BEMANI Sound Team \"Sota F.\"",
 		"data": {
 			"basename": "newm",
+			"ddrSongHash": "q96q9D9oIIOQl8QQ60ii19P0Dbq8Q609",
 			"flareCategory": "GOLD",
 			"inGameID": 38501
 		},
@@ -13504,6 +14550,7 @@
 		"artist": "iconoclasm",
 		"data": {
 			"basename": "perd",
+			"ddrSongHash": "OPbd0ldd89Ddll690qiObDld9oDdPdOi",
 			"flareCategory": "GOLD",
 			"inGameID": 38502
 		},
@@ -13552,6 +14599,7 @@
 		"artist": "D-Evoke（与那嶺雅人/小日向翔）",
 		"data": {
 			"basename": "kyoh",
+			"ddrSongHash": "8I090lbOOOP90O01bDbi0Qo0OPldIdP6",
 			"flareCategory": "GOLD",
 			"inGameID": 38506
 		},
@@ -13564,6 +14612,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "sayh",
+			"ddrSongHash": "lO08lblo68qbdPq0dIlIqqdiiOq900Pb",
 			"flareCategory": "GOLD",
 			"inGameID": 38507
 		},
@@ -13576,6 +14625,7 @@
 		"artist": "佐々木博史",
 		"data": {
 			"basename": "conc",
+			"ddrSongHash": "qoD0olPq6qbOi6bbPllOib0q1i16iI1O",
 			"flareCategory": "GOLD",
 			"inGameID": 38508
 		},
@@ -13588,6 +14638,7 @@
 		"artist": "TOKYO MACHINE",
 		"data": {
 			"basename": "grme",
+			"ddrSongHash": "ob0P66Q8dqbI81qi6OQDPP6086iPoO1P",
 			"flareCategory": "GOLD",
 			"inGameID": 38509
 		},
@@ -13600,6 +14651,7 @@
 		"artist": "meiyo",
 		"data": {
 			"basename": "ueue",
+			"ddrSongHash": "8ooI09QP161IqI00IdPOD1QdDd8oDod9",
 			"flareCategory": "GOLD",
 			"inGameID": 38510
 		},
@@ -13612,6 +14664,7 @@
 		"artist": "BEMANI Sound Team \"S-C-U\"",
 		"data": {
 			"basename": "belu",
+			"ddrSongHash": "DqoQD9iDodq9Iq108l119OQ1olOPi6D1",
 			"flareCategory": "GOLD",
 			"inGameID": 38511
 		},
@@ -13624,6 +14677,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "wopl",
+			"ddrSongHash": "1lqii0IibdbPD19P6DiIl0Id9do6qqd1",
 			"flareCategory": "GOLD",
 			"inGameID": 38512
 		},
@@ -13636,6 +14690,7 @@
 		"artist": "BEMANI Sound Team \"Yvya\"",
 		"data": {
 			"basename": "qwer",
+			"ddrSongHash": "6ibO1P1I1ooDdd9l1oDOqDDdOlO9o6io",
 			"flareCategory": "GOLD",
 			"inGameID": 38513
 		},
@@ -13648,6 +14703,7 @@
 		"artist": "BEMANI Sound Team \"PHQUASE\"",
 		"data": {
 			"basename": "ster",
+			"ddrSongHash": "boO8d11P8o6l89i81i1i1IdPlP109QoQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38514
 		},
@@ -13660,6 +14716,7 @@
 		"artist": "キノシタ feat.音街ウナ",
 		"data": {
 			"basename": "ayma",
+			"ddrSongHash": "PDoiQoi9q08PQ96Pl6oD9IIi6iq0Q6D6",
 			"flareCategory": "GOLD",
 			"inGameID": 38515
 		},
@@ -13672,6 +14729,7 @@
 		"artist": "ビートまりお(COOL&CREATE)",
 		"data": {
 			"basename": "usty",
+			"ddrSongHash": "9oIO98IPOiq1idiIIbOOqdDQIOdQPPd6",
 			"flareCategory": "GOLD",
 			"inGameID": 38516
 		},
@@ -13684,6 +14742,7 @@
 		"artist": "暁Records",
 		"data": {
 			"basename": "warn",
+			"ddrSongHash": "I0091lboOD1Dii10dQ0qbDqil69PQ0io",
 			"flareCategory": "GOLD",
 			"inGameID": 38517
 		},
@@ -13696,6 +14755,7 @@
 		"artist": "ARM(IOSYS)",
 		"data": {
 			"basename": "kanb",
+			"ddrSongHash": "6OIoOPDb9iI8i1Do9qQ96Q0ddOdd6q9i",
 			"flareCategory": "GOLD",
 			"inGameID": 38518
 		},
@@ -13708,6 +14768,7 @@
 		"artist": "lapix",
 		"data": {
 			"basename": "debu",
+			"ddrSongHash": "dQdo08Qb6bOPIl8686DPDd60I1oqidIP",
 			"flareCategory": "GOLD",
 			"inGameID": 38519
 		},
@@ -13720,6 +14781,7 @@
 		"artist": "kors k feat.Jaejun by NuevoStudio",
 		"data": {
 			"basename": "leda",
+			"ddrSongHash": "ddqQ801q1lIdIooDiq66qPil1oD0611I",
 			"flareCategory": "GOLD",
 			"inGameID": 38520
 		},
@@ -13732,6 +14794,7 @@
 		"artist": "Toby Fox",
 		"data": {
 			"basename": "mega",
+			"ddrSongHash": "PddldblI909IqI8PPiQIo9lIIiQdDo1l",
 			"flareCategory": "GOLD",
 			"inGameID": 38521
 		},
@@ -13744,6 +14807,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "mana",
+			"ddrSongHash": "ibOId89QQPI6dli9I6PO09Qo86686O6i",
 			"flareCategory": "GOLD",
 			"inGameID": 38522
 		},
@@ -13756,6 +14820,7 @@
 		"artist": "黒猫ダンジョン",
 		"data": {
 			"basename": "lien",
+			"ddrSongHash": "IidO8qlodqdoioodqqb9Dqiq991Ilo10",
 			"flareCategory": "GOLD",
 			"inGameID": 38523
 		},
@@ -13768,6 +14833,7 @@
 		"artist": "Mayumi Morinaga,Fernweh by BEMANI Sound Team \"L.E.D. & HuΣeR\"",
 		"data": {
 			"basename": "dual",
+			"ddrSongHash": "9b60DI1OQddDI6D9D1qPoDPODD19Db8d",
 			"flareCategory": "GOLD",
 			"inGameID": 38524
 		},
@@ -13780,6 +14846,7 @@
 		"artist": "かなたん,アマギセーラ,ぁゅ by BEMANI Sound Team \"藤森崇多\"",
 		"data": {
 			"basename": "matr",
+			"ddrSongHash": "qIIDP8iPlII9qlOQIIol0i81b0d68qo8",
 			"flareCategory": "GOLD",
 			"inGameID": 38525
 		},
@@ -13792,6 +14859,7 @@
 		"artist": "ななひら,Nana Takahashi,猫体質 by BEMANI Sound Team \"劇ダンサーレコード\"",
 		"data": {
 			"basename": "chum",
+			"ddrSongHash": "OoQiq8OiPbIPI80OqOlliP661bOIDd9o",
 			"flareCategory": "GOLD",
 			"inGameID": 38526
 		},
@@ -13804,6 +14872,7 @@
 		"artist": "mami,駄々子 by BEMANI Sound Team \"Akhuta Works\"",
 		"data": {
 			"basename": "muba",
+			"ddrSongHash": "I86OI9lQ1qQ66dPDlddo8PoPo01PO66i",
 			"flareCategory": "GOLD",
 			"inGameID": 38527
 		},
@@ -13816,6 +14885,7 @@
 		"artist": "ZxNX",
 		"data": {
 			"basename": "losy",
+			"ddrSongHash": "b1QllqO8oQdqo086QdIlIblDDbPodDoP",
 			"flareCategory": "GOLD",
 			"inGameID": 38528
 		},
@@ -13828,6 +14898,7 @@
 		"artist": "PIKASONIC",
 		"data": {
 			"basename": "spad",
+			"ddrSongHash": "o89biodIl0Oo1bQqll86QDi0oQQd61Db",
 			"flareCategory": "GOLD",
 			"inGameID": 38529
 		},
@@ -13840,6 +14911,7 @@
 		"artist": "Stessie",
 		"data": {
 			"basename": "abil",
+			"ddrSongHash": "iQ9qQ8Iob108iPD9D0bdoIol0d81IOdo",
 			"flareCategory": "GOLD",
 			"inGameID": 38530
 		},
@@ -13852,6 +14924,7 @@
 		"artist": "yadosan",
 		"data": {
 			"basename": "ravi",
+			"ddrSongHash": "PIl8P90Pll19Pido608olD61QIqq0b9d",
 			"flareCategory": "GOLD",
 			"inGameID": 38531
 		},
@@ -13864,6 +14937,7 @@
 		"artist": "DJ Shimamura",
 		"data": {
 			"basename": "takh",
+			"ddrSongHash": "PoiPd1OP1q9I9IP00PDlI1Q09QQ9b16o",
 			"flareCategory": "GOLD",
 			"inGameID": 38532
 		},
@@ -13876,6 +14950,7 @@
 		"artist": "android52",
 		"data": {
 			"basename": "gr04",
+			"ddrSongHash": "lOOo9bPb09dIOb6Po19bqqbqOlb8Dq0i",
 			"flareCategory": "GOLD",
 			"inGameID": 38533
 		},
@@ -13888,6 +14963,7 @@
 		"artist": "Akira Complex",
 		"data": {
 			"basename": "saeu",
+			"ddrSongHash": "iq6b9lP6qQQIOIPQDdPD8ld1o9891Pq9",
 			"flareCategory": "GOLD",
 			"inGameID": 38534
 		},
@@ -13900,6 +14976,7 @@
 		"artist": "Odyssey Eurobeat",
 		"data": {
 			"basename": "noal",
+			"ddrSongHash": "i6bIQ6D0P09olqbOiP8I919006DdII1P",
 			"flareCategory": "GOLD",
 			"inGameID": 38535
 		},
@@ -13912,6 +14989,7 @@
 		"artist": "RYOQUCHA",
 		"data": {
 			"basename": "sect",
+			"ddrSongHash": "O6q9qPQ1q69ddPl6DPO0bQO6989QO1ii",
 			"flareCategory": "GOLD",
 			"inGameID": 38536
 		},
@@ -13924,6 +15002,7 @@
 		"artist": "NATSUMI",
 		"data": {
 			"basename": "jdan",
+			"ddrSongHash": "iQi8Oool866oDQ6i660o88b86689QiOb",
 			"flareCategory": "GOLD",
 			"inGameID": 38537
 		},
@@ -13936,6 +15015,7 @@
 		"artist": "2021真夏のSingers",
 		"data": {
 			"basename": "rena2",
+			"ddrSongHash": "bqoboI0o8lIObPPdqq8lDDdI8b1QPDb1",
 			"flareCategory": "GOLD",
 			"inGameID": 38538
 		},
@@ -13948,6 +15028,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "glac",
+			"ddrSongHash": "1IIiOQiliQ8b1dbo9D6D9PlODqIPOOb8",
 			"flareCategory": "GOLD",
 			"inGameID": 38539
 		},
@@ -13960,6 +15041,7 @@
 		"artist": "SYUNN",
 		"data": {
 			"basename": "mgar",
+			"ddrSongHash": "O9Odqd8qiQiOqQdOOq01D8OQlOiO1iPD",
 			"flareCategory": "GOLD",
 			"inGameID": 38540
 		},
@@ -13972,6 +15054,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"basename": "wowi",
+			"ddrSongHash": "6b6QIoDPoQ010o8Di1q6Q8DdiQll0Di1",
 			"flareCategory": "GOLD",
 			"inGameID": 38541
 		},
@@ -13984,6 +15067,7 @@
 		"artist": "S-C-U",
 		"data": {
 			"basename": "naho",
+			"ddrSongHash": "Do06Q18olQo0bloll9919olDQ8lDoqbd",
 			"flareCategory": "GOLD",
 			"inGameID": 38542
 		},
@@ -13996,6 +15080,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"basename": "albi",
+			"ddrSongHash": "Io196q006I86IllQPOb098qd1DQd60Oq",
 			"flareCategory": "GOLD",
 			"inGameID": 38543
 		},
@@ -14008,6 +15093,7 @@
 		"artist": "Project B-",
 		"data": {
 			"basename": "glfl",
+			"ddrSongHash": "06lOillb6id0Dib9o1b06iPblqPl61PI",
 			"flareCategory": "GOLD",
 			"inGameID": 38544
 		},
@@ -14020,6 +15106,7 @@
 		"artist": "movies (moimoi × Xceon × Dai.)",
 		"data": {
 			"basename": "tola",
+			"ddrSongHash": "IDqoidbllIb0bQQb8dQ1QqP91Q8li9P0",
 			"flareCategory": "GOLD",
 			"inGameID": 38545
 		},
@@ -14032,6 +15119,7 @@
 		"artist": "黒猫ダンジョン",
 		"data": {
 			"basename": "ryum",
+			"ddrSongHash": "dPI9loII89Q6P6iD6Ioo1iiI880DI1Dd",
 			"flareCategory": "GOLD",
 			"inGameID": 38546
 		},
@@ -14044,6 +15132,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"",
 		"data": {
 			"basename": "gerb",
+			"ddrSongHash": "bd8OODli0POo9bOq6i0oIPdIlbDlI910",
 			"flareCategory": "GOLD",
 			"inGameID": 38547
 		},
@@ -14056,6 +15145,7 @@
 		"artist": "黒魔",
 		"data": {
 			"basename": "blem",
+			"ddrSongHash": "9dI8ilPi9bd9blI6Q8D6IPb1lblqDl1Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38548
 		},
@@ -14080,6 +15170,7 @@
 		"artist": "undefined",
 		"data": {
 			"basename": "mixn",
+			"ddrSongHash": "99I10l8o6DPI886l9818ID16OlqI8oId",
 			"flareCategory": "GOLD",
 			"inGameID": 38550
 		},
@@ -14092,6 +15183,7 @@
 		"artist": "undefined",
 		"data": {
 			"basename": "itiz",
+			"ddrSongHash": "dqP6loDiD0l6b0I6i0iO90i6D0O68qO1",
 			"flareCategory": "GOLD",
 			"inGameID": 38551
 		},
@@ -14104,6 +15196,7 @@
 		"artist": "Kanaria",
 		"data": {
 			"basename": "king",
+			"ddrSongHash": "O8lq1l6qIi6I9l69IOPdoI6lbiodQOP6",
 			"flareCategory": "GOLD",
 			"inGameID": 38552
 		},
@@ -14116,6 +15209,7 @@
 		"artist": "Kanaria",
 		"data": {
 			"basename": "yoid",
+			"ddrSongHash": "IqibilD8QI9idP60P8o9ob0lqblQD89P",
 			"flareCategory": "GOLD",
 			"inGameID": 38553
 		},
@@ -14128,6 +15222,7 @@
 		"artist": "BEMANI Sound Team \"L.E.D.-G\"",
 		"data": {
 			"basename": "akib",
+			"ddrSongHash": "IlP88I0bbl91iOD6OQ6o6PPb9o6dlDb8",
 			"flareCategory": "GOLD",
 			"inGameID": 38554
 		},
@@ -14140,6 +15235,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "eape",
+			"ddrSongHash": "iiIblq9IDiOill8qdI68OOIPq6OPdiDo",
 			"flareCategory": "GOLD",
 			"inGameID": 38555
 		},
@@ -14152,6 +15248,7 @@
 		"artist": "D.watt feat. 紡音れい",
 		"data": {
 			"basename": "yyyo",
+			"ddrSongHash": "oilPP86l0PPq6Db0qqibQlqDiIOD0l1O",
 			"flareCategory": "GOLD",
 			"inGameID": 38556
 		},
@@ -14164,6 +15261,7 @@
 		"artist": "BlackY",
 		"data": {
 			"basename": "pref",
+			"ddrSongHash": "88Qq96qbdd69bqI089600l9bDDdiQI0l",
 			"flareCategory": "GOLD",
 			"inGameID": 38557
 		},
@@ -14176,6 +15274,7 @@
 		"artist": "KO3",
 		"data": {
 			"basename": "godo",
+			"ddrSongHash": "iIDOlq6QoQPiqoii0iiDOiI9ODiQOIDb",
 			"flareCategory": "GOLD",
 			"inGameID": 38558
 		},
@@ -14188,6 +15287,7 @@
 		"artist": "Relect",
 		"data": {
 			"basename": "acid",
+			"ddrSongHash": "q8QPqbiQ00i6odq81P0D960I108bIiQb",
 			"flareCategory": "GOLD",
 			"inGameID": 38559
 		},
@@ -14200,6 +15300,7 @@
 		"artist": "GRAN-NEW DRAMATIC BOYS",
 		"data": {
 			"basename": "gtto",
+			"ddrSongHash": "l106dqq891bI19iPoIo9OO688l8oOQQ6",
 			"flareCategory": "GOLD",
 			"inGameID": 38560
 		},
@@ -14212,6 +15313,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "waku",
+			"ddrSongHash": "Pb0D8b8b8PoDIO9Q9DbiQiI8qi0D89D8",
 			"flareCategory": "GOLD",
 			"inGameID": 38561
 		},
@@ -14224,6 +15326,7 @@
 		"artist": "MARON (IOSYS)",
 		"data": {
 			"basename": "bone",
+			"ddrSongHash": "IPdQ8qIqPiIdqQloI1dQQ688O0qlOQQo",
 			"flareCategory": "GOLD",
 			"inGameID": 38562
 		},
@@ -14236,6 +15339,7 @@
 		"artist": "工藤吉三（ベイシスケイプ）",
 		"data": {
 			"basename": "kiya",
+			"ddrSongHash": "6dQ0P6odPlD6dQdbP8dIiQQdQ66qllI6",
 			"flareCategory": "GOLD",
 			"inGameID": 38563
 		},
@@ -14248,6 +15352,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "brli",
+			"ddrSongHash": "O8Qb086QQIQ109d1lqilOQ9QD8lPIqdd",
 			"flareCategory": "GOLD",
 			"inGameID": 38564
 		},
@@ -14260,6 +15365,7 @@
 		"artist": "BlackY",
 		"data": {
 			"basename": "crys",
+			"ddrSongHash": "oP8iIdilQ0QiDllqDbDIOl0iQPd9PQ9I",
 			"flareCategory": "GOLD",
 			"inGameID": 38565
 		},
@@ -14296,6 +15402,7 @@
 		"artist": "Virtual Self",
 		"data": {
 			"basename": "eonb",
+			"ddrSongHash": "QD8l9QQd89PO9ql1iOD0dO69OQ1DldbP",
 			"flareCategory": "GOLD",
 			"inGameID": 38568
 		},
@@ -14308,6 +15415,7 @@
 		"artist": "Porter Robinson",
 		"data": {
 			"basename": "lats",
+			"ddrSongHash": "biO8o0DdD9lqdI9I8QI9q8oQoO8oI8q6",
 			"flareCategory": "GOLD",
 			"inGameID": 38569
 		},
@@ -14320,6 +15428,7 @@
 		"artist": "Porter Robinson",
 		"data": {
 			"basename": "soco",
+			"ddrSongHash": "DdbI8dPqPI8ll69q6QidI6lldDQod8b9",
 			"flareCategory": "GOLD",
 			"inGameID": 38570
 		},
@@ -14332,6 +15441,7 @@
 		"artist": "Porter Robinson",
 		"data": {
 			"basename": "muan",
+			"ddrSongHash": "q8q0D8QoP89IqooiiD0q66QPI1b8lDi0",
 			"flareCategory": "GOLD",
 			"inGameID": 38571
 		},
@@ -14344,6 +15454,7 @@
 		"artist": "BEMANI Sound Team \"DJ TOTTO VS 兎々\"",
 		"data": {
 			"basename": "voqu",
+			"ddrSongHash": "QldQ19DlqDbq1l091q0l1Q1qD6ldQ6qi",
 			"flareCategory": "GOLD",
 			"inGameID": 38572
 		},
@@ -14356,6 +15467,7 @@
 		"artist": "BEMANI Sound Team \"U1-ASAMi\"",
 		"data": {
 			"basename": "snhb",
+			"ddrSongHash": "Pd8bD1od1iOOl80oOiiiIb9QdqIQQllQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38573
 		},
@@ -14368,6 +15480,7 @@
 		"artist": "伊達朱里紗",
 		"data": {
 			"basename": "awwi",
+			"ddrSongHash": "QO69qib8Q61lqbO8QI0dODo8D1b6Iqlq",
 			"flareCategory": "GOLD",
 			"inGameID": 38574
 		},
@@ -14380,6 +15493,7 @@
 		"artist": "BEMANI Sound Team \"Yvya\"",
 		"data": {
 			"basename": "kilo",
+			"ddrSongHash": "61Db8oi9d9bOIlloq8dqI8O000ilDb08",
 			"flareCategory": "GOLD",
 			"inGameID": 38575
 		},
@@ -14392,6 +15506,7 @@
 		"artist": "七条レタスグループ",
 		"data": {
 			"basename": "suke",
+			"ddrSongHash": "1liPbq0890qqI0D8qDP9diOOPlDdi0Oi",
 			"flareCategory": "GOLD",
 			"inGameID": 38576
 		},
@@ -14404,6 +15519,7 @@
 		"artist": "uno & 夕野ヨシミ feat. miko",
 		"data": {
 			"basename": "chon",
+			"ddrSongHash": "6l99bqIQOQl0QQDIoiQ6PQPOoDPlD0O9",
 			"flareCategory": "GOLD",
 			"inGameID": 38577
 		},
@@ -14416,6 +15532,7 @@
 		"artist": "Tomoyuki Uchida feat.秋成",
 		"data": {
 			"basename": "inst",
+			"ddrSongHash": "6oIO00P8bdqqbP9qlqIqDP1Q1d9PD0qi",
 			"flareCategory": "GOLD",
 			"inGameID": 38578
 		},
@@ -14428,6 +15545,7 @@
 		"artist": "ビートまりお(COOL&CREATE)",
 		"data": {
 			"basename": "resp",
+			"ddrSongHash": "OiQI998qPiooq60099bPdO886q9bd011",
 			"flareCategory": "GOLD",
 			"inGameID": 38579
 		},
@@ -14440,6 +15558,7 @@
 		"artist": "ビートまりお(COOL&CREATE)",
 		"data": {
 			"basename": "sash",
+			"ddrSongHash": "9bqO1dPbO1b89q9dO1iOP1ibiPdP01q9",
 			"flareCategory": "GOLD",
 			"inGameID": 38580
 		},
@@ -14452,6 +15571,7 @@
 		"artist": "BEMANI Sound Team \"KE!JU\"",
 		"data": {
 			"basename": "snga",
+			"ddrSongHash": "8ql0DIiI0D9D1OP0qb8olo9bIQdP0ddq",
 			"flareCategory": "GOLD",
 			"inGameID": 38581
 		},
@@ -14464,6 +15584,7 @@
 		"artist": "月乃 ＆ BEMANI Sound Team \"劇団レコード\"",
 		"data": {
 			"basename": "mull",
+			"ddrSongHash": "0q90DbbI1O90D91I8ddDdDlP9IdoQ0oo",
 			"flareCategory": "GOLD",
 			"inGameID": 38582
 		},
@@ -14476,6 +15597,7 @@
 		"artist": "BEMANI Sound Team \"PON\" feat.かなたん",
 		"data": {
 			"basename": "paea",
+			"ddrSongHash": "diq9D0qbI00iOOb69q6Q1Q90PQOlo6dl",
 			"flareCategory": "GOLD",
 			"inGameID": 38583
 		},
@@ -14488,6 +15610,7 @@
 		"artist": "Sota Fujimori 2nd Season",
 		"data": {
 			"basename": "phlo",
+			"ddrSongHash": "1088IDQiIDl6I888OQi60l66DP6D0qOl",
 			"flareCategory": "GOLD",
 			"inGameID": 38584
 		},
@@ -14500,6 +15623,7 @@
 		"artist": "U1 overground",
 		"data": {
 			"basename": "adrn",
+			"ddrSongHash": "111O66bbPIQb09PlIoolIOD666QqqIdP",
 			"flareCategory": "GOLD",
 			"inGameID": 38585
 		},
@@ -14512,6 +15636,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "chap",
+			"ddrSongHash": "Od6bOOb69PqbqPdb6lO1QI66DOqo0POO",
 			"flareCategory": "GOLD",
 			"inGameID": 38586
 		},
@@ -14524,6 +15649,7 @@
 		"artist": "S-C-U",
 		"data": {
 			"basename": "spri",
+			"ddrSongHash": "DID6l8bbD0D6661lPiP6QIQ1dPbb010d",
 			"flareCategory": "GOLD",
 			"inGameID": 38587
 		},
@@ -14548,6 +15674,7 @@
 		"artist": "OSTER project feat. そらこ",
 		"data": {
 			"basename": "youh",
+			"ddrSongHash": "qb9Od0IQI16b6D9PP0O6ilqoq0dDQO66",
 			"flareCategory": "GOLD",
 			"inGameID": 38589
 		},
@@ -14560,6 +15687,7 @@
 		"artist": "undefined",
 		"data": {
 			"basename": "souv",
+			"ddrSongHash": "8o10d9O89d6DQOiDlbb160Id8IIO6b01",
 			"flareCategory": "GOLD",
 			"inGameID": 38590
 		},
@@ -14572,6 +15700,7 @@
 		"artist": "ARM (IOSYS) x BEMANI Sound Team \"U1\" ft. Kradness x TRIΔNGLE",
 		"data": {
 			"basename": "brfu",
+			"ddrSongHash": "dlq91b19ld10IdIqQ9q99O8QDOOi18dq",
 			"flareCategory": "GOLD",
 			"inGameID": 38591
 		},
@@ -14584,6 +15713,7 @@
 		"artist": "Tanukichi",
 		"data": {
 			"basename": "draw",
+			"ddrSongHash": "b0o6bl18Q1bqI9o9oqQ9POoP8DiDDibP",
 			"flareCategory": "GOLD",
 			"inGameID": 38592
 		},
@@ -14596,6 +15726,7 @@
 		"artist": "ZxNX",
 		"data": {
 			"basename": "aria",
+			"ddrSongHash": "688O16o80Iib0DPI8oQOIOdbIdQq0P1Q",
 			"flareCategory": "GOLD",
 			"inGameID": 38593
 		},
@@ -14608,6 +15739,7 @@
 		"artist": "Numb'n'dub",
 		"data": {
 			"basename": "cogv",
+			"ddrSongHash": "919bPoOo9QO6dODOI6d0loO6qo6OqDlI",
 			"flareCategory": "GOLD",
 			"inGameID": 38594
 		},
@@ -14620,6 +15752,7 @@
 		"artist": "DJ Shimamura",
 		"data": {
 			"basename": "glcr",
+			"ddrSongHash": "8d9Q0olQ980lQdPIdqbIiD8o1l1dQPI0",
 			"flareCategory": "GOLD",
 			"inGameID": 38595
 		},
@@ -14632,6 +15765,7 @@
 		"artist": "Whac-A-Me",
 		"data": {
 			"basename": "smas",
+			"ddrSongHash": "68iObo1dP91oqDQ18iiiPQDDb8O6ddq6",
 			"flareCategory": "GOLD",
 			"inGameID": 38596
 		},
@@ -14644,6 +15778,7 @@
 		"artist": "Relect",
 		"data": {
 			"basename": "riao",
+			"ddrSongHash": "DdIQdo1D01PblPQd06696dPq610o1lIl",
 			"flareCategory": "GOLD",
 			"inGameID": 38597
 		},
@@ -14656,6 +15791,7 @@
 		"artist": "JAKAZiD",
 		"data": {
 			"basename": "chbu",
+			"ddrSongHash": "1IdqDqDdd08dboO911P6OQ8lobb16PDd",
 			"flareCategory": "GOLD",
 			"inGameID": 38598
 		},
@@ -14668,6 +15804,7 @@
 		"artist": "Mameyudoufu",
 		"data": {
 			"basename": "abma",
+			"ddrSongHash": "OQO1Di8IQIQqP1d81d1ID9QD110b0888",
 			"flareCategory": "GOLD",
 			"inGameID": 38599
 		},
@@ -14680,6 +15817,7 @@
 		"artist": "Qrispy Joybox feat.mao",
 		"data": {
 			"basename": "comi",
+			"ddrSongHash": "O6P1dIO0IDO6o8ib6i8oP86Qb9D08idd",
 			"flareCategory": "GOLD",
 			"inGameID": 38602
 		},
@@ -14692,6 +15830,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "flfl",
+			"ddrSongHash": "Id1D9D68OOqqqdDiOoDd6Q6oo10P6oqI",
 			"flareCategory": "GOLD",
 			"inGameID": 38603
 		},
@@ -14704,6 +15843,7 @@
 		"artist": "Sota Fujimori 2nd Season",
 		"data": {
 			"basename": "gltr",
+			"ddrSongHash": "8IDiil0bDd00P1l1iQiq9DP6bO0b8dQb",
 			"flareCategory": "GOLD",
 			"inGameID": 38604
 		},
@@ -14716,6 +15856,7 @@
 		"artist": "DJ TOTTO",
 		"data": {
 			"basename": "vala",
+			"ddrSongHash": "9lo10Dl06QIblQqOOid1qi0bd10I9lQ9",
 			"flareCategory": "GOLD",
 			"inGameID": 38605
 		},
@@ -14728,6 +15869,7 @@
 		"artist": "dj TAKA feat.AiMEE",
 		"data": {
 			"basename": "brkn",
+			"ddrSongHash": "6qPlI8DQPoDIo6D819boPioIPPDIPblq",
 			"flareCategory": "GOLD",
 			"inGameID": 38606
 		},
@@ -14740,6 +15882,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "plwf",
+			"ddrSongHash": "bOQ0dIIIilDD9Do6qIDdlObQdo01DD80",
 			"flareCategory": "GOLD",
 			"inGameID": 38607
 		},
@@ -14752,6 +15895,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"basename": "towh",
+			"ddrSongHash": "Odd6dI6o98O68I98l6q8PqODIooQO9ol",
 			"flareCategory": "GOLD",
 			"inGameID": 38608
 		},
@@ -14764,6 +15908,7 @@
 		"artist": "DJ TOTTO VS 兎々",
 		"data": {
 			"basename": "basa",
+			"ddrSongHash": "iQDQD8889Q8O018Oi60I69D6qD6odDI0",
 			"flareCategory": "GOLD",
 			"inGameID": 38609
 		},
@@ -14776,6 +15921,7 @@
 		"artist": "enzo + O2i3",
 		"data": {
 			"basename": "mtpn",
+			"ddrSongHash": "8q96ObOdqPq8blPob9QdDq9b1iQoIQOI",
 			"flareCategory": "GOLD",
 			"inGameID": 38610
 		},
@@ -14788,6 +15934,7 @@
 		"artist": "Sota Fujimori",
 		"data": {
 			"basename": "urli",
+			"ddrSongHash": "69diddO9DOI9IPd9b66l0o0DDlPb8oqP",
 			"flareCategory": "GOLD",
 			"inGameID": 38611
 		},
@@ -14800,6 +15947,7 @@
 		"artist": "三代目 ADULTIC TEACHERS feat. BEMANI Sound Team \"スコーピオン志村\"",
 		"data": {
 			"basename": "mago",
+			"ddrSongHash": "08O1i8ib1lDPbdOoPlD069PoOI1860qi",
 			"flareCategory": "GOLD",
 			"inGameID": 38612
 		},
@@ -14812,6 +15960,7 @@
 		"artist": "Dormir",
 		"data": {
 			"basename": "tknt",
+			"ddrSongHash": "Oqo009llDdDIODldDOI6OIolqlI9PI0d",
 			"flareCategory": "GOLD",
 			"inGameID": 38613
 		},
@@ -14824,6 +15973,7 @@
 		"artist": "sky_delta",
 		"data": {
 			"basename": "emtr",
+			"ddrSongHash": "db8Ddd060IQ9lPlOlqO0PoPi0Qdb88o6",
 			"flareCategory": "GOLD",
 			"inGameID": 38614
 		},
@@ -14836,6 +15986,7 @@
 		"artist": "kors k",
 		"data": {
 			"basename": "puru",
+			"ddrSongHash": "IiiqDblQ8Oqlbo8OOiqI6IqO6P8I8I1d",
 			"flareCategory": "GOLD",
 			"inGameID": 38615
 		},
@@ -14848,6 +15999,7 @@
 		"artist": "キノシタ feat.音街ウナ・鏡音リン",
 		"data": {
 			"basename": "poda",
+			"ddrSongHash": "Q8P19lIP698I9Q8oolP98Qb6DIqQ10ql",
 			"flareCategory": "GOLD",
 			"inGameID": 38616
 		},
@@ -14860,6 +16012,7 @@
 		"artist": "キノシタ feat.音街ウナ・鏡音リン",
 		"data": {
 			"basename": "poca",
+			"ddrSongHash": "09PIO19oPoo09q0ioli6oO1di89o8Ilb",
 			"flareCategory": "GOLD",
 			"inGameID": 38617
 		},
@@ -14872,6 +16025,7 @@
 		"artist": "暁Records",
 		"data": {
 			"basename": "loea",
+			"ddrSongHash": "Q86bq1iQDIqDllbdD6ldIO089q8Q1689",
 			"flareCategory": "GOLD",
 			"inGameID": 38618
 		},
@@ -14884,6 +16038,7 @@
 		"artist": "暁Records",
 		"data": {
 			"basename": "trda",
+			"ddrSongHash": "8069d8dPiqloqD8i8od1o1Pq1Q6Q8i9D",
 			"flareCategory": "GOLD",
 			"inGameID": 38619
 		},
@@ -14896,6 +16051,7 @@
 		"artist": "nagomu tamaki",
 		"data": {
 			"basename": "iwuu",
+			"ddrSongHash": "ob6IPbiqD969Q66808obd908DI81bqPi",
 			"flareCategory": "GOLD",
 			"inGameID": 38620
 		},
@@ -14908,6 +16064,7 @@
 		"artist": "DC Mizey",
 		"data": {
 			"basename": "euph",
+			"ddrSongHash": "0dD8bq9QiD1DO0Io118idQoiP6PP900d",
 			"flareCategory": "GOLD",
 			"inGameID": 38621
 		},
@@ -14920,6 +16077,7 @@
 		"artist": "sky_delta",
 		"data": {
 			"basename": "diab",
+			"ddrSongHash": "QlQ10I6o1l88loioo6DIObi0P09PPdiD",
 			"flareCategory": "GOLD",
 			"inGameID": 38623
 		},
@@ -14932,6 +16090,7 @@
 		"artist": "RoughSkreamZ feat. Aikapin",
 		"data": {
 			"basename": "ccnn",
+			"ddrSongHash": "odPq866q0QPOP9QOQ9QQIlIO60Oid16o",
 			"flareCategory": "GOLD",
 			"inGameID": 38624
 		},
@@ -14944,6 +16103,7 @@
 		"artist": "Toby Fox",
 		"data": {
 			"basename": "bath",
+			"ddrSongHash": "I6oq8ODq6DOOiqod1iI1109DO1II9iiO",
 			"flareCategory": "GOLD",
 			"inGameID": 38625
 		},
@@ -14956,6 +16116,7 @@
 		"artist": "Toby Fox",
 		"data": {
 			"basename": "dbgl",
+			"ddrSongHash": "qqdlo1QOQo6QIi8PqOi8iIOO0il1IblQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38626
 		},
@@ -14968,6 +16129,7 @@
 		"artist": "Toby Fox",
 		"data": {
 			"basename": "file",
+			"ddrSongHash": "Qid6OQOIibbOiDo808oq9oQO668bDodP",
 			"flareCategory": "GOLD",
 			"inGameID": 38627
 		},
@@ -14980,6 +16142,7 @@
 		"artist": "BEMANI Sound Team \"猫叉Master VS dj TAKA\"",
 		"data": {
 			"basename": "susp",
+			"ddrSongHash": "Q88iD188IiqQbIoP9Oq818bPbOP1d1bQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38628
 		},
@@ -14992,6 +16155,7 @@
 		"artist": "暁Records",
 		"data": {
 			"basename": "hani",
+			"ddrSongHash": "8Oq81q8q1Q9D0l0PO0bQQ00l9P19didi",
 			"flareCategory": "GOLD",
 			"inGameID": 38632
 		},
@@ -15004,6 +16168,7 @@
 		"artist": "NUU$HI",
 		"data": {
 			"basename": "crea",
+			"ddrSongHash": "1Dd0b8lIQOd011qqOPiq1QDbDqod9Od8",
 			"flareCategory": "GOLD",
 			"inGameID": 38633
 		},
@@ -15016,6 +16181,7 @@
 		"artist": "Zekk",
 		"data": {
 			"basename": "niou",
+			"ddrSongHash": "Q9PP10bOQdIPD1iI99llI9QID9b09q0o",
 			"flareCategory": "GOLD",
 			"inGameID": 38634
 		},
@@ -15028,6 +16194,7 @@
 		"artist": "BEMANI Sound Team \"KE!JU\"",
 		"data": {
 			"basename": "ropa",
+			"ddrSongHash": "1II6199qOd1bo0P0D19Q9qd06ll1QOl9",
 			"flareCategory": "GOLD",
 			"inGameID": 38635
 		},
@@ -15040,6 +16207,7 @@
 		"artist": "BEMANI Sound Team \"Paoon\"",
 		"data": {
 			"basename": "sisy",
+			"ddrSongHash": "lliDD9qPqiIDI8P9bb18IO60l9D061Io",
 			"flareCategory": "GOLD",
 			"inGameID": 38636
 		},
@@ -15052,6 +16220,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "inwo",
+			"ddrSongHash": "lob09DPQD0Dl6Q09dbq8biIb6QqDql8i",
 			"flareCategory": "GOLD",
 			"inGameID": 38637
 		},
@@ -15064,6 +16233,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "shwa",
+			"ddrSongHash": "dQQ6dQb1dQDd8bPqIPI0blb11ioq1QQo",
 			"flareCategory": "GOLD",
 			"inGameID": 38638
 		},
@@ -15076,6 +16246,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi & 709sec.",
 		"data": {
 			"basename": "kini",
+			"ddrSongHash": "99ll6bPDDPqQ8boPIQbdQ6bPo8bl69O9",
 			"flareCategory": "GOLD",
 			"inGameID": 38639
 		},
@@ -15088,6 +16259,7 @@
 		"artist": "SARAH",
 		"data": {
 			"basename": "nefu",
+			"ddrSongHash": "qiqP8qb8Qlld0Oqbll00o0bqlq9PoO09",
 			"flareCategory": "GOLD",
 			"inGameID": 38640
 		},
@@ -15100,6 +16272,7 @@
 		"artist": "Coretex feat. MIDI War",
 		"data": {
 			"basename": "mydr",
+			"ddrSongHash": "DQqO696iPldD6olDOOdP09l08ll989l8",
 			"flareCategory": "GOLD",
 			"inGameID": 38641
 		},
@@ -15112,6 +16285,7 @@
 		"artist": "ここなつ2.0",
 		"data": {
 			"basename": "pola",
+			"ddrSongHash": "D6iI9O90il0OoIqP1Q86OIQdDQQilII8",
 			"flareCategory": "GOLD",
 			"inGameID": 38643
 		},
@@ -15124,6 +16298,7 @@
 		"artist": "ここなつ Produced by lapix",
 		"data": {
 			"basename": "fidi",
+			"ddrSongHash": "OQ6o9D6ldd0iqoqoQQ0QbIi01DI9dO6b",
 			"flareCategory": "GOLD",
 			"inGameID": 38644
 		},
@@ -15136,6 +16311,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "toka",
+			"ddrSongHash": "88lIDIi1Pi0IObl8D9oblqQ9PPdI1DqI",
 			"flareCategory": "GOLD",
 			"inGameID": 38645
 		},
@@ -15148,6 +16324,7 @@
 		"artist": "ここなつ",
 		"data": {
 			"basename": "nali",
+			"ddrSongHash": "D8P1qO8bqQIP9bOOP1dPOP660OdIllbD",
 			"flareCategory": "GOLD",
 			"inGameID": 38646
 		},
@@ -15160,6 +16337,7 @@
 		"artist": "ここなつ Produced by U-ske",
 		"data": {
 			"basename": "cnfc",
+			"ddrSongHash": "q8llPoIloObO6QIPlQOl9P06dDQlPlQi",
 			"flareCategory": "GOLD",
 			"inGameID": 38647
 		},
@@ -15172,6 +16350,7 @@
 		"artist": "ここなつ Produced by uma",
 		"data": {
 			"basename": "senk",
+			"ddrSongHash": "loQ0Ibqqo8OO11oI9i9D6o0DDI0PDiOO",
 			"flareCategory": "GOLD",
 			"inGameID": 38648
 		},
@@ -15184,6 +16363,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "hame",
+			"ddrSongHash": "diPbi6I8O1lQ1b9lO0q8IoqDqbD9P6dP",
 			"flareCategory": "GOLD",
 			"inGameID": 38649
 		},
@@ -15196,6 +16376,7 @@
 		"artist": "Remixed by BEMANI Sound Team \"Yvya\"",
 		"data": {
 			"basename": "ckpp2",
+			"ddrSongHash": "I8qDQbQoiPPi9D1bdQ6iOlqb0Il9DlI0",
 			"flareCategory": "GOLD",
 			"inGameID": 38650
 		},
@@ -15208,6 +16389,7 @@
 		"artist": "Remixed by BEMANI Sound Team \"ZAQUVA\"",
 		"data": {
 			"basename": "meum2",
+			"ddrSongHash": "6QQ1OdO99Ob001OQ90iP86o0I8OoQbib",
 			"flareCategory": "GOLD",
 			"inGameID": 38651
 		},
@@ -15220,6 +16402,7 @@
 		"artist": "BEMANI Sound Team \"ZAQUVA\" feat. Uzumaki",
 		"data": {
 			"basename": "thou",
+			"ddrSongHash": "9oll10Dq1qdbPQl68OQ8dOd9q86999i1",
 			"flareCategory": "GOLD",
 			"inGameID": 38652
 		},
@@ -15232,6 +16415,7 @@
 		"artist": "BEMANI Sound Team \"HuΣeR\"",
 		"data": {
 			"basename": "dent",
+			"ddrSongHash": "Di0ODIlddo8d90oo09qqd98QObQP1llI",
 			"flareCategory": "GOLD",
 			"inGameID": 38653
 		},
@@ -15244,6 +16428,7 @@
 		"artist": "BEMANI Sound Team \"ZAQUVA\"",
 		"data": {
 			"basename": "whst",
+			"ddrSongHash": "qdbO199oIDIbQ61iDQIPObOPQOIDP68i",
 			"flareCategory": "GOLD",
 			"inGameID": 38654
 		},
@@ -15256,6 +16441,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "dwtd",
+			"ddrSongHash": "1dldQ1il1O89O8Ol0Ib0Dq8Pl8ol111I",
 			"flareCategory": "GOLD",
 			"inGameID": 38655
 		},
@@ -15268,6 +16454,7 @@
 		"artist": "BEMANI Sound Team \"Sota Fujimori\"",
 		"data": {
 			"basename": "meta",
+			"ddrSongHash": "IqiOOoDoo061DlbqPPQdPlP1qloP6096",
 			"flareCategory": "GOLD",
 			"inGameID": 38656
 		},
@@ -15280,6 +16467,7 @@
 		"artist": "BEMANI Sound Team \"Power Of Nature\"",
 		"data": {
 			"basename": "indi",
+			"ddrSongHash": "P18io0P06q09qiId0lP6OO901li96bbl",
 			"flareCategory": "GOLD",
 			"inGameID": 38657
 		},
@@ -15292,6 +16480,7 @@
 		"artist": "BEMANI Sound Team \"dj TAKA\"",
 		"data": {
 			"basename": "rink",
+			"ddrSongHash": "dIiD86llO8biiDollQ1ioIoQl6iQ8dbQ",
 			"flareCategory": "GOLD",
 			"inGameID": 38658
 		},
@@ -15304,6 +16493,7 @@
 		"artist": "Kaname",
 		"data": {
 			"basename": "odys",
+			"ddrSongHash": "I18Iolqio01IlPi9QIqPQ8Q9O6iOod0O",
 			"flareCategory": "NONE",
 			"inGameID": 38659
 		},
@@ -15316,6 +16506,7 @@
 		"artist": "アツムワンダフル",
 		"data": {
 			"basename": "drat",
+			"ddrSongHash": "l08OoDq6P9DIQo1Po0Pdd80qoq6QID9o",
 			"flareCategory": "NONE",
 			"inGameID": 38660
 		},
@@ -15328,6 +16519,7 @@
 		"artist": "SK MUSIC",
 		"data": {
 			"basename": "hyno",
+			"ddrSongHash": "DoOoDio1q81OQdoOO0b6bPQPOoq6I0Qi",
 			"flareCategory": "NONE",
 			"inGameID": 38661
 		},
@@ -15340,6 +16532,7 @@
 		"artist": "みーに feat. はらもりよしな",
 		"data": {
 			"basename": "baaw",
+			"ddrSongHash": "iQi1DOQoqI6Q08I89PQD8iIQloPd190I",
 			"flareCategory": "NONE",
 			"inGameID": 38662
 		},
@@ -15352,6 +16545,7 @@
 		"artist": "OMOCHI feat.星野奏子",
 		"data": {
 			"basename": "arca",
+			"ddrSongHash": "6qdbqO66oOo1Q0d6I10IIIbQI9D1dDP6",
 			"flareCategory": "NONE",
 			"inGameID": 38663
 		},
@@ -15364,6 +16558,7 @@
 		"artist": "赤木エリ & BJ.chika feat. 菜月なこ",
 		"data": {
 			"basename": "dflo",
+			"ddrSongHash": "1d6oI0ol8oO8O1qq16O96d1D19doD0bl",
 			"flareCategory": "NONE",
 			"inGameID": 38664
 		},
@@ -15376,6 +16571,7 @@
 		"artist": "X-END",
 		"data": {
 			"basename": "grco",
+			"ddrSongHash": "1iPqdbQiqoi9l8D6Q106i01DbOO8191b",
 			"flareCategory": "NONE",
 			"inGameID": 38665
 		},
@@ -15388,6 +16584,7 @@
 		"artist": "Malixi",
 		"data": {
 			"basename": "swfr",
+			"ddrSongHash": "bbID6DO6PiIOQ1oDl1oiOd1bI9bQPi69",
 			"flareCategory": "NONE",
 			"inGameID": 38666
 		},
@@ -15400,6 +16597,7 @@
 		"artist": "Kolaa",
 		"data": {
 			"basename": "kyok",
+			"ddrSongHash": "1bo1qQDPidPPOlD16Ii9PoQOlQ996qb8",
 			"flareCategory": "NONE",
 			"inGameID": 38667
 		},
@@ -15412,6 +16610,7 @@
 		"artist": "MUGIPONG",
 		"data": {
 			"basename": "woco",
+			"ddrSongHash": "lDdID1ili0D0i10bdiO06Q8OqDIdo91l",
 			"flareCategory": "NONE",
 			"inGameID": 38668
 		},
@@ -15424,6 +16623,7 @@
 		"artist": "Felysrator",
 		"data": {
 			"basename": "roli",
+			"ddrSongHash": "QoD9DQ8QQ11ib0Idob9dbIQqbq0Q8Q6i",
 			"flareCategory": "NONE",
 			"inGameID": 38669
 		},
@@ -15436,6 +16636,7 @@
 		"artist": "Amebre Kizami",
 		"data": {
 			"basename": "hera",
+			"ddrSongHash": "1lIi8O100iq1Plolql1biO1QIOOillOQ",
 			"flareCategory": "NONE",
 			"inGameID": 38670
 		},
@@ -15448,6 +16649,7 @@
 		"artist": "MYUKKE.",
 		"data": {
 			"basename": "th88",
+			"ddrSongHash": "D6ql9DIOPi9Id8iiOOi1olOPdO9dl1qQ",
 			"flareCategory": "NONE",
 			"inGameID": 38671
 		},
@@ -15460,6 +16662,7 @@
 		"artist": "Se-U-Ra",
 		"data": {
 			"basename": "asbo",
+			"ddrSongHash": "lO990qi9qq9II1boI10ObdbbolQ1Ii0i",
 			"flareCategory": "NONE",
 			"inGameID": 38672
 		},
@@ -15472,6 +16675,7 @@
 		"artist": "setu-O",
 		"data": {
 			"basename": "fiac",
+			"ddrSongHash": "odb1D9l8QoDbii0861iP0qo9i1qibqdP",
 			"flareCategory": "NONE",
 			"inGameID": 38677
 		},
@@ -15484,6 +16688,7 @@
 		"artist": "SPACELECTRO",
 		"data": {
 			"basename": "haji",
+			"ddrSongHash": "8i0QblodqDQ196b0Oi81I0811QI99Q8b",
 			"flareCategory": "NONE",
 			"inGameID": 38678
 		},
@@ -15496,6 +16701,7 @@
 		"artist": "Alkome",
 		"data": {
 			"basename": "orpu",
+			"ddrSongHash": "1PQDi1P0dd6bIi9bQ0P0IQId808bPi1Q",
 			"flareCategory": "NONE",
 			"inGameID": 38680
 		},
@@ -15508,6 +16714,7 @@
 		"artist": "Halv",
 		"data": {
 			"basename": "dshc",
+			"ddrSongHash": "iQ0qQP11I8I9D9oIdllbP6989PDiiPoI",
 			"flareCategory": "NONE",
 			"inGameID": 38688
 		},
@@ -15520,6 +16727,7 @@
 		"artist": "nagomu tamaki feat. ぽめ",
 		"data": {
 			"basename": "kiun",
+			"ddrSongHash": "id8lqDol8I889lO9ld0Qbqd9O6PoQlld",
 			"flareCategory": "NONE",
 			"inGameID": 38691
 		},
@@ -15532,6 +16740,7 @@
 		"artist": "kors k feat. haru",
 		"data": {
 			"basename": "movo",
+			"ddrSongHash": "QQODQlOodQdbOdO6iQPi89PPIQi9oodQ",
 			"flareCategory": "NONE",
 			"inGameID": 38692
 		},
@@ -15544,6 +16753,7 @@
 		"artist": "nc feat. TOCORO十 ",
 		"data": {
 			"basename": "odva",
+			"ddrSongHash": "8IoP10odbqPdPPbIq01OID99o98DIoQl",
 			"flareCategory": "NONE",
 			"inGameID": 38693
 		},
@@ -15556,6 +16766,7 @@
 		"artist": "SOUND HOLIC feat. taru",
 		"data": {
 			"basename": "nise",
+			"ddrSongHash": "9QP8IdI00QP101lQPPQbP89DIDQPoD0d",
 			"flareCategory": "NONE",
 			"inGameID": 38694
 		},
@@ -15568,6 +16779,7 @@
 		"artist": "Shoichiro Hirata feat. ちょぴん ",
 		"data": {
 			"basename": "hd2u",
+			"ddrSongHash": "OlPqPi1qq1bIlDPOQQPi80D0lOQl8PP8",
 			"flareCategory": "NONE",
 			"inGameID": 38695
 		},
@@ -15580,6 +16792,7 @@
 		"artist": "青龍",
 		"data": {
 			"basename": "y3s3",
+			"ddrSongHash": "loD8qPl09qqi0o1iqbbDOdllDblioDIl",
 			"flareCategory": "GOLD",
 			"inGameID": 38701
 		},
@@ -15592,6 +16805,7 @@
 		"artist": "U-ske feat. 棗いつき",
 		"data": {
 			"basename": "cosc",
+			"ddrSongHash": "9ioI0IQ16OPb1Q0q8Oqdd6D9dPqDb618",
 			"flareCategory": "GOLD",
 			"inGameID": 38702
 		},
@@ -15604,6 +16818,7 @@
 		"artist": "BEMANI Sound Team \"二代目朱雀 feat.朱雀\"",
 		"data": {
 			"basename": "toyo",
+			"ddrSongHash": "00qIiO99Q18biD8bQ6d1QOooDP00O1Od",
 			"flareCategory": "GOLD",
 			"inGameID": 38703
 		},
@@ -15616,6 +16831,7 @@
 		"artist": "Yukopi",
 		"data": {
 			"basename": "kyal",
+			"ddrSongHash": "b86i9lPlObdl1008PO0PIi09q9o9l88i",
 			"flareCategory": "NONE",
 			"inGameID": 38704
 		},
@@ -15628,6 +16844,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"basename": "vamp",
+			"ddrSongHash": "Dl09QdQ19IoQl6D81qdlPPIdolP1lDi0",
 			"flareCategory": "NONE",
 			"inGameID": 38705
 		},
@@ -15640,6 +16857,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"basename": "tokm",
+			"ddrSongHash": "dQlo0DDqlIPod6bq89DPDODllDOi681i",
 			"flareCategory": "NONE",
 			"inGameID": 38706
 		},
@@ -15664,6 +16882,7 @@
 		"artist": "BEMANI Sound Team",
 		"data": {
 			"basename": "smxx",
+			"ddrSongHash": "Oo66i08qboI8PDbdQoiIb9qQ1i99oboP",
 			"flareCategory": "GOLD",
 			"inGameID": 38708
 		},
@@ -15676,6 +16895,7 @@
 		"artist": "Zektbach",
 		"data": {
 			"basename": "kaga",
+			"ddrSongHash": "88qq1I89IQ8P9PdqbbdD0ood8oi9d68I",
 			"flareCategory": "NONE",
 			"inGameID": 38710
 		},
@@ -15688,6 +16908,7 @@
 		"artist": "Des-ROW・組",
 		"data": {
 			"basename": "sets",
+			"ddrSongHash": "qib6O1d6010d8Iql8IQ0q8diqOP6dIqb",
 			"flareCategory": "NONE",
 			"inGameID": 38711
 		},
@@ -15700,6 +16921,7 @@
 		"artist": "猫叉Master",
 		"data": {
 			"basename": "beea",
+			"ddrSongHash": "bP61iObqb9Oo1IOQOdlQ0idilOII9O66",
 			"flareCategory": "NONE",
 			"inGameID": 38712
 		},
@@ -15712,6 +16934,7 @@
 		"artist": "BEMANI Sound Team \"HuΣeR\" feat.Fernweh",
 		"data": {
 			"basename": "sazu",
+			"ddrSongHash": "Dl89dQdOQooI0i0DoPQd68db6di86PD8",
 			"flareCategory": "NONE",
 			"inGameID": 38713
 		},
@@ -15724,6 +16947,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"basename": "tyco",
+			"ddrSongHash": "0ODl10P0O10D1OQID91QiPlQd988bio8",
 			"flareCategory": "NONE",
 			"inGameID": 38714
 		},
@@ -15736,6 +16960,7 @@
 		"artist": "technoplanet",
 		"data": {
 			"basename": "~Yr",
+			"ddrSongHash": "Qib986b6oDqPl8IQiOoDOQ06IlbD68bl",
 			"flareCategory": "NONE",
 			"inGameID": 38715
 		},
@@ -15748,6 +16973,7 @@
 		"artist": "Risk Junk",
 		"data": {
 			"basename": "quav",
+			"ddrSongHash": "09P10l1q98b1DiDQdlIii0bld111O86D",
 			"flareCategory": "NONE",
 			"inGameID": 38716
 		},
@@ -15760,6 +16986,7 @@
 		"artist": "度胸兄弟",
 		"data": {
 			"basename": "diav",
+			"ddrSongHash": "Pdlib1o06DD6oIbdIdIoIqQqO8P896do",
 			"flareCategory": "NONE",
 			"inGameID": 38717
 		},
@@ -15772,6 +16999,7 @@
 		"artist": "DJ Mass MAD Izm*",
 		"data": {
 			"basename": "redf",
+			"ddrSongHash": "0b8lD690qQO1bDOib1IqiO0OO169o9IQ",
 			"flareCategory": "NONE",
 			"inGameID": 38718
 		},
@@ -15784,6 +17012,7 @@
 		"artist": "Xceon feat. Mayumi Morinaga",
 		"data": {
 			"basename": "tsba",
+			"ddrSongHash": "b9iI8O6bd0bq0I1OoooQ9i9iddidODbO",
 			"flareCategory": "NONE",
 			"inGameID": 38719
 		},
@@ -15796,6 +17025,7 @@
 		"artist": "Moe Shop",
 		"data": {
 			"basename": "meh4",
+			"ddrSongHash": "9DlbD6PI1IQQ9q0OIdD1I8olIPPo6dPl",
 			"flareCategory": "GOLD",
 			"inGameID": 38720
 		},
@@ -15808,6 +17038,7 @@
 		"artist": "B小町 ルビー（CV：伊駒ゆりえ）、有馬かな（CV：潘めぐみ）、MEMちょ（CV：大久保瑠美）",
 		"data": {
 			"basename": "saib",
+			"ddrSongHash": "0i8iq6bldDo9l0iDi9q9OqIoQOlqld0q",
 			"flareCategory": "NONE",
 			"inGameID": 38721
 		},
@@ -15820,6 +17051,7 @@
 		"artist": "原口沙輔",
 		"data": {
 			"basename": "hito",
+			"ddrSongHash": "iDli1d0oP8lI6i8Qobbilo86OIPIqQlb",
 			"flareCategory": "NONE",
 			"inGameID": 38722
 		},
@@ -15832,6 +17064,7 @@
 		"artist": "しぐれうい (9さい)",
 		"data": {
 			"basename": "shuk",
+			"ddrSongHash": "618q1bI6Odd9dqQd9Q8OIoOdolqi66lq",
 			"flareCategory": "NONE",
 			"inGameID": 38723
 		},
@@ -15844,6 +17077,7 @@
 		"artist": "いよわ",
 		"data": {
 			"basename": "kyuk",
+			"ddrSongHash": "8OlQb0IDIOD1qIIiIqI0l6ol06bbDiDi",
 			"flareCategory": "NONE",
 			"inGameID": 38724
 		},
@@ -15856,6 +17090,7 @@
 		"artist": "Pizuya's Cell VS BEMANI Sound Team \"dj TAKA\"",
 		"data": {
 			"basename": "hesk",
+			"ddrSongHash": "Pbd01POIdQPdl6IDd6D6oP0006o6iO00",
 			"flareCategory": "NONE",
 			"inGameID": 38727
 		},
@@ -15868,6 +17103,7 @@
 		"artist": "SOUND HOLIC Vs. BEMANI Sound Team \"KE!JU\" feat. Nana Takahashi",
 		"data": {
 			"basename": "zanz",
+			"ddrSongHash": "16Qb0Oib60oQ1Oql8P806dDd8D0boDi1",
 			"flareCategory": "NONE",
 			"inGameID": 38728
 		},
@@ -15880,6 +17116,7 @@
 		"artist": "Yukopi",
 		"data": {
 			"basename": "neok",
+			"ddrSongHash": "IdOQPlbD9d9IO16Pd1IDO0b88Qo0boO9",
 			"flareCategory": "NONE",
 			"inGameID": 38730
 		},
@@ -15892,6 +17129,7 @@
 		"artist": "Yukopi",
 		"data": {
 			"basename": "buta",
+			"ddrSongHash": "0bqi6lPDP1qOl9dIb0DD1I9i8l8OlbQb",
 			"flareCategory": "NONE",
 			"inGameID": 38731
 		},
@@ -15904,6 +17142,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"basename": "imkk",
+			"ddrSongHash": "d01QdIl6i69DqIbbQQd6IPOiQOObPdIi",
 			"flareCategory": "NONE",
 			"inGameID": 38733
 		},
@@ -15916,6 +17155,7 @@
 		"artist": "豚乙女×BEMANI Sound Team \"PON\"",
 		"data": {
 			"basename": "dama",
+			"ddrSongHash": "lDIO66Dqili0bD0Qo00iIlO6b100i8i0",
 			"flareCategory": "NONE",
 			"inGameID": 38735
 		},
@@ -15928,6 +17168,7 @@
 		"artist": "Amateras Records vs BEMANI Sound Team \"TATSUYA\" feat. miko",
 		"data": {
 			"basename": "suhr",
+			"ddrSongHash": "d1bdqOI8IPIO8i00Plq09d189lIbIo0I",
 			"flareCategory": "NONE",
 			"inGameID": 38736
 		},
@@ -15940,6 +17181,7 @@
 		"artist": "BEMANI Sound Team \"SYUNN\"",
 		"data": {
 			"basename": "safa2",
+			"ddrSongHash": "bd9dlo8IQOOdQD0dlPQ0bqqdOdl90ol0",
 			"flareCategory": "NONE",
 			"inGameID": 38737
 		},
@@ -15952,6 +17194,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"basename": "onga2",
+			"ddrSongHash": "bdP0IOiPiQ8OlIbD1QQO8O6dPQqqb1Qb",
 			"flareCategory": "NONE",
 			"inGameID": 38738
 		},
@@ -15964,6 +17207,7 @@
 		"artist": "幽閉サテライト feat. senya",
 		"data": {
 			"basename": "tumu",
+			"ddrSongHash": "QQ8IoPqdIb61D8o886oo8b6didDIPqql",
 			"flareCategory": "NONE",
 			"inGameID": 38739
 		},

--- a/seeds/scripts/test/match-type.test.ts
+++ b/seeds/scripts/test/match-type.test.ts
@@ -31,7 +31,7 @@ const MATCH_TYPE_CHECKS: Record<
 	MatchTypes,
 	| {
 			type: "SONGS";
-			fn: (s: SongDocument) => string | Array<string>;
+			fn: (s: any) => string | Array<string>;
 	  }
 	| {
 			type: "CHARTS";
@@ -62,31 +62,14 @@ const MATCH_TYPE_CHECKS: Record<
 	},
 	uscChartHash: { type: "CHARTS", fn: (c) => c.data.hashSHA1 },
 	ddrSongHash: {
-		type: "CHARTS",
-		fn: (c) => {
-			// if there's no ddrSongHash then it must be a konaste song
+		type: "SONGS",
+		fn: (s: SongDocument<"ddr">) => {
+			// if there's no ddrSongHash then it's a konaste song / we're missing seed data
 			// so just use the inGameID
-			if (c.data.ddrSongHash === undefined) {
-				return `${c.data.inGameID}-${c.difficulty}`;
+			if (s.data.ddrSongHash === undefined) {
+				return `${s.data.inGameID}`;
 			}
-
-			// edge case for the song "B4U (The Acolyte mix)"
-			//
-			// for some reason konmai decided to change its inGameID in DDR A3
-			// so now there's an a20plus version and an a3 version
-			// (see songIDs 37225 and 37310)
-			//
-			// unfortunately, they decided to keep the same ddrSongHash across both!
-			// so we manually distinguish it here.
-			const B4UAcolyteSongHash = "01lbO69qQiP691ll6DIiqPbIdd9O806o";
-			if (c.data.ddrSongHash === B4UAcolyteSongHash) {
-				if (c.versions[0] === "a20plus") {
-					return `${c.data.ddrSongHash}-${c.difficulty}-a20plus`;
-				}
-			}
-			// perhaps we could just merge the two "songs" together in the seeds to avoid all this?
-
-			return `${c.data.ddrSongHash}-${c.difficulty}`;
+			return s.data.ddrSongHash;
 		},
 	},
 };

--- a/seeds/scripts/test/match-type.test.ts
+++ b/seeds/scripts/test/match-type.test.ts
@@ -61,6 +61,34 @@ const MATCH_TYPE_CHECKS: Record<
 		},
 	},
 	uscChartHash: { type: "CHARTS", fn: (c) => c.data.hashSHA1 },
+	ddrSongHash: {
+		type: "CHARTS",
+		fn: (c) => {
+			// if there's no ddrSongHash then it must be a konaste song
+			// so just use the inGameID
+			if (c.data.ddrSongHash === undefined) {
+				return `${c.data.inGameID}-${c.difficulty}`;
+			}
+
+			// edge case for the song "B4U (The Acolyte mix)"
+			//
+			// for some reason konmai decided to change its inGameID in DDR A3
+			// so now there's an a20plus version and an a3 version
+			// (see songIDs 37225 and 37310)
+			//
+			// unfortunately, they decided to keep the same ddrSongHash across both!
+			// so we manually distinguish it here.
+			const B4UAcolyteSongHash = "01lbO69qQiP691ll6DIiqPbIdd9O806o";
+			if (c.data.ddrSongHash === B4UAcolyteSongHash) {
+				if (c.versions[0] === "a20plus") {
+					return `${c.data.ddrSongHash}-${c.difficulty}-a20plus`;
+				}
+			}
+			// perhaps we could just merge the two "songs" together in the seeds to avoid all this?
+
+			return `${c.data.ddrSongHash}-${c.difficulty}`;
+		},
+	},
 };
 
 let exitCode = 0;

--- a/server/src/lib/score-import/import-types/common/batch-manual/converter.ts
+++ b/server/src/lib/score-import/import-types/common/batch-manual/converter.ts
@@ -433,6 +433,10 @@ export async function ResolveMatchTypeToTachiData(
 		}
 
 		case "ddrSongHash": {
+			if (game !== "ddr") {
+				throw new InvalidScoreFailure(`ddrSongHash matchType can only be used on DDR.`);
+			}
+
 			const difficulty = AssertStrAsDifficulty(data.difficulty, game, context.playtype);
 
 			const song = await db.anySongs.ddr.findOne({


### PR DESCRIPTION
`ddrSongHash` is a 32-character hash used by the official DDR e-amusement website to identify a song.

I believe Tachi supported this match type in the past but I didn't look too much into it. Re-implementing this will allow users to use services that scrape DDR scores from e-amusement, such as 3icecream (however their timestamps can be unreliable; I'm working on my own tool as well).

I tried my best to figure it out without official documentation. If anything's missing, please advise!