### PR TITLE
fix: jubeat music rate rounding in GAN/NAG/CGD API imports

### DIFF
--- a/server/src/lib/score-import/import-types/common/api-cg/jb/converter.test.ts
+++ b/server/src/lib/score-import/import-types/common/api-cg/jb/converter.test.ts
@@ -21,7 +21,7 @@ function mkInput(modifant: Partial<CGJubeatScore> = {}) {
 		goodCount: 25,
 		poorCount: 0,
 		missCount: 0,
-		musicRate: 950,
+		musicRate: 952,
 		clearFlag: 0, // unknown, unused
 	};
 
@@ -48,7 +48,7 @@ function mkOutput(modifant: any = {}): DryScore<"jubeat:Single"> {
 				good: 25,
 				poor: 0,
 			},
-			musicRate: 95.0,
+			musicRate: 95.2,
 			optional: {},
 		},
 		scoreMeta: {},

--- a/server/src/lib/score-import/import-types/common/api-cg/jb/converter.ts
+++ b/server/src/lib/score-import/import-types/common/api-cg/jb/converter.ts
@@ -122,7 +122,7 @@ function ConvertVersion(ver: number): Versions["jubeat:Single"] {
 }
 
 function ConvertMusicRate(rate: number): number {
-	return Math.round(rate / 10);
+	return rate / 10;
 }
 
 function GuessLamp(judgments: Record<Judgements["jubeat:Single"], integer | null>, score: number) {


### PR DESCRIPTION
Patch is actually by @defvs who worked on the affected jubeat import, he sent me the patch because he does not have access to GitHub during the day.