### PR TITLE
fix(client): "e is undefined" in session search

### DIFF
--- a/client/src/components/tables/components/TachiTable.tsx
+++ b/client/src/components/tables/components/TachiTable.tsx
@@ -168,7 +168,7 @@ export default function TachiTable<D>({
 					<tbody>
 						<NoDataWrapper>
 							{window.map((e, i) => (
-								<React.Fragment key={i}>{rowFunction(e)}</React.Fragment>
+								<React.Fragment key={i}>{e && rowFunction(e)}</React.Fragment>
 							))}
 						</NoDataWrapper>
 					</tbody>

--- a/client/src/components/tables/sessions/GenericSessionTable.tsx
+++ b/client/src/components/tables/sessions/GenericSessionTable.tsx
@@ -129,7 +129,7 @@ function Row({
 				{data.scoreIDs.length}
 				<br />
 				<small className="text-body-secondary">
-					PBs: {GetPBs(data.__related.scoreInfo).length}
+					{data.__related?.scoreInfo && `PBs: ${GetPBs(data.__related.scoreInfo).length}`}
 				</small>
 			</td>
 			<td>


### PR DESCRIPTION
This simple nullish check prevents `"error": "e is undefined"` when typing anything in a session search bar. Admittedly this is a band-aid fix, as the PB data is still missing, but at least it doesn't crash.