### PR TITLE
Replace - with space for youtube searches, adjust maimai search 

### DIFF
--- a/client/src/components/game/charts/ChartInfoFormat.tsx
+++ b/client/src/components/game/charts/ChartInfoFormat.tsx
@@ -187,8 +187,10 @@ function ChartInfoMiddle({
 	const gameConfig = GetGameConfig(game);
 
 	const diff = FormatDifficultySearch(chart, game);
-	const gameName = game === "ongeki" ? "オンゲキ" : gameConfig.name;
-	let search = `${gameName} ${song.title}`;
+	const gameName = game === "ongeki" ? "オンゲキ" : game === "maimaidx" ? "maimaiでらくす" : gameConfig.name;
+	const formattedTitle = song.title.replace(/-/g, ' ');
+	
+	let search = `${gameName} ${formattedTitle}`;
 
 	if (diff !== null) {
 		search += ` ${diff}`;


### PR DESCRIPTION
"Contrapasso -paradiso-" doesn't search properly since - excludes paradiso as a search boolean.
https://kamai.tachi.ac/games/maimaidx/Single/songs/275/Master
This replaces all - with spaces.

Also changed maimai dx to maimaiでらくす since it yields better search results.