### PR TITLE
fix(api-cg/jb): use clearFlag bitfield to generate Lamp

### DIFF
--- a/server/src/lib/score-import/import-types/common/api-cg/jb/converter.ts
+++ b/server/src/lib/score-import/import-types/common/api-cg/jb/converter.ts
@@ -28,7 +28,7 @@ export const ConverterAPICGJubeat: ConverterFunction<CGJubeatScore, CGContext> =
 		poor: data.poorCount,
 		miss: data.missCount,
 	};
-	const lamp = GuessLamp(judgements, data.score);
+	const lamp = GetLamp(data.clearFlag);
 
 	const chart = await FindChartOnInGameID("jubeat", data.internalId, "Single", difficulty);
 
@@ -125,23 +125,23 @@ function ConvertMusicRate(rate: number): number {
 	return rate / 10;
 }
 
-function GuessLamp(judgments: Record<Judgements["jubeat:Single"], integer | null>, score: number) {
-	if (
-		judgments.good === 0 &&
-		judgments.great === 0 &&
-		judgments.miss === 0 &&
-		judgments.poor === 0
-	) {
-		if (score !== 1_000_000) {
-			throw new InvalidScoreFailure(`Score is an EXC, yet score !== 1_000_000.`);
-		}
-
+/* eslint-disable no-bitwise */
+function GetLamp(clearFlag: integer) {
+	if ((clearFlag & (1 << 3)) !== 0) {
 		return "EXCELLENT";
-	} else if (judgments.miss === 0 && judgments.poor === 0) {
+	}
+
+	if ((clearFlag & (1 << 2)) !== 0) {
 		return "FULL COMBO";
-	} else if (score >= 700_000) {
+	}
+
+	if ((clearFlag & (1 << 1)) !== 0) {
 		return "CLEAR";
 	}
 
-	return "FAILED";
+	if ((clearFlag & (1 << 0)) !== 0) {
+		return "FAILED";
+	}
+
+	throw new InvalidScoreFailure("Failed to decode Lamp using bitfield clearFlag.");
 }

--- a/server/src/lib/score-import/import-types/common/api-cg/types.ts
+++ b/server/src/lib/score-import/import-types/common/api-cg/types.ts
@@ -71,7 +71,7 @@ export interface CGJubeatScore {
 	internalId: integer;
 	difficulty: integer;
 	version: integer;
-	clearFlag: unknown; // Weird bitwise field, unused.
+	clearFlag: integer; // Weird bitwise field, unused.
 
 	score: integer;
 	hardMode: boolean;


### PR DESCRIPTION
Those bitfield values are taken from what the game sends - Radio told me that this is supposedly the same as what the CG API returns. **I cannot confirm it. I do not have CG API access. Please test this outside of prod.**.

I got the bitfield values from actually dumping the network calls of my own cab, there's further stuff in the MSB of the bitfield but these seem mostly useless.

Here are the bit positions:

| 31:4             | 3   | 2  | 1     | 0            |
|------------------|-----|----|-------|--------------|
| ? | EXC | FC | CLEAR | FAILED/SAVED |

I've created various tests for that as well - including the edge case of a 'challenge fail'.