### PR TITLE
update sdvx konaste seeds and add alt title

### DIFF
--- a/seeds/collections/charts-sdvx.json
+++ b/seeds/collections/charts-sdvx.json
@@ -129276,7 +129276,8 @@
 		"playtype": "Single",
 		"songID": 1822,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -129291,7 +129292,8 @@
 		"playtype": "Single",
 		"songID": 1822,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -129316,7 +129318,8 @@
 		"playtype": "Single",
 		"songID": 1822,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -129331,7 +129334,8 @@
 		"playtype": "Single",
 		"songID": 1822,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -142210,7 +142214,8 @@
 		"playtype": "Single",
 		"songID": 2094,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -142230,7 +142235,8 @@
 		"playtype": "Single",
 		"songID": 2094,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -142255,7 +142261,8 @@
 		"playtype": "Single",
 		"songID": 2094,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -142270,7 +142277,8 @@
 		"playtype": "Single",
 		"songID": 2094,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{

--- a/seeds/collections/songs-sdvx.json
+++ b/seeds/collections/songs-sdvx.json
@@ -24804,7 +24804,9 @@
 		"title": "Ahoy!! 我ら宝鐘海賊団☆"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"I’m Your Treasure Box ＊あなたは マリンせんちょうを たからばこからみつけた。"
+		],
 		"artist": "宝鐘マリン",
 		"data": {
 			"displayVersion": "exceed"


### PR DESCRIPTION
2 songs were made available for konaste on [10/31](https://x.com/SOUNDVOLTEX573/status/1851084470365147414)

alt title from CSV import was added from a discord bug report