### PR TITLE
fix: floating-point profile rating calculation

### DIFF
--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -1,6 +1,6 @@
 import { FAST_SLOW_MAXCOMBO } from "./_common";
 import { FmtNum } from "../../utils/util";
-import { ClassValue, zodNonNegativeInt } from "../config-utils";
+import { ClassValue, ToDecimalPlaces, zodNonNegativeInt } from "../config-utils";
 import { p } from "prudence";
 import { z } from "zod";
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_PT_CONFIG } from "../../types/internals";
@@ -87,15 +87,20 @@ export const CHUNITHM_SINGLE_CONF = {
 		rating: {
 			description:
 				"The rating value of this score. This is identical to the system used in game.",
+			formatter: ToDecimalPlaces(2),
 		},
 	},
 	sessionRatingAlgs: {
-		naiveRating: { description: "The average of your best 10 ratings this session." },
+		naiveRating: {
+			description: "The average of your best 10 ratings this session.",
+			formatter: ToDecimalPlaces(2),
+		},
 	},
 	profileRatingAlgs: {
 		naiveRating: {
 			description:
 				"The average of your best 30 ratings. This is different to in-game, as it does not take into account your recent scores in any way.",
+			formatter: ToDecimalPlaces(2),
 		},
 	},
 

--- a/common/src/config/game-support/ongeki.ts
+++ b/common/src/config/game-support/ongeki.ts
@@ -1,6 +1,6 @@
 import { FAST_SLOW_MAXCOMBO } from "./_common";
 import { FmtNum } from "../../utils/util";
-import { ClassValue } from "../config-utils";
+import { ClassValue, ToDecimalPlaces } from "../config-utils";
 import { p } from "prudence";
 import { z } from "zod";
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_PT_CONFIG } from "../../types/internals";
@@ -112,14 +112,19 @@ export const ONGEKI_SINGLE_CONF = {
 		rating: {
 			description:
 				"The rating value of this score. This is identical to the system used in game.",
+			formatter: ToDecimalPlaces(2),
 		},
 	},
 	sessionRatingAlgs: {
-		naiveRating: { description: "The average of your best 10 ratings this session." },
+		naiveRating: {
+			description: "The average of your best 10 ratings this session.",
+			formatter: ToDecimalPlaces(2),
+		},
 	},
 	profileRatingAlgs: {
 		naiveRating: {
 			description: "The average of your best 45 scores.",
+			formatter: ToDecimalPlaces(2),
 		},
 	},
 

--- a/server/src/game-implementations/games/chunithm.ts
+++ b/server/src/game-implementations/games/chunithm.ts
@@ -16,7 +16,7 @@ export const CHUNITHM_IMPL: GPTServerImplementation<"chunithm:Single"> = {
 		rating: (scoreData, chart) => CHUNITHMRating.calculate(scoreData.score, chart.levelNum),
 	},
 	sessionCalcs: { naiveRating: SessionAvgBest10For("rating") },
