### PR TITLE
feat(seeds): update chunithm to 27/03/25

### DIFF
--- a/seeds/collections/charts-chunithm.json
+++ b/seeds/collections/charts-chunithm.json
@@ -185035,6 +185035,321 @@
 		]
 	},
 	{
+		"chartID": "703f17d48101ddcd0789a30f3b6ffff9842dfefc",
+		"data": {
+			"inGameID": 2745
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2745,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "1bece4ddea0231fe4d0c0efeffd6a9dcaaebdd1d",
+		"data": {
+			"inGameID": 2745
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2745,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "6ee850163234757bec362fad9b46f42df29f942f",
+		"data": {
+			"inGameID": 2745
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10.2,
+		"playtype": "Single",
+		"songID": 2745,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "fdf0c6b218fc631a781e2e4b5ea584afedafb2ad",
+		"data": {
+			"inGameID": 2745
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14.2,
+		"playtype": "Single",
+		"songID": 2745,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "eba8fa8481f671553e6462800cb1eae4a0462c48",
+		"data": {
+			"inGameID": 2746
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2746,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "e668436f139d067046fe9a42a38d921d22708abb",
+		"data": {
+			"inGameID": 2746
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"songID": 2746,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "5e30a4d6f79ae206c390c20ebb88afc1a151cf53",
+		"data": {
+			"inGameID": 2746
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "9+",
+		"levelNum": 9.5,
+		"playtype": "Single",
+		"songID": 2746,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "05bd2d57984deadc526a23d87ee015e1ebc807d5",
+		"data": {
+			"inGameID": 2746
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "12+",
+		"levelNum": 12.9,
+		"playtype": "Single",
+		"songID": 2746,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "b0559590f484e679bcbb309f72ebb88a0befae99",
+		"data": {
+			"inGameID": 2746
+		},
+		"difficulty": "ULTIMA",
+		"isPrimary": true,
+		"level": "14+",
+		"levelNum": 14.6,
+		"playtype": "Single",
+		"songID": 2746,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "8416919ed26bd6b23fa9188d76b4895f231c9546",
+		"data": {
+			"inGameID": 2747
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2747,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "45b6aedf7cf45d9ee56f02c0e037822d5144307c",
+		"data": {
+			"inGameID": 2747
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2747,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "a3dfc5581e83ad81e6044806d10fe45eedf7effa",
+		"data": {
+			"inGameID": 2747
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"songID": 2747,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "a114ca64aa6c492ddf2794e06f1399fa55c27a46",
+		"data": {
+			"inGameID": 2747
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.5,
+		"playtype": "Single",
+		"songID": 2747,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "3e6d95e0fe7463d904bebe311b7a1ba2d793a27a",
+		"data": {
+			"inGameID": 2748
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2748,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "29eaa52fee6083ca9a0db836a67172b95e8caf37",
+		"data": {
+			"inGameID": 2748
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2748,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "dca8a10f415ee474e557e0bb56f73cf207e773cc",
+		"data": {
+			"inGameID": 2748
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "10+",
+		"levelNum": 10.5,
+		"playtype": "Single",
+		"songID": 2748,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "a9eaf932a20e1bc33d5c940d59226b6928150ec4",
+		"data": {
+			"inGameID": 2748
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.6,
+		"playtype": "Single",
+		"songID": 2748,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "05e833157f91df184df85faf27a744ad93c966d3",
+		"data": {
+			"inGameID": 2749
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2749,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "f40084a87083326d3c3af2d48e701fff13992a1f",
+		"data": {
+			"inGameID": 2749
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2749,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "a819f8e164ac86dddc706d384b6e6a11f708772b",
+		"data": {
+			"inGameID": 2749
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"songID": 2749,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "26835086cf0a0a607a86726536a4f09003f7004d",
+		"data": {
+			"inGameID": 2749
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.8,
+		"playtype": "Single",
+		"songID": 2749,
+		"versions": [
+			"verse"
+		]
+	},
+	{
 		"chartID": "2ab91979f187bc5bcfe624d105b84c15dead6965",
 		"data": {
 			"inGameID": 2750
@@ -185672,6 +185987,66 @@
 		"versions": [
 			"verse",
 			"verse-omni"
+		]
+	},
+	{
+		"chartID": "1a6d73f1155c90b42fcc542b7aa816be1bfb64f6",
+		"data": {
+			"inGameID": 2800
+		},
+		"difficulty": "ADVANCED",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"songID": 2800,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "1add6f76902dc5b6e06992d49fa811da68b20105",
+		"data": {
+			"inGameID": 2800
+		},
+		"difficulty": "BASIC",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2800,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "cbbfc7ef221708f55a04e88c8483be93f77348f4",
+		"data": {
+			"inGameID": 2800
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.7,
+		"playtype": "Single",
+		"songID": 2800,
+		"versions": [
+			"verse"
+		]
+	},
+	{
+		"chartID": "1a42341f79eb38bdea8b23557a6426dc218f26e2",
+		"data": {
+			"inGameID": 2800
+		},
+		"difficulty": "MASTER",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"songID": 2800,
+		"versions": [
+			"verse"
 		]
 	},
 	{

--- a/seeds/collections/charts-chunithm.json
+++ b/seeds/collections/charts-chunithm.json
@@ -185046,7 +185046,8 @@
 		"playtype": "Single",
 		"songID": 2745,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185061,7 +185062,8 @@
 		"playtype": "Single",
 		"songID": 2745,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185076,7 +185078,8 @@
 		"playtype": "Single",
 		"songID": 2745,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185091,7 +185094,8 @@
 		"playtype": "Single",
 		"songID": 2745,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185106,7 +185110,8 @@
 		"playtype": "Single",
 		"songID": 2746,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185121,7 +185126,8 @@
 		"playtype": "Single",
 		"songID": 2746,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185136,7 +185142,8 @@
 		"playtype": "Single",
 		"songID": 2746,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185151,7 +185158,8 @@
 		"playtype": "Single",
 		"songID": 2746,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185166,7 +185174,8 @@
 		"playtype": "Single",
 		"songID": 2746,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185181,7 +185190,8 @@
 		"playtype": "Single",
 		"songID": 2747,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185196,7 +185206,8 @@
 		"playtype": "Single",
 		"songID": 2747,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185211,7 +185222,8 @@
 		"playtype": "Single",
 		"songID": 2747,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185226,7 +185238,8 @@
 		"playtype": "Single",
 		"songID": 2747,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185241,7 +185254,8 @@
 		"playtype": "Single",
 		"songID": 2748,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185256,7 +185270,8 @@
 		"playtype": "Single",
 		"songID": 2748,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185271,7 +185286,8 @@
 		"playtype": "Single",
 		"songID": 2748,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185286,7 +185302,8 @@
 		"playtype": "Single",
 		"songID": 2748,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185301,7 +185318,8 @@
 		"playtype": "Single",
 		"songID": 2749,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185316,7 +185334,8 @@
 		"playtype": "Single",
 		"songID": 2749,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185331,7 +185350,8 @@
 		"playtype": "Single",
 		"songID": 2749,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -185346,7 +185366,8 @@
 		"playtype": "Single",
 		"songID": 2749,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -186001,7 +186022,8 @@
 		"playtype": "Single",
 		"songID": 2800,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -186016,7 +186038,8 @@
 		"playtype": "Single",
 		"songID": 2800,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -186031,7 +186054,8 @@
 		"playtype": "Single",
 		"songID": 2800,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{
@@ -186046,7 +186070,8 @@
 		"playtype": "Single",
 		"songID": 2800,
 		"versions": [
-			"verse"
+			"verse",
+			"verse-omni"
 		]
 	},
 	{

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -20798,6 +20798,61 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "原口沙輔 feat.重音テト",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "niconico"
+		},
+		"id": 2745,
+		"searchTerms": [],
+		"title": "人マニア"
+	},
+	{
+		"altTitles": [],
+		"artist": "吉田夜世",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "niconico"
+		},
+		"id": 2746,
+		"searchTerms": [],
+		"title": "オーバーライド"
+	},
+	{
+		"altTitles": [],
+		"artist": "マサラダ",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "niconico"
+		},
+		"id": 2747,
+		"searchTerms": [],
+		"title": "ライアーダンサー"
+	},
+	{
+		"altTitles": [],
+		"artist": "フロクロ",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "niconico"
+		},
+		"id": 2748,
+		"searchTerms": [],
+		"title": "黒塗り世界宛て書簡"
+	},
+	{
+		"altTitles": [],
+		"artist": "曲：eba／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "ゲキマイ"
+		},
+		"id": 2749,
+		"searchTerms": [],
+		"title": "本能的 Survivor"
+	},
+	{
+		"altTitles": [],
 		"artist": "Reku Mochizuki",
 		"data": {
 			"displayVersion": "verse",
@@ -20908,6 +20963,17 @@
 			"funeral song for you and me"
 		],
 		"title": "キミとボクへの葬送歌"
+	},
+	{
+		"altTitles": [],
+		"artist": "打打だいず vs. siromaru vs. Tanchiky",
+		"data": {
+			"displayVersion": "verse",
+			"genre": "ゲキマイ"
+		},
+		"id": 2800,
+		"searchTerms": [],
+		"title": "淵底のグレイ・ユークロニア"
 	},
 	{
 		"altTitles": [],


### PR DESCRIPTION
# changelog
- teto update:
	- 原口沙輔 feat.重音テト - 人マニア
	- 吉田夜世 - オーバーライド
	- マサラダ - ライアーダンサー
	- フロクロ - 黒塗り世界宛て書簡
- ongeki collab:
	- 曲：eba／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)] - 本能的 Survivor
	- 打打だいず vs. siromaru vs. Tanchiky - 淵底のグレイ・ユークロニア

data from the amazing @beer-psi as always.