### PR TITLE
chore(deps): update rg-stats to 0.5.10

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -68,7 +68,7 @@
 		"react-router-bootstrap": "^0.25.0",
 		"react-router-dom": "5.1.2",
 		"react-select": "^5.6.1",
-		"rg-stats": "0.5.8",
+		"rg-stats": "0.5.10",
 		"sync-fetch": "^0.3.1",
 		"tachi-common": "workspace:../common",
 		"vite-plugin-html": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^5.6.1
         version: 5.6.1(@babel/core@7.1.0)(@types/react@17.0.13)(react-dom@17.0.2)(react@17.0.2)
       rg-stats:
-        specifier: 0.5.8
-        version: 0.5.8
+        specifier: 0.5.10
+        version: 0.5.10
       sync-fetch:
         specifier: ^0.3.1
         version: 0.3.1
@@ -659,8 +659,8 @@ importers:
         specifier: 3.1.2
         version: 3.1.2
       rg-stats:
-        specifier: 0.5.8
-        version: 0.5.8
+        specifier: 0.5.10
+        version: 0.5.10
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -10244,8 +10244,8 @@ packages:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
     dev: false
 
-  /rg-stats@0.5.8:
-    resolution: {integrity: sha512-AqhksXLcwACA3Af1XQkJhVSeQtFlu6NggmTqxXvw7BLDiaOsTJDZn4+gnk4XlJtf+7U0nlrMKUFM8ZlHCNFjXA==}
+  /rg-stats@0.5.10:
+    resolution: {integrity: sha512-UZfB5PFnaiSInlcQMTYXgvMvWqd9wiHd9mQX5Ecf1VT/JJI2ycdFYJXU8lVLA6eyxYaHpx66E+HvweCIt+q4fw==}
     dev: false
 
   /rimraf@2.4.5:

--- a/server/package.json
+++ b/server/package.json
@@ -97,7 +97,7 @@
 		"prudence": "0.10.0",
 		"rate-limit-redis": "2.1.0",
 		"redis": "3.1.2",
-		"rg-stats": "0.5.8",
+		"rg-stats": "0.5.10",
 		"rimraf": "3.0.2",
 		"safe-json-stringify": "1.2.0",
 		"semver": "^7.3.7",


### PR DESCRIPTION
This version of rg-stats fixes a bug with maimai rating for scores between 100% and max (https://github.com/zkrising/rg-stats/pull/14).

Requires a recalc on all scores >=100%.