### PR TITLE
[bot] Add minimum threshold for maimai/maimai DX color class updates

### DIFF
--- a/bot/src/webhookHandlers/classUpdate.ts
+++ b/bot/src/webhookHandlers/classUpdate.ts
@@ -117,6 +117,10 @@ function GetMinimumScores(
 		return 20;
 	} else if (game === "ddr") {
 		return 90;
+	} else if (game === "maimai" && classSet === "colour") {
+		return 30;
+	} else if (game === "maimaidx" && classSet === "colour") {
+		return 50;
 	}
 
 	return null;


### PR DESCRIPTION
maimai's rating is best30 and maimai DX's rating is best50, so if the user doesn't have enough scores to fill their best rating frame they will blitz through most of the lower ranks.