### PR TITLE
[chunithm] Update seeds to 2025/02/27

### DIFF
--- a/seeds/collections/charts-chunithm.json
+++ b/seeds/collections/charts-chunithm.json
@@ -2169,6 +2169,7 @@
 		"songID": 35,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -60538,6 +60539,7 @@
 		"songID": 628,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159196,6 +159198,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159214,6 +159217,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159232,6 +159236,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159250,6 +159255,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159268,6 +159274,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159286,6 +159293,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159304,6 +159312,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159322,6 +159331,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159340,6 +159350,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159358,6 +159369,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159376,6 +159388,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159394,6 +159407,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159412,6 +159426,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159430,6 +159445,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159448,6 +159464,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159466,6 +159483,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159484,6 +159502,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159502,6 +159521,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159520,6 +159540,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -159538,6 +159559,7 @@
 			"luminous",
 			"luminous-omni",
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -165902,6 +165924,7 @@
 		"songID": 2605,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -165918,6 +165941,7 @@
 		"songID": 2605,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -165934,6 +165958,7 @@
 		"songID": 2605,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -165950,6 +165975,7 @@
 		"songID": 2605,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167054,6 +167080,7 @@
 		"songID": 2629,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167070,6 +167097,7 @@
 		"songID": 2629,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167086,6 +167114,7 @@
 		"songID": 2629,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167102,6 +167131,7 @@
 		"songID": 2629,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167118,6 +167148,7 @@
 		"songID": 2630,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167134,6 +167165,7 @@
 		"songID": 2630,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167150,6 +167182,7 @@
 		"songID": 2630,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167166,6 +167199,7 @@
 		"songID": 2630,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167182,6 +167216,7 @@
 		"songID": 2631,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167198,6 +167233,7 @@
 		"songID": 2631,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167214,6 +167250,7 @@
 		"songID": 2631,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167230,6 +167267,7 @@
 		"songID": 2631,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167246,6 +167284,7 @@
 		"songID": 2632,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167262,6 +167301,7 @@
 		"songID": 2632,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167278,6 +167318,7 @@
 		"songID": 2632,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167294,6 +167335,7 @@
 		"songID": 2632,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167310,6 +167352,7 @@
 		"songID": 2633,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167326,6 +167369,7 @@
 		"songID": 2633,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167342,6 +167386,7 @@
 		"songID": 2633,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167358,6 +167403,7 @@
 		"songID": 2633,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167374,6 +167420,7 @@
 		"songID": 2634,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167390,6 +167437,7 @@
 		"songID": 2634,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167406,6 +167454,7 @@
 		"songID": 2634,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167422,6 +167471,7 @@
 		"songID": 2634,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167438,6 +167488,7 @@
 		"songID": 2635,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167454,6 +167505,7 @@
 		"songID": 2635,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167470,6 +167522,7 @@
 		"songID": 2635,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167486,6 +167539,7 @@
 		"songID": 2635,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167570,6 +167624,7 @@
 		"songID": 2637,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167586,6 +167641,7 @@
 		"songID": 2637,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167602,6 +167658,7 @@
 		"songID": 2637,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167618,6 +167675,7 @@
 		"songID": 2637,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167634,6 +167692,7 @@
 		"songID": 2638,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167650,6 +167709,7 @@
 		"songID": 2638,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167666,6 +167726,7 @@
 		"songID": 2638,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167682,6 +167743,7 @@
 		"songID": 2638,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167698,6 +167760,7 @@
 		"songID": 2639,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167714,6 +167777,7 @@
 		"songID": 2639,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167730,6 +167794,7 @@
 		"songID": 2639,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167746,6 +167811,7 @@
 		"songID": 2639,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167762,6 +167828,7 @@
 		"songID": 2641,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167778,6 +167845,7 @@
 		"songID": 2641,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167794,6 +167862,7 @@
 		"songID": 2641,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167810,6 +167879,7 @@
 		"songID": 2641,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167826,6 +167896,7 @@
 		"songID": 2642,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167842,6 +167913,7 @@
 		"songID": 2642,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167858,6 +167930,7 @@
 		"songID": 2642,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167874,6 +167947,7 @@
 		"songID": 2642,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167890,6 +167964,7 @@
 		"songID": 2643,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167906,6 +167981,7 @@
 		"songID": 2643,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167922,6 +167998,7 @@
 		"songID": 2643,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -167938,6 +168015,7 @@
 		"songID": 2643,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169190,6 +169268,7 @@
 		"songID": 2673,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169206,6 +169285,7 @@
 		"songID": 2673,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169222,6 +169302,7 @@
 		"songID": 2673,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169238,6 +169319,7 @@
 		"songID": 2673,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169254,6 +169336,7 @@
 		"songID": 2674,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169270,6 +169353,7 @@
 		"songID": 2674,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169286,6 +169370,7 @@
 		"songID": 2674,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169302,6 +169387,7 @@
 		"songID": 2674,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169386,6 +169472,7 @@
 		"songID": 2676,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169402,6 +169489,7 @@
 		"songID": 2676,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169418,6 +169506,7 @@
 		"songID": 2676,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169434,6 +169523,7 @@
 		"songID": 2676,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169450,6 +169540,7 @@
 		"songID": 2677,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169466,6 +169557,7 @@
 		"songID": 2677,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169482,6 +169574,7 @@
 		"songID": 2677,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169498,6 +169591,7 @@
 		"songID": 2677,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169514,6 +169608,7 @@
 		"songID": 2677,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169530,6 +169625,7 @@
 		"songID": 2679,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169546,6 +169642,7 @@
 		"songID": 2679,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169562,6 +169659,7 @@
 		"songID": 2679,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169578,6 +169676,7 @@
 		"songID": 2679,
 		"versions": [
 			"luminousplus",
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	},
@@ -169706,6 +169805,134 @@
 		"songID": 2681,
 		"versions": [
 			"luminousplus",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "40e2d721eda52ec7601b32902fd47a84300a2917",
+		"data": {
+			"inGameID": 2739
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "8+",
+		"levelNum": 8.5,
+		"playtype": "Single",
+		"songID": 2739,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "d8c09c9c9b27ae7038a7485427d306f1e87cca94",
+		"data": {
+			"inGameID": 2739
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2739,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "bc7755a3eaa43e9752fc87f31b594f0a6ccefa74",
+		"data": {
+			"inGameID": 2739
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14.4,
+		"playtype": "Single",
+		"songID": 2739,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "f60f45cdcf9d963b51010fc1278497ea2bfc0343",
+		"data": {
+			"inGameID": 2739
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15.3,
+		"playtype": "Single",
+		"songID": 2739,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "4c621a64d48ca40f53fa4d8c3b6ba7504b0f90e4",
+		"data": {
+			"inGameID": 2744
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"songID": 2744,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "a43b3fb1670c9337a8fc331d53b74700ced7e4fd",
+		"data": {
+			"inGameID": 2744
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2744,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "edbc548fe8ef6ffa83c68ee75289dac03ee0192d",
+		"data": {
+			"inGameID": 2744
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13.3,
+		"playtype": "Single",
+		"songID": 2744,
+		"versions": [
+			"luminousplus-intl",
+			"luminousplus-omni"
+		]
+	},
+	{
+		"chartID": "9d9ab3605b75d087839e1958bef994cdc6787ec0",
+		"data": {
+			"inGameID": 2744
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15.2,
+		"playtype": "Single",
+		"songID": 2744,
+		"versions": [
+			"luminousplus-intl",
 			"luminousplus-omni"
 		]
 	}

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -20249,5 +20249,27 @@
 			"ultramarine signal"
 		],
 		"title": "群青シグナル"
+	},
+	{
+		"altTitles": [],
+		"artist": "void (Mournfinale) × 水野健治",
+		"data": {
+			"displayVersion": "luminousplus",
+			"genre": "ORIGINAL"
+		},
+		"id": 2739,
+		"searchTerms": [],
+		"title": "Aether Crest: Celestial"
+	},
+	{
+		"altTitles": [],
+		"artist": "MintJam vs Masahiro \"Godspeed\" Aoki",
+		"data": {
+			"displayVersion": "luminousplus",
+			"genre": "ORIGINAL"
+		},
+		"id": 2744,
+		"searchTerms": [],
+		"title": "Crush the Dystopia"
 	}
 ]


### PR DESCRIPTION
Aside from the two new songs for King of Performai 6th:
- void (Mournfinale) × 水野健治 - Aether Crest: Celestial
- MintJam vs Masahiro "Godspeed" Aoki - Crush the Dystopia

this just updates the international table to the current version. I haven't been able to catch up recently due to personal circumstances. Sorry about that.