### PR TITLE
feat: additional classes for gekichumai

### DIFF
--- a/client/src/lib/game-implementations.tsx
+++ b/client/src/lib/game-implementations.tsx
@@ -62,6 +62,11 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 						"linear-gradient(-45deg, #f0788a, #f48fb1, #9174c2, #79bcf2, #70a173, #f7ff99, #faca7d, #ff9d80, #f0788a)",
 					color: "var(--bs-dark)",
 				},
+				RAINBOW_EX: {
+					background:
+						"linear-gradient(-45deg, #0fa091, #0f98d5, #67087f, #d9007e, #f56e06)",
+					color: "var(--bs-light)",
+				},
 			},
 			dan: {
 				DAN_I: bgc("#3b66f1", "var(--bs-light)"),
@@ -368,6 +373,11 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 					background:
 						"linear-gradient(-45deg, #f0788a, #f48fb1, #9174c2, #79bcf2, #70a173, #f7ff99, #faca7d, #ff9d80, #f0788a)",
 					color: "var(--bs-dark)",
+				},
+				RAINBOW_EX: {
+					background:
+						"linear-gradient(-45deg, #0fa091, #0f98d5, #67087f, #d9007e, #f56e06)",
+					color: "var(--bs-light)",
 				},
 			},
 			matchingClass: {
@@ -739,6 +749,16 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 					background:
 						"linear-gradient(-45deg, #f0788a, #f48fb1, #9174c2, #79bcf2, #70a173, #f7ff99, #faca7d, #ff9d80, #f0788a)",
 					color: "var(--bs-dark)",
+				},
+				RAINBOW_PLUS: {
+					background:
+						"linear-gradient(-45deg, #f0788a, #f48fb1, #9174c2, #79bcf2, #70a173, #f7ff99, #faca7d, #ff9d80, #f0788a)",
+					color: "var(--bs-dark)",
+				},
+				RAINBOW_EX: {
+					background:
+						"linear-gradient(-45deg, #0fa091, #0f98d5, #67087f, #d9007e, #f56e06)",
+					color: "var(--bs-light)",
 				},
 			},
 		},

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -24,7 +24,8 @@ export const CHUNITHMColours = [
 	ClassValue("SILVER", "銀", "Silver: 13.25 - 14.49 Rating"),
 	ClassValue("GOLD", "金", "Gold: 14.50 - 15.24 Rating"),
 	ClassValue("PLATINUM", "鉑", "Platinum: 15.25 - 15.99 Rating"),
-	ClassValue("RAINBOW", "虹", "Rainbow: >=16 Rating"),
+	ClassValue("RAINBOW", "虹", "Rainbow: 16 - 16.99 Rating"),
+	ClassValue("RAINBOW_EX", "虹(極)", "Rainbow (Extreme): >=17 Rating"),
 ];
 
 export const CHUNITHMClasses = [

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -53,7 +53,8 @@ const MaimaiDXColours = [
 	ClassValue("SILVER", "Silver", "13000 - 13999 Rating"),
 	ClassValue("GOLD", "Gold", "14000 - 14499 Rating"),
 	ClassValue("PLATINUM", "Platinum", "14500 - 14999 Rating"),
-	ClassValue("RAINBOW", "Rainbow", ">=15000 Rating"),
+	ClassValue("RAINBOW", "Rainbow", "15000 - 15999 Rating"),
+	ClassValue("RAINBOW_EX", "Rainbow (EX)", ">=16000 Rating"),
 ];
 
 const MaimaiDXMatchingClasses = [

--- a/common/src/config/game-support/ongeki.ts
+++ b/common/src/config/game-support/ongeki.ts
@@ -14,16 +14,18 @@ export const ONGEKI_CONF = {
 } as const satisfies INTERNAL_GAME_CONFIG;
 
 export const OngekiColours = [
-	ClassValue("BLUE", "青", "Blue: 0 - 1.99 Rating"),
-	ClassValue("GREEN", "緑", "Green: 2 - 3.99 Rating"),
-	ClassValue("ORANGE", "橙", "Orange: 4 - 6.99 Rating"),
-	ClassValue("RED", "赤", "Red: 7 - 9.99 Rating"),
-	ClassValue("PURPLE", "紫", "Purple: 10 - 11.99 Rating"),
-	ClassValue("COPPER", "銅", "Copper: 12 - 12.99 Rating"),
-	ClassValue("SILVER", "銀", "Silver: 13 - 13.99 Rating"),
-	ClassValue("GOLD", "金", "Gold: 14.00 - 14.49 Rating"),
+	ClassValue("BLUE", "青", "Blue: 0.00 – 1.99 Rating"),
+	ClassValue("GREEN", "緑", "Green: 2.00 – 3.99 Rating"),
+	ClassValue("ORANGE", "橙", "Orange: 4.00 – 6.99 Rating"),
+	ClassValue("RED", "赤", "Red: 7.00 – 9.99 Rating"),
+	ClassValue("PURPLE", "紫", "Purple: 10.00 – 11.99 Rating"),
+	ClassValue("COPPER", "銅", "Copper: 12.00 – 12.99 Rating"),
+	ClassValue("SILVER", "銀", "Silver: 13.00 – 13.99 Rating"),
+	ClassValue("GOLD", "金", "Gold: 14.00 – 14.49 Rating"),
 	ClassValue("PLATINUM", "鉑", "Platinum: 14.50 - 14.99 Rating"),
-	ClassValue("RAINBOW", "虹", "Rainbow: >=15 Rating"),
+	ClassValue("RAINBOW", "虹", "Rainbow: 15.00 – 15.99 Rating"),
+	ClassValue("RAINBOW_PLUS", "虹+", "Rainbow +: 16.00 – 16.99 Rating"),
+	ClassValue("RAINBOW_EX", "虹(極)", "Rainbow (Extreme): >=17.00 Rating"),
 ];
 
 export const ONGEKI_SINGLE_CONF = {

--- a/common/src/constants/game.ts
+++ b/common/src/constants/game.ts
@@ -366,6 +366,7 @@ export enum CHUNITHM_COLOURS {
 	GOLD = 7,
 	PLATINUM = 8,
 	RAINBOW = 9,
+	RAINBOW_EX = 10,
 }
 
 export enum WACCA_STAGEUPS {
@@ -433,6 +434,7 @@ export enum MAIMAIDX_COLOURS {
 	GOLD = 8,
 	PLATINUM = 9,
 	RAINBOW = 10,
+	RAINBOW_EX = 11,
 }
 
 export enum MAIMAIDX_DANS {
@@ -595,4 +597,6 @@ export enum ONGEKI_COLOURS {
 	GOLD = 7,
 	PLATINUM = 8,
 	RAINBOW = 9,
+	RAINBOW_PLUS = 10,
+	RAINBOW_EX = 11,
 }

--- a/server/src/game-implementations/games/chunithm.test.ts
+++ b/server/src/game-implementations/games/chunithm.test.ts
@@ -90,6 +90,7 @@ t.test("CHUNITHM Implementation", (t) => {
 		f(14.5, "GOLD");
 		f(15.25, "PLATINUM");
 		f(16, "RAINBOW");
+		f(17, "RAINBOW_EX");
 
 		t.end();
 	});

--- a/server/src/game-implementations/games/chunithm.ts
+++ b/server/src/game-implementations/games/chunithm.ts
@@ -25,7 +25,9 @@ export const CHUNITHM_IMPL: GPTServerImplementation<"chunithm:Single"> = {
 				return null;
 			}
 
-			if (rating >= 16) {
+			if (rating >= 17) {
+				return "RAINBOW_EX";
+			} else if (rating >= 16) {
 				return "RAINBOW";
 			} else if (rating >= 15.25) {
 				return "PLATINUM";

--- a/server/src/game-implementations/games/maimaidx.test.ts
+++ b/server/src/game-implementations/games/maimaidx.test.ts
@@ -76,6 +76,7 @@ t.test("Maimai DX Implementation", (t) => {
 		f(null, null);
 		f(0, "WHITE");
 
+		f(16000, "RAINBOW_EX");
 		f(15000, "RAINBOW");
 		f(14500, "PLATINUM");
 		f(14000, "GOLD");

--- a/server/src/game-implementations/games/maimaidx.ts
+++ b/server/src/game-implementations/games/maimaidx.ts
@@ -27,7 +27,9 @@ export const MAIMAIDX_IMPL: GPTServerImplementation<"maimaidx:Single"> = {
 				return null;
 			}
 
-			if (rate >= 15000) {
+			if (rate >= 16000) {
+				return "RAINBOW_EX";
+			} else if (rate >= 15000) {
 				return "RAINBOW";
 			} else if (rate >= 14500) {
 				return "PLATINUM";

--- a/server/src/game-implementations/games/ongeki.test.ts
+++ b/server/src/game-implementations/games/ongeki.test.ts
@@ -92,6 +92,8 @@ t.test("ONGEKI Implementation", (t) => {
 		f(14, "GOLD");
 		f(14.5, "PLATINUM");
 		f(15, "RAINBOW");
+		f(16, "RAINBOW_PLUS");
+		f(17, "RAINBOW_EX");
 
 		t.end();
 	});

--- a/server/src/game-implementations/games/ongeki.ts
+++ b/server/src/game-implementations/games/ongeki.ts
@@ -66,7 +66,11 @@ export const ONGEKI_IMPL: GPTServerImplementation<"ongeki:Single"> = {
 				return null;
 			}
 
-			if (rating >= 15) {
+			if (rating >= 17) {
+				return "RAINBOW_EX";
+			} else if (rating >= 16) {
+				return "RAINBOW_PLUS";
+			} else if (rating >= 15) {
 				return "RAINBOW";
 			} else if (rating >= 14.5) {
 				return "PLATINUM";


### PR DESCRIPTION
This branch adds additional classes for Ongeki (16.00, 17.00), Chunithm (17.00) and maiDX (16k). Marking this as a draft because Chunithm and maiDX maintainers have to be on board, and there are details to discuss. The names of the new classes are basically placeholders. This is just a proposal that has been preliminarily discussed in the #general chat.

![pic1](https://github.com/user-attachments/assets/51877e77-9394-40ba-a5b9-32f069d0c0c1)

The motivation for these classes is "they are cool", and can be something to strive for. In all three games, achieving rainbow is generally considered easy as long as you play seriously, and definitely can't be considered endgame. Ongeki in particular has experienced severe rating inflation, hence there is also "Rainbow +" at the halfway point. I'm still not sure about that one.

The term 虹(極) and the purple/blue gradient is an official designation for achieving combined 50k rating in all three games (for example ,17.00 Ongeki + 17.00 Chunithm + 16k maiDX). As for the English name:
* "rainbow extreme" is a literal translation of 虹(極). 
* "rating master" is a nameplate received for achieving rating 17.00 in Ongeki.
* "true rainbow" is a term some people use. 

Things to consider:
* Whether this is a good idea in the first place.
* Whether to call it 虹(極) or just 極 for consistency, and then there's maimai.
* What to call it in English (see above).
* Whether it would be a better idea to put it a new separate enum, just in case S*GA decides to shake things up (unlikely but possible) .
  * If not, I don't know how it would affect the existing data.
* Whether to include maimai classic.

Finally, to back this up with data, our current leaderboards are as follows:

  | Chunithm | Ongeki | maiDX
-- | -- | -- | --
≥ 17.00 | 20 | 1 | *N/A*
≥ 16.00 | 147 | 25 | 44
≥ 15.00 | *N/A* | 60 | 156
≥ 10.00 | 478 | 131 | 313

10.00 has been chosen semi-arbitrarily for counting the number of players (players below 10.00 often don't have enough scores to fill the naiverating window). Percentages of players against that 10.00 baseline is as follows: 
  | Chunithm | Ongeki | maiDX
-- | -- | -- | --
≥ 17.00 | 4.18% | 0.76% | *N/A* <sub><sup><sub><sup>literally impossible</sup></sub></sup></sub>
≥ 16.00 | 30.75% | 19.08% | 14.06%
≥ 15.00 | *N/A* | 45.80% | 49.84%

![pic2](https://github.com/user-attachments/assets/2aef436b-a5fe-4c05-87d0-f3e7748da644)

PS Turns out Chunithm actually introduced this purple gradient for rating 17.00 *as I was writing this comment*