-	profileCalcs: { naiveRating: ProfileAvgBestN("rating", 30) },
+	profileCalcs: { naiveRating: ProfileAvgBestN("rating", 30, false, 100) },
 	classDerivers: {
 		colour: (ratings) => {
 			const rating = ratings.naiveRating;

--- a/server/src/game-implementations/games/ongeki.test.ts
+++ b/server/src/game-implementations/games/ongeki.test.ts
@@ -76,10 +76,8 @@ t.test("ONGEKI Implementation", (t) => {
 		t.beforeEach(ResetDBState);
 
 		const mockPBs = async (ratings: Array<number>) => {
-			const p = [];
-
-			for (const [idx, rating] of ratings.entries()) {
-				p.push(
+			await Promise.all(
+				ratings.map((rating, idx) =>
 					db["personal-bests"].insert({
 						...TestingOngekiScorePB,
 						chartID: `TEST${idx}`,
@@ -88,23 +86,12 @@ t.test("ONGEKI Implementation", (t) => {
 							rating,
 						},
 					})
-				);
-			}
-
-			await Promise.all(p);
+				)
+			);
 		};
 
 		t.test("Floating-point edge case", async (t) => {
-			await mockPBs([
-				17, 16.9, 16.7, 16.61, 16.55, 16.4, 16.4, 16.4, 16.39, 16.35, 16.33, 16.32, 16.31,
-				16.3, 16.28, 16.28, 16.27, 16.27, 16.25, 16.25, 16.24, 16.24, 16.23, 16.21, 16.2,
-				16.2, 16.2, 16.2, 16.18, 16.17, 16.17, 16.16, 16.15, 16.14, 16.14, 16.13, 16.11,
-				16.1, 16.1, 16.06, 16.06, 16.06, 16.05, 16.05, 16.04, 16.02, 16.01, 16.01, 16, 16,
-				16, 16, 15.98, 15.98, 15.98, 15.97, 15.97, 15.94, 15.94, 15.93, 15.93, 15.92, 15.92,
-				15.92, 15.91, 15.91, 15.91, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9,
-				15.88, 15.88, 15.88, 15.88, 15.87, 15.87, 15.87, 15.86, 15.86, 15.85, 15.84, 15.83,
-				15.82, 15.8, 15.8, 15.8, 15.8, 15.8, 15.79, 15.79, 15.78, 15.78, 15.78, 15.77,
-			]);
+			await mockPBs(Array(45).fill(16.27));
 
 			t.equal(await ONGEKI_IMPL.profileCalcs.naiveRating("ongeki", "Single", 1), 16.27);
 

--- a/server/src/game-implementations/games/ongeki.test.ts
+++ b/server/src/game-implementations/games/ongeki.test.ts
@@ -6,7 +6,7 @@ import { ONGEKI_BELL_LAMPS, ONGEKI_GRADES, ONGEKI_NOTE_LAMPS } from "tachi-commo
 import t from "tap";
 import { dmf, mkMockPB, mkMockScore } from "test-utils/misc";
 import ResetDBState from "test-utils/resets";
-import { TestingOngekiChart } from "test-utils/test-data";
+import { TestingOngekiChart, TestingOngekiScorePB } from "test-utils/test-data";
 import type { ProvidedMetrics, ScoreData } from "tachi-common";
 
 const baseMetrics: ProvidedMetrics["ongeki:Single"] = {
@@ -71,7 +71,56 @@ t.test("ONGEKI Implementation", (t) => {
 	});
 
 	t.todo("Session Calcs");
-	t.todo("Profile Calcs");
+
+	t.test("Profile Calcs", (t) => {
+		t.beforeEach(ResetDBState);
+
+		const mockPBs = async (ratings: Array<number>) => {
+			const p = [];
+
+			for (const [idx, rating] of ratings.entries()) {
+				p.push(
+					db["personal-bests"].insert({
+						...TestingOngekiScorePB,
+						chartID: `TEST${idx}`,
+						calculatedData: {
+							...TestingOngekiScorePB.calculatedData,
+							rating,
+						},
+					})
+				);
+			}
+
+			await Promise.all(p);
+		};
+
+		t.test("Floating-point edge case", async (t) => {
+			await mockPBs([
+				17, 16.9, 16.7, 16.61, 16.55, 16.4, 16.4, 16.4, 16.39, 16.35, 16.33, 16.32, 16.31,
+				16.3, 16.28, 16.28, 16.27, 16.27, 16.25, 16.25, 16.24, 16.24, 16.23, 16.21, 16.2,
+				16.2, 16.2, 16.2, 16.18, 16.17, 16.17, 16.16, 16.15, 16.14, 16.14, 16.13, 16.11,
+				16.1, 16.1, 16.06, 16.06, 16.06, 16.05, 16.05, 16.04, 16.02, 16.01, 16.01, 16, 16,
+				16, 16, 15.98, 15.98, 15.98, 15.97, 15.97, 15.94, 15.94, 15.93, 15.93, 15.92, 15.92,
+				15.92, 15.91, 15.91, 15.91, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9, 15.9,
+				15.88, 15.88, 15.88, 15.88, 15.87, 15.87, 15.87, 15.86, 15.86, 15.85, 15.84, 15.83,
+				15.82, 15.8, 15.8, 15.8, 15.8, 15.8, 15.79, 15.79, 15.78, 15.78, 15.78, 15.77,
+			]);
+
+			t.equal(await ONGEKI_IMPL.profileCalcs.naiveRating("ongeki", "Single", 1), 16.27);
+
+			t.end();
+		});
+
+		t.test("Profile with fewer than 45 scores", async (t) => {
+			await mockPBs([16, 16, 16, 16]);
+
+			t.equal(await ONGEKI_IMPL.profileCalcs.naiveRating("ongeki", "Single", 1), 1.42);
+
+			t.end();
+		});
+
+		t.end();
+	});
 
 	t.test("Colour Deriver", (t) => {
 		const f = (v: number | null, expected: any) =>

--- a/server/src/game-implementations/games/ongeki.ts
+++ b/server/src/game-implementations/games/ongeki.ts
@@ -56,7 +56,7 @@ export const ONGEKI_IMPL: GPTServerImplementation<"ongeki:Single"> = {
 	},
 	sessionCalcs: { naiveRating: SessionAvgBest10For("rating") },
 	profileCalcs: {
-		naiveRating: ProfileAvgBestN("rating", 45),
+		naiveRating: ProfileAvgBestN("rating", 45, false, 100),
 	},
 	classDerivers: {
 		colour: (ratings) => {

--- a/server/src/test-utils/test-data.ts
+++ b/server/src/test-utils/test-data.ts
@@ -1380,6 +1380,41 @@ export const TestingOngekiChart: ChartDocument<"ongeki:Single"> = {
 	versions: ["brightMemory3", "brightMemory3Omni"],
 };
 
+export const TestingOngekiScorePB: PBScoreDocument<"ongeki:Single"> = {
+	chartID: "213796bdb6150f80ba6412ce69df1249e16c0cb0",
+	userID: 1,
+	calculatedData: {
+		rating: 17,
+	},
+	composedFrom: [{ name: "Best Score", scoreID: "TESTING_SCORE_ID" }],
+	highlight: false,
+	isPrimary: true,
+	scoreData: {
+		score: 1010000,
+		noteLamp: "ALL BREAK",
+		bellLamp: "FULL BELL",
+		grade: "SSS+",
+		enumIndexes: {
+			grade: 11,
+			noteLamp: 3,
+			bellLamp: 1,
+		},
+		judgements: {},
+		optional: {
+			enumIndexes: {},
+		},
+	},
+	rankingData: {
+		rank: 1,
+		outOf: 1,
+		rivalRank: null,
+	},
+	songID: 19,
+	game: "ongeki",
+	playtype: "Single",
+	timeAchieved: 10000,
+};
+
 export const TestingOngekiChartConverter: ChartDocument<"ongeki:Single"> = {
 	chartID: "e5e4ee3d4feb233c399751b3ba3daf8ba149c9e6",
 	data: {

--- a/server/src/test-utils/test-data.ts
+++ b/server/src/test-utils/test-data.ts
@@ -651,6 +651,39 @@ export const CHUNITHMBBKKChart: ChartDocument<"chunithm:Single"> = {
 	versions: ["paradiselost"],
 };
 
+export const TestingChunithmScorePB: PBScoreDocument<"chunithm:Single"> = {
+	chartID: "192b96bdb6150f80ba6412ce02df1249e16c0cb0",
+	userID: 1,
+	calculatedData: {
+		rating: 5,
+	},
+	composedFrom: [{ name: "Best Score", scoreID: "TESTING_SCORE_ID" }],
+	highlight: false,
+	isPrimary: true,
+	scoreData: {
+		score: 1010000,
+		lamp: "ALL JUSTICE CRITICAL",
+		grade: "SSS+",
+		enumIndexes: {
+			grade: 13,
+			lamp: 4,
+		},
+		judgements: {},
+		optional: {
+			enumIndexes: {},
+		},
+	},
+	rankingData: {
+		rank: 1,
+		outOf: 1,
+		rivalRank: null,
+	},
+	songID: 3,
+	game: "chunithm",
+	playtype: "Single",
+	timeAchieved: 10000,
+};
+
 export const TestingDoraChart: ChartDocument<"gitadora:Dora"> = {
 	songID: 0,
 	chartID: "29f0bfab357ba54e3fd0176fb3cbc578c9ec8df5",


### PR DESCRIPTION
Added a new parameter to `CalcN`. If active (I activated it for Ongeki and Chunithm, although all games with non-integer ratings are possibly affected), profile rating will be calculated using fixed-point arithmetic. This is basically https://github.com/zkrising/rg-stats/pull/10 but for profile rating.

This fixes edge cases *like my current rating* as well as these wacky rating graphs (since rating is now truncated as it should be):

![image](https://github.com/user-attachments/assets/e9af8eb1-026d-4e88-95ed-5211fd6021f9)

If you restore `ongeki.ts:59`, i.e. `naiveRating: ProfileAvgBestN("rating", 45)`, the new tests will fail with ratings `16.269999999999996` `1.4222222222222223`. Likewise, `chunithm.ts:19`.

An alternative fix would be to re-define rating and store it multiplied by 100 in the DB but that would require fixing old scores.