### PR TITLE
Fix NAG/GAN jb import using DEV url

### DIFF
--- a/server/src/lib/score-import/import-types/parsers.ts
+++ b/server/src/lib/score-import/import-types/parsers.ts
@@ -15,9 +15,11 @@ import {
 	ParseCGGanMuseca,
 	ParseCGGanPopn,
 	ParseCGGanSDVX,
+	ParseCGGanJubeat,
 	ParseCGNagMuseca,
 	ParseCGNagPopn,
 	ParseCGNagSDVX,
+	ParseCGNagJubeat,
 } from "./common/api-cg/parsers";
 import ParseBatchManual from "./file/batch-manual/parser";
 import ParseEamusementIIDXCSV from "./file/eamusement-iidx-csv/parser";
@@ -61,12 +63,12 @@ export const Parsers = {
 	"api/cg-nag-sdvx": ParseCGNagSDVX,
 	"api/cg-nag-popn": ParseCGNagPopn,
 	"api/cg-nag-museca": ParseCGNagMuseca,
-	"api/cg-nag-jubeat": ParseCGDevJubeat,
+	"api/cg-nag-jubeat": ParseCGNagJubeat,
 
 	"api/cg-gan-sdvx": ParseCGGanSDVX,
 	"api/cg-gan-popn": ParseCGGanPopn,
 	"api/cg-gan-museca": ParseCGGanMuseca,
-	"api/cg-gan-jubeat": ParseCGDevJubeat,
+	"api/cg-gan-jubeat": ParseCGGanJubeat,
 
 	"api/myt-chunithm": ParseMytChunithm,
 	"api/myt-maimaidx": ParseMytMaimaiDx,


### PR DESCRIPTION
Fix a bug introduced in https://github.com/zkrising/Tachi/commit/c254b69d40ff3828e938e7fb3038d5058a00c45d where importing from GAN or NAG would use DEV url instead, thus importing DEV scores.