### PR TITLE
feat(client): chunithm graphs, song durations

### DIFF
--- a/client/src/components/charts/GekichuScoreChart.tsx
+++ b/client/src/components/charts/GekichuScoreChart.tsx
@@ -123,23 +123,24 @@ export default function GekichuScoreChart({
 } & ResponsiveLine["props"]) {
 	let color = COLOUR_SET.gray;
 
-	if (game === "chunithm") {
-		color =
-			GPT_CLIENT_IMPLEMENTATIONS["chunithm:Single"].difficultyColours[
-				difficulty as Difficulties["chunithm:Single"]
-			];
-	} else if (game === "ongeki") {
-		if (type === "Score") {
+	if (type === "Score") {
+		if (game === "chunithm") {
+			color =
+				GPT_CLIENT_IMPLEMENTATIONS["chunithm:Single"].difficultyColours[
+					difficulty as Difficulties["chunithm:Single"]
+				];
+		} else if (game === "ongeki") {
 			color =
 				GPT_CLIENT_IMPLEMENTATIONS["ongeki:Single"].difficultyColours[
 					difficulty as Difficulties["ongeki:Single"]
 				];
-		} else if (type === "Bells") {
-			color = COLOUR_SET.vibrantYellow;
-		} else {
-			color = COLOUR_SET.vibrantGreen;
 		}
+	} else if (type === "Bells") {
+		color = COLOUR_SET.vibrantYellow;
+	} else {
+		color = COLOUR_SET.vibrantGreen;
 	}
+
 	const gradientId = type === "Score" ? difficulty : type;
 
 	const commonProps: Omit<LineSvgProps, "data"> = {
@@ -195,7 +196,7 @@ export default function GekichuScoreChart({
 					)}
 				/>
 			);
-		} else {
+		} else if (game === "chunithm") {
 			component = (
 				<ResponsiveLine
 					{...commonProps}
@@ -242,19 +243,22 @@ export default function GekichuScoreChart({
 				)}
 			/>
 		);
-	} else {
+	} else if (type === "Life") {
+		const max = game === "ongeki" ? 100 : (data[0].data[0].y as number);
+		const suffix = game === "ongeki" ? "%" : "";
 		component = (
 			<ResponsiveLine
 				{...commonProps}
 				data={data}
-				yScale={{ type: "linear", min: 0, max: 100 }}
+				yScale={{ type: "linear", min: 0, max }}
 				enableGridY={false}
-				axisLeft={{ format: (d: number) => `${d}%` }}
+				axisLeft={{ format: (d: number) => `${d}${suffix}` }}
 				colors={strokeColor("BASIC")}
 				areaBaselineValue={0}
 				tooltip={(d: PointTooltipProps) => (
 					<ChartTooltip>
-						{d.point.data.y}% @ {formatTime(d.point.data.x)}
+						{d.point.data.y}
+						{suffix} @ {formatTime(d.point.data.x)}
 					</ChartTooltip>
 				)}
 			/>

--- a/client/src/components/charts/GekichuScoreChart.tsx
+++ b/client/src/components/charts/GekichuScoreChart.tsx
@@ -110,6 +110,7 @@ export default function GekichuScoreChart({
 	totalBellCount,
 	data,
 	game,
+	duration,
 }: {
 	mobileHeight?: number | string;
 	mobileWidth?: number | string;
@@ -120,6 +121,7 @@ export default function GekichuScoreChart({
 	totalBellCount?: number;
 	data: Serie[];
 	game: Game;
+	duration: number;
 } & ResponsiveLine["props"]) {
 	let color = COLOUR_SET.gray;
 
@@ -146,7 +148,7 @@ export default function GekichuScoreChart({
 	const commonProps: Omit<LineSvgProps, "data"> = {
 		margin: { top: 30, bottom: 50, left: 50, right: 50 },
 		enableGridX: false,
-		xScale: { type: "linear", min: 0, max: data[0].data.length - 1 },
+		xScale: { type: "linear", min: 0, max: duration },
 		axisBottom: { format: (d: number) => formatTime(d) },
 		motionConfig: "stiff",
 		crosshairType: "x",

--- a/client/src/components/charts/GekichuScoreChart.tsx
+++ b/client/src/components/charts/GekichuScoreChart.tsx
@@ -22,7 +22,7 @@ const formatTime = (s: DatumValue) =>
 		.toString()
 		.padStart(2, "0")}`;
 
-const scoreToLamp = (game: Game) => (s: number) => {
+const getScoreYAxisNotch = (game: Game) => (s: number) => {
 	if (game === "ongeki") {
 		switch (s) {
 			case 970_000:
@@ -184,7 +184,7 @@ export default function GekichuScoreChart({
 					yFormat={">-,.0f"}
 					axisLeft={{
 						tickValues: [970000, 990000, 1000000, 1007500, 1010000],
-						format: scoreToLamp(game),
+						format: getScoreYAxisNotch(game),
 					}}
 					gridYValues={[970000, 980000, 990000, 1000000, 1007500, 1010000]}
 					enableGridY={true}
@@ -207,7 +207,7 @@ export default function GekichuScoreChart({
 					yFormat={">-,.0f"}
 					axisLeft={{
 						tickValues: [990_000, 1000_000, 1005_000, 1007_500, 1009_000, 1010_000],
-						format: scoreToLamp(game),
+						format: getScoreYAxisNotch(game),
 					}}
 					gridYValues={[990_000, 1000_000, 1005_000, 1007_500, 1009_000, 1010_000]}
 					enableGridY={true}

--- a/client/src/components/tables/dropdowns/GPTDropdownSettings.tsx
+++ b/client/src/components/tables/dropdowns/GPTDropdownSettings.tsx
@@ -4,6 +4,7 @@ import { IIDXGraphsComponent } from "./components/IIDXScoreDropdownParts";
 import { ITGGraphsComponent } from "./components/ITGScoreDropdownParts";
 import { JubeatGraphsComponent } from "./components/JubeatScoreDropdownParts";
 import { OngekiGraphsComponent } from "./components/OngekiScoreDropdownParts";
+import { ChunithmGraphsComponent } from "./components/ChunithmScoreDropdownParts";
 
 export function GPTDropdownSettings(game: Game, playtype: Playtype): any {
 	if (game === "iidx") {
@@ -32,6 +33,11 @@ export function GPTDropdownSettings(game: Game, playtype: Playtype): any {
 		return {
 			renderScoreInfo: true,
 			GraphComponent: OngekiGraphsComponent as any,
+		};
+	} else if (game === "chunithm") {
+		return {
+			renderScoreInfo: true,
+			GraphComponent: ChunithmGraphsComponent as any,
 		};
 	}
 

--- a/client/src/components/tables/dropdowns/PBDropdown.tsx
+++ b/client/src/components/tables/dropdowns/PBDropdown.tsx
@@ -148,6 +148,7 @@ export default function PBDropdown({
 				pbData={data}
 				scoreState={scoreState}
 				chart={chart}
+				song={song}
 			/>
 		);
 	}

--- a/client/src/components/tables/dropdowns/ScoreDropdown.tsx
+++ b/client/src/components/tables/dropdowns/ScoreDropdown.tsx
@@ -120,10 +120,11 @@ export default function ScoreDropdown({
 				onScoreUpdate={onScoreUpdate}
 				pbData={data}
 				chart={chart}
+				song={song}
 			/>
 		);
 	} else if (view === "vsPB") {
-		body = <PBCompare data={data} DocComponent={DocComponent} scoreState={scoreState} />;
+		body = <PBCompare data={data} DocComponent={DocComponent as any} scoreState={scoreState} />;
 	} else if (view === "manage") {
 		body = <DeleteScoreBtn score={thisScore} />;
 	} else if (view === "targets") {

--- a/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import {
+	ChartDocument,
+	Difficulties,
+	PBScoreDocument,
+	ScoreData,
+	ScoreDocument,
+} from "tachi-common";
+import GekichuScoreChart from "components/charts/GekichuScoreChart";
+
+export function ChunithmGraphsComponent({
+	score,
+	chart,
+}: {
+	score: ScoreDocument<"chunithm:Single"> | PBScoreDocument<"chunithm:Single">;
+	chart: ChartDocument<"chunithm:Single">;
+}) {
+	const available = score.scoreData.optional.scoreGraph;
+
+	return (
+		<>
+			<div className="col-12">
+				{available ? (
+					<GraphComponent scoreData={score.scoreData} difficulty={chart.difficulty} />
+				) : (
+					<div
+						className="d-flex align-items-center justify-content-center"
+						style={{ height: "200px" }}
+					>
+						<span className="text-body-secondary">No charts available</span>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}
+
+function GraphComponent({
+	scoreData,
+	difficulty,
+}: {
+	scoreData: ScoreData<"chunithm:Single">;
+	difficulty: Difficulties["chunithm:Single"];
+}) {
+	const values = scoreData.optional.scoreGraph!;
+	return (
+		<GekichuScoreChart
+			height="360px"
+			mobileHeight="175px"
+			type="Score"
+			difficulty={difficulty}
+			data={[
+				{
+					id: "Score",
+					data: values.map((e, i) => ({ x: i, y: e })),
+				},
+			]}
+			game="chunithm"
+		/>
+	);
+}

--- a/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
 	ChartDocument,
 	Difficulties,
@@ -7,6 +7,10 @@ import {
 	ScoreDocument,
 } from "tachi-common";
 import GekichuScoreChart from "components/charts/GekichuScoreChart";
+import SelectNav from "components/util/SelectNav";
+import { Nav } from "react-bootstrap";
+
+type ChartTypes = "Score" | "Life";
 
 export function ChunithmGraphsComponent({
 	score,
@@ -15,13 +19,28 @@ export function ChunithmGraphsComponent({
 	score: ScoreDocument<"chunithm:Single"> | PBScoreDocument<"chunithm:Single">;
 	chart: ChartDocument<"chunithm:Single">;
 }) {
-	const available = score.scoreData.optional.scoreGraph;
+	const [graph, setGraph] = useState<ChartTypes>("Score");
+	const available = score.scoreData.optional.scoreGraph && score.scoreData.optional.lifeGraph;
 
 	return (
 		<>
+			<div className="col-12 d-flex justify-content-center">
+				<Nav variant="pills">
+					<SelectNav id="Score" value={graph} setValue={setGraph} disabled={!available}>
+						Score
+					</SelectNav>
+					<SelectNav id="Life" value={graph} setValue={setGraph} disabled={!available}>
+						Life
+					</SelectNav>
+				</Nav>
+			</div>
 			<div className="col-12">
 				{available ? (
-					<GraphComponent scoreData={score.scoreData} difficulty={chart.difficulty} />
+					<GraphComponent
+						type={graph}
+						scoreData={score.scoreData}
+						difficulty={chart.difficulty}
+					/>
 				) : (
 					<div
 						className="d-flex align-items-center justify-content-center"
@@ -38,20 +57,23 @@ export function ChunithmGraphsComponent({
 function GraphComponent({
 	scoreData,
 	difficulty,
+	type,
 }: {
 	scoreData: ScoreData<"chunithm:Single">;
 	difficulty: Difficulties["chunithm:Single"];
+	type: ChartTypes;
 }) {
-	const values = scoreData.optional.scoreGraph!;
+	const values =
+		type === "Score" ? scoreData.optional.scoreGraph! : scoreData.optional.lifeGraph!;
 	return (
 		<GekichuScoreChart
 			height="360px"
 			mobileHeight="175px"
-			type="Score"
+			type={type}
 			difficulty={difficulty}
 			data={[
 				{
-					id: "Score",
+					id: type,
 					data: values.map((e, i) => ({ x: i, y: e })),
 				},
 			]}

--- a/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
@@ -23,7 +23,10 @@ export function ChunithmGraphsComponent({
 	song: SongDocument<"chunithm">;
 }) {
 	const [graph, setGraph] = useState<ChartType>("Score");
-	const available = score.scoreData.optional.scoreGraph && score.scoreData.optional.lifeGraph;
+	const available =
+		score.scoreData.optional.scoreGraph &&
+		score.scoreData.optional.lifeGraph &&
+		song.data.duration !== undefined;
 
 	return (
 		<>
@@ -84,7 +87,7 @@ function GraphComponent({
 				},
 			]}
 			game="chunithm"
-			duration={song.data.duration}
+			duration={song.data.duration!}
 		/>
 	);
 }

--- a/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
@@ -5,21 +5,24 @@ import {
 	PBScoreDocument,
 	ScoreData,
 	ScoreDocument,
+	SongDocument,
 } from "tachi-common";
 import GekichuScoreChart from "components/charts/GekichuScoreChart";
 import SelectNav from "components/util/SelectNav";
 import { Nav } from "react-bootstrap";
 
-type ChartTypes = "Score" | "Life";
+type ChartType = "Score" | "Life";
 
 export function ChunithmGraphsComponent({
 	score,
 	chart,
+	song,
 }: {
 	score: ScoreDocument<"chunithm:Single"> | PBScoreDocument<"chunithm:Single">;
 	chart: ChartDocument<"chunithm:Single">;
+	song: SongDocument<"chunithm">;
 }) {
-	const [graph, setGraph] = useState<ChartTypes>("Score");
+	const [graph, setGraph] = useState<ChartType>("Score");
 	const available = score.scoreData.optional.scoreGraph && score.scoreData.optional.lifeGraph;
 
 	return (
@@ -40,6 +43,7 @@ export function ChunithmGraphsComponent({
 						type={graph}
 						scoreData={score.scoreData}
 						difficulty={chart.difficulty}
+						song={song}
 					/>
 				) : (
 					<div
@@ -56,12 +60,14 @@ export function ChunithmGraphsComponent({
 
 function GraphComponent({
 	scoreData,
+	song,
 	difficulty,
 	type,
 }: {
 	scoreData: ScoreData<"chunithm:Single">;
+	song: SongDocument<"chunithm">;
 	difficulty: Difficulties["chunithm:Single"];
-	type: ChartTypes;
+	type: ChartType;
 }) {
 	const values =
 		type === "Score" ? scoreData.optional.scoreGraph! : scoreData.optional.lifeGraph!;
@@ -78,6 +84,7 @@ function GraphComponent({
 				},
 			]}
 			game="chunithm"
+			duration={song.data.duration}
 		/>
 	);
 }

--- a/client/src/components/tables/dropdowns/components/DocumentComponent.tsx
+++ b/client/src/components/tables/dropdowns/components/DocumentComponent.tsx
@@ -1,10 +1,16 @@
 import { IsScore } from "util/asserts";
-import { FormatGPTProfileRatingName, UppercaseFirst } from "util/misc";
+import { FormatGPTProfileRatingName } from "util/misc";
 import TimestampCell from "components/tables/cells/TimestampCell";
 import ScoreCoreCells from "components/tables/game-core-cells/ScoreCoreCells";
 import useScoreRatingAlg from "components/util/useScoreRatingAlg";
 import React, { useContext, useEffect, useState } from "react";
-import { ChartDocument, GetGPTString, PBScoreDocument, ScoreDocument } from "tachi-common";
+import {
+	ChartDocument,
+	GetGPTString,
+	PBScoreDocument,
+	ScoreDocument,
+	SongDocument,
+} from "tachi-common";
 import { UGPTChartPBComposition } from "types/api-returns";
 import { SetState } from "types/react";
 import { UserContext } from "context/UserContext";
@@ -68,6 +74,7 @@ export default function DocumentComponent({
 	forceScoreData = false,
 	pbData,
 	chart,
+	song,
 	onScoreUpdate,
 }: {
 	score: ScoreDocument | PBScoreDocument;
@@ -81,14 +88,17 @@ export default function DocumentComponent({
 	pbData: UGPTChartPBComposition;
 	forceScoreData?: boolean;
 	chart: ChartDocument;
+	song: SongDocument;
 	onScoreUpdate?: (sc: ScoreDocument) => void;
 	GraphComponent?:
 		| (({
 				score,
 				chart,
+				song,
 		  }: {
 				score: ScoreDocument | PBScoreDocument;
 				chart: ChartDocument;
+				song: SongDocument;
 		  }) => JSX.Element)
 		| null;
 }) {
@@ -111,7 +121,7 @@ export default function DocumentComponent({
 			<div style={{ flex: 9 }}>
 				<div className="row h-100 justify-content-center">
 					{GraphComponent ? (
-						<GraphComponent chart={chart} score={score} />
+						<GraphComponent chart={chart} score={score} song={song} />
 					) : (
 						<div
 							className="d-flex align-items-center justify-content-center"

--- a/client/src/components/tables/dropdowns/components/OngekiScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/OngekiScoreDropdownParts.tsx
@@ -7,19 +7,22 @@ import {
 	PBScoreDocument,
 	ScoreData,
 	ScoreDocument,
+	SongDocument,
 } from "tachi-common";
 import GekichuScoreChart from "components/charts/GekichuScoreChart";
 
-type ChartTypes = "Score" | "Bells" | "Life";
+type ChartType = "Score" | "Bells" | "Life";
 
 export function OngekiGraphsComponent({
 	score,
 	chart,
+	song,
 }: {
 	score: ScoreDocument<"ongeki:Single"> | PBScoreDocument<"ongeki:Single">;
 	chart: ChartDocument<"ongeki:Single">;
+	song: SongDocument<"ongeki">;
 }) {
-	const [graph, setGraph] = useState<ChartTypes>("Score");
+	const [graph, setGraph] = useState<ChartType>("Score");
 	const available =
 		score.scoreData.optional.scoreGraph &&
 		score.scoreData.optional.bellGraph &&
@@ -47,6 +50,7 @@ export function OngekiGraphsComponent({
 					<GraphComponent
 						type={graph}
 						scoreData={score.scoreData}
+						song={song}
 						difficulty={chart.difficulty}
 					/>
 				) : (
@@ -65,10 +69,12 @@ export function OngekiGraphsComponent({
 function GraphComponent({
 	type,
 	scoreData,
+	song,
 	difficulty,
 }: {
-	type: ChartTypes;
+	type: ChartType;
 	scoreData: ScoreData<"ongeki:Single">;
+	song: SongDocument<"ongeki">;
 	difficulty: Difficulties["ongeki:Single"];
 }) {
 	const values =
@@ -91,6 +97,7 @@ function GraphComponent({
 				},
 			]}
 			game="ongeki"
+			duration={song.data.duration}
 		/>
 	);
 }

--- a/client/src/components/tables/dropdowns/components/OngekiScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/OngekiScoreDropdownParts.tsx
@@ -8,7 +8,7 @@ import {
 	ScoreData,
 	ScoreDocument,
 } from "tachi-common";
-import OngekiScoreChart from "components/charts/OngekiScoreChart";
+import GekichuScoreChart from "components/charts/GekichuScoreChart";
 
 type ChartTypes = "Score" | "Bells" | "Life";
 
@@ -78,7 +78,7 @@ function GraphComponent({
 			? scoreData.optional.bellGraph!
 			: scoreData.optional.lifeGraph!;
 	return (
-		<OngekiScoreChart
+		<GekichuScoreChart
 			height="360px"
 			mobileHeight="175px"
 			type={type}
@@ -90,6 +90,7 @@ function GraphComponent({
 					data: values.map((e, i) => ({ x: i, y: e })),
 				},
 			]}
+			game="ongeki"
 		/>
 	);
 }

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -87,6 +87,11 @@ export const CHUNITHM_SINGLE_CONF = {
 
 	optionalMetrics: {
 		...FAST_SLOW_MAXCOMBO,
+		scoreGraph: {
+			type: "NULLABLE_GRAPH",
+			validate: p.isBetween(0, 1010000),
+			description: "The history of the projected score, queried in one-second intervals.",
+		},
 	},
 
 	scoreRatingAlgs: {

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -92,6 +92,11 @@ export const CHUNITHM_SINGLE_CONF = {
 			validate: p.isBetween(0, 1010000),
 			description: "The history of the projected score, queried in one-second intervals.",
 		},
+		lifeGraph: {
+			type: "NULLABLE_GRAPH",
+			validate: p.isBetween(0, 999),
+			description: "Challenge gauge history, queried in one-second intervals.",
+		},
 	},
 
 	scoreRatingAlgs: {

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -11,6 +11,7 @@ export const CHUNITHM_CONF = {
 	songData: z.strictObject({
 		genre: z.string(),
 		displayVersion: z.string(),
+		duration: z.number(),
 	}),
 } as const satisfies INTERNAL_GAME_CONFIG;
 

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -89,12 +89,12 @@ export const CHUNITHM_SINGLE_CONF = {
 	optionalMetrics: {
 		...FAST_SLOW_MAXCOMBO,
 		scoreGraph: {
-			type: "NULLABLE_GRAPH",
+			type: "GRAPH",
 			validate: p.isBetween(0, 1010000),
 			description: "The history of the projected score, queried in one-second intervals.",
 		},
 		lifeGraph: {
-			type: "NULLABLE_GRAPH",
+			type: "GRAPH",
 			validate: p.isBetween(0, 999),
 			description: "Challenge gauge history, queried in one-second intervals.",
 		},

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -11,7 +11,7 @@ export const CHUNITHM_CONF = {
 	songData: z.strictObject({
 		genre: z.string(),
 		displayVersion: z.string(),
-		duration: z.number(),
+		duration: z.number().optional(),
 	}),
 } as const satisfies INTERNAL_GAME_CONFIG;
 

--- a/common/src/config/game-support/ongeki.ts
+++ b/common/src/config/game-support/ongeki.ts
@@ -19,6 +19,7 @@ export const ONGEKI_CONF = {
 			"LUNATIC",
 			"ボーナストラック",
 		]),
+		duration: z.number(),
 	}),
 } as const satisfies INTERNAL_GAME_CONFIG;
 

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -4,6 +4,7 @@
 		"artist": "BUMP OF CHICKEN [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.178,
 			"genre": "POPS & ANIME"
 		},
 		"id": 0,
@@ -17,6 +18,7 @@
 		"artist": "nora2r",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 128.541,
 			"genre": "VARIETY"
 		},
 		"id": 3,
@@ -28,6 +30,7 @@
 		"artist": "Scatman John",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.344,
 			"genre": "POPS & ANIME"
 		},
 		"id": 5,
@@ -39,6 +42,7 @@
 		"artist": "ソニック カラーズ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 112.315,
 			"genre": "VARIETY"
 		},
 		"id": 6,
@@ -52,6 +56,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 142.25,
 			"genre": "niconico"
 		},
 		"id": 7,
@@ -66,6 +71,7 @@
 		"artist": "→Pia-no-jaC←×葉加瀬 太郎",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 131.229,
 			"genre": "POPS & ANIME"
 		},
 		"id": 9,
@@ -79,6 +85,7 @@
 		"artist": "The Offspring",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 113.758,
 			"genre": "VARIETY"
 		},
 		"id": 10,
@@ -90,6 +97,7 @@
 		"artist": "Linked Horizon",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 93.563,
 			"genre": "POPS & ANIME"
 		},
 		"id": 12,
@@ -103,6 +111,7 @@
 		"artist": "ClariS 「魔法少女まどか☆マギカ」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 112.136,
 			"genre": "POPS & ANIME"
 		},
 		"id": 14,
@@ -116,6 +125,7 @@
 		"artist": "中川 翔子",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.418,
 			"genre": "POPS & ANIME"
 		},
 		"id": 17,
@@ -129,6 +139,7 @@
 		"artist": "黒うさP",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 155.065,
 			"genre": "niconico"
 		},
 		"id": 18,
@@ -144,6 +155,7 @@
 		"artist": "Nankumo/CUBE3",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 91.2,
 			"genre": "VARIETY"
 		},
 		"id": 19,
@@ -155,6 +167,7 @@
 		"artist": "REDALiCE (HARDCORE TANO*C)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 141.375,
 			"genre": "東方Project"
 		},
 		"id": 20,
@@ -168,6 +181,7 @@
 		"artist": "ビートまりお",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 113.522,
 			"genre": "東方Project"
 		},
 		"id": 21,
@@ -185,6 +199,7 @@
 		"artist": "れるりり",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 139.122,
 			"genre": "niconico"
 		},
 		"id": 23,
@@ -200,6 +215,7 @@
 		"artist": "ハチ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 141.19,
 			"genre": "niconico"
 		},
 		"id": 24,
@@ -213,6 +229,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 152.788,
 			"genre": "niconico"
 		},
 		"id": 27,
@@ -226,6 +243,7 @@
 		"artist": "目黒将司「ペルソナ4 ダンシング・オールナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.274,
 			"genre": "VARIETY"
 		},
 		"id": 28,
@@ -237,6 +255,7 @@
 		"artist": "from PACA PACA PASSION",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.772,
 			"genre": "VARIETY"
 		},
 		"id": 33,
@@ -248,6 +267,7 @@
 		"artist": "ALI PROJECT",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 133.615,
 			"genre": "POPS & ANIME"
 		},
 		"id": 34,
@@ -261,6 +281,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 127.655,
 			"genre": "VARIETY"
 		},
 		"id": 35,
@@ -272,6 +293,7 @@
 		"artist": "上原 れな 「WHITE ALBUM2」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 139.778,
 			"genre": "POPS & ANIME"
 		},
 		"id": 36,
@@ -285,6 +307,7 @@
 		"artist": "Lia「AIR」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 171.684,
 			"genre": "POPS & ANIME"
 		},
 		"id": 37,
@@ -298,6 +321,7 @@
 		"artist": "164",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 129.191,
 			"genre": "niconico"
 		},
 		"id": 38,
@@ -311,6 +335,7 @@
 		"artist": "SIAM SHADE [covered by 湯毛]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.629,
 			"genre": "POPS & ANIME"
 		},
 		"id": 39,
@@ -324,6 +349,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 130.099,
 			"genre": "東方Project"
 		},
 		"id": 41,
@@ -335,6 +361,7 @@
 		"artist": "LiSA",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 148.421,
 			"genre": "POPS & ANIME"
 		},
 		"id": 42,
@@ -346,6 +373,7 @@
 		"artist": "後ろから這いより隊G [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 149.107,
 			"genre": "POPS & ANIME"
 		},
 		"id": 43,
@@ -359,6 +387,7 @@
 		"artist": "paraoka",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 123.614,
 			"genre": "VARIETY"
 		},
 		"id": 45,
@@ -370,6 +399,7 @@
 		"artist": "Masayoshi Minoshima",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 133.043,
 			"genre": "東方Project"
 		},
 		"id": 46,
@@ -383,6 +413,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 143.605,
 			"genre": "niconico"
 		},
 		"id": 47,
@@ -399,6 +430,7 @@
 		"artist": "t+pazolite feat.鈴木 ななこ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 123.392,
 			"genre": "東方Project"
 		},
 		"id": 48,
@@ -410,6 +442,7 @@
 		"artist": "SYNC.ART'S feat.美里",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 114.717,
 			"genre": "東方Project"
 		},
 		"id": 49,
@@ -423,6 +456,7 @@
 		"artist": "cubesato",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.368,
 			"genre": "ORIGINAL"
 		},
 		"id": 51,
@@ -436,6 +470,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 133.548,
 			"genre": "ORIGINAL"
 		},
 		"id": 52,
@@ -447,6 +482,7 @@
 		"artist": "owl＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.125,
 			"genre": "ORIGINAL"
 		},
 		"id": 53,
@@ -458,6 +494,7 @@
 		"artist": "いきものがかり [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.437,
 			"genre": "POPS & ANIME"
 		},
 		"id": 54,
@@ -471,6 +508,7 @@
 		"artist": "JITTERIN'JINN [covered by ろん]",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 127.66,
 			"genre": "POPS & ANIME"
 		},
 		"id": 55,
@@ -485,6 +523,7 @@
 		"artist": "JUDY AND MARY [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 114.018,
 			"genre": "POPS & ANIME"
 		},
 		"id": 56,
@@ -498,6 +537,7 @@
 		"artist": "L'Arc～en～Ciel [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 120,
 			"genre": "POPS & ANIME"
 		},
 		"id": 57,
@@ -509,6 +549,7 @@
 		"artist": "[cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.02,
 			"genre": "POPS & ANIME"
 		},
 		"id": 58,
@@ -523,6 +564,7 @@
 		"artist": "れるりり feat.ろん",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.898,
 			"genre": "ORIGINAL"
 		},
 		"id": 59,
@@ -534,6 +576,7 @@
 		"artist": "fripSide [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 145.594,
 			"genre": "POPS & ANIME"
 		},
 		"id": 60,
@@ -545,6 +588,7 @@
 		"artist": "Morrigan",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 131.091,
 			"genre": "ORIGINAL"
 		},
 		"id": 61,
@@ -556,6 +600,7 @@
 		"artist": "六弦アリス",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 140.667,
 			"genre": "ORIGINAL"
 		},
 		"id": 62,
@@ -569,6 +614,7 @@
 		"artist": "Godspeed",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.8,
 			"genre": "ORIGINAL"
 		},
 		"id": 63,
@@ -580,6 +626,7 @@
 		"artist": "あべにゅうぷろじぇくと feat.佐倉 紗織　produced by ave;new",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.991,
 			"genre": "ORIGINAL"
 		},
 		"id": 64,
@@ -593,6 +640,7 @@
 		"artist": "ESTi",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 139.119,
 			"genre": "ORIGINAL"
 		},
 		"id": 65,
@@ -604,6 +652,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 144.868,
 			"genre": "ORIGINAL"
 		},
 		"id": 66,
@@ -618,6 +667,7 @@
 		"artist": "halyosy",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 126.067,
 			"genre": "ORIGINAL"
 		},
 		"id": 67,
@@ -631,6 +681,7 @@
 		"artist": "solfa feat.茶太",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 134.161,
 			"genre": "ORIGINAL"
 		},
 		"id": 68,
@@ -644,6 +695,7 @@
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 69,
@@ -655,6 +707,7 @@
 		"artist": "SEXY-SYNTHESIZER",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 159.485,
 			"genre": "ORIGINAL"
 		},
 		"id": 70,
@@ -666,6 +719,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.216,
 			"genre": "ORIGINAL"
 		},
 		"id": 71,
@@ -677,6 +731,7 @@
 		"artist": "Morrigan feat.Lily",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 126.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 72,
@@ -688,6 +743,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 159.107,
 			"genre": "ORIGINAL"
 		},
 		"id": 73,
@@ -701,6 +757,7 @@
 		"artist": "TaNaBaTa",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 150.539,
 			"genre": "ORIGINAL"
 		},
 		"id": 74,
@@ -715,6 +772,7 @@
 		"artist": "DECO*27 feat.echo",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 145.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 75,
@@ -726,6 +784,7 @@
 		"artist": "WASi303",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 135,
 			"genre": "ORIGINAL"
 		},
 		"id": 76,
@@ -737,6 +796,7 @@
 		"artist": "ゼッケン屋",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 151.61,
 			"genre": "ORIGINAL"
 		},
 		"id": 77,
@@ -751,6 +811,7 @@
 		"artist": "LiSA",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 101.371,
 			"genre": "POPS & ANIME"
 		},
 		"id": 78,
@@ -762,6 +823,7 @@
 		"artist": "片霧烈火オンザみんマンション",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 152.114,
 			"genre": "ORIGINAL"
 		},
 		"id": 79,
@@ -775,6 +837,7 @@
 		"artist": "古代 祐三",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 170,
 			"genre": "ORIGINAL"
 		},
 		"id": 80,
@@ -786,6 +849,7 @@
 		"artist": "Aiko Oi",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 136.114,
 			"genre": "ORIGINAL"
 		},
 		"id": 82,
@@ -797,6 +861,7 @@
 		"artist": "Neru",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 132.461,
 			"genre": "niconico"
 		},
 		"id": 83,
@@ -813,6 +878,7 @@
 		"artist": "シド [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 117.892,
 			"genre": "POPS & ANIME"
 		},
 		"id": 84,
@@ -824,6 +890,7 @@
 		"artist": "湘南乃風 [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 151.5,
 			"genre": "POPS & ANIME"
 		},
 		"id": 85,
@@ -837,6 +904,7 @@
 		"artist": "ゲスの極み乙女。",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 109.254,
 			"genre": "POPS & ANIME"
 		},
 		"id": 86,
@@ -850,6 +918,7 @@
 		"artist": "和田 光司 [cover]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 96.364,
 			"genre": "POPS & ANIME"
 		},
 		"id": 87,
@@ -861,6 +930,7 @@
 		"artist": "長沼 英樹",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 121.475,
 			"genre": "VARIETY"
 		},
 		"id": 88,
@@ -874,6 +944,7 @@
 		"artist": "from PACA PACA PASSION Special",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 150.698,
 			"genre": "VARIETY"
 		},
 		"id": 89,
@@ -885,6 +956,7 @@
 		"artist": "Osamu Kubota",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 153.813,
 			"genre": "ORIGINAL"
 		},
 		"id": 90,
@@ -898,6 +970,7 @@
 		"artist": "myu314 feat.あまね（COOL&CREATE）",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 115.543,
 			"genre": "東方Project"
 		},
 		"id": 91,
@@ -909,6 +982,7 @@
 		"artist": "ビートまりお",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 132.9,
 			"genre": "東方Project"
 		},
 		"id": 92,
@@ -922,6 +996,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 131,
 			"genre": "東方Project"
 		},
 		"id": 93,
@@ -935,6 +1010,7 @@
 		"artist": "Last Note.",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 150.939,
 			"genre": "niconico"
 		},
 		"id": 94,
@@ -948,6 +1024,7 @@
 		"artist": "海田 明里",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 162.073,
 			"genre": "ORIGINAL"
 		},
 		"id": 95,
@@ -961,6 +1038,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 127.543,
 			"genre": "東方Project"
 		},
 		"id": 96,
@@ -975,6 +1053,7 @@
 		"artist": "ビートまりお",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 128.033,
 			"genre": "東方Project"
 		},
 		"id": 97,
@@ -988,6 +1067,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.藤咲かりん",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 123.333,
 			"genre": "東方Project"
 		},
 		"id": 98,
@@ -1001,6 +1081,7 @@
 		"artist": "そらる・ろん×れるりり",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.4,
 			"genre": "ゲキマイ"
 		},
 		"id": 99,
@@ -1014,6 +1095,7 @@
 		"artist": "霜月はるか",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 140.682,
 			"genre": "ORIGINAL"
 		},
 		"id": 100,
@@ -1025,6 +1107,7 @@
 		"artist": "Yoko Shimomura",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 159.276,
 			"genre": "ORIGINAL"
 		},
 		"id": 101,
@@ -1036,6 +1119,7 @@
 		"artist": "COOL&CREATE",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 152.063,
 			"genre": "ORIGINAL"
 		},
 		"id": 102,
@@ -1047,6 +1131,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 170.895,
 			"genre": "ORIGINAL"
 		},
 		"id": 103,
@@ -1061,6 +1146,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 139.953,
 			"genre": "ORIGINAL"
 		},
 		"id": 104,
@@ -1074,6 +1160,7 @@
 		"artist": "景山 将太",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.214,
 			"genre": "ORIGINAL"
 		},
 		"id": 105,
@@ -1085,6 +1172,7 @@
 		"artist": "Cranky feat.おもしろ三国志",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 171.244,
 			"genre": "ORIGINAL"
 		},
 		"id": 106,
@@ -1102,6 +1190,7 @@
 		"artist": "Queen P.A.L.",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 136.875,
 			"genre": "ORIGINAL"
 		},
 		"id": 107,
@@ -1113,6 +1202,7 @@
 		"artist": "浜渦 正志",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.163,
 			"genre": "ORIGINAL"
 		},
 		"id": 108,
@@ -1124,6 +1214,7 @@
 		"artist": "MAN WITH A MISSION",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 151.02,
 			"genre": "POPS & ANIME"
 		},
 		"id": 109,
@@ -1135,6 +1226,7 @@
 		"artist": "Kalafina 「魔法少女まどか☆マギカ」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 166.32,
 			"genre": "POPS & ANIME"
 		},
 		"id": 110,
@@ -1146,6 +1238,7 @@
 		"artist": "戦場ヶ原 ひたぎ 「化物語」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 155.581,
 			"genre": "POPS & ANIME"
 		},
 		"id": 111,
@@ -1157,6 +1250,7 @@
 		"artist": "ST☆RISH",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.558,
 			"genre": "POPS & ANIME"
 		},
 		"id": 112,
@@ -1170,6 +1264,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 143.006,
 			"genre": "niconico"
 		},
 		"id": 113,
@@ -1183,6 +1278,7 @@
 		"artist": "八王子P",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.636,
 			"genre": "niconico"
 		},
 		"id": 114,
@@ -1194,6 +1290,7 @@
 		"artist": "Alstroemeria Records",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 135.556,
 			"genre": "東方Project"
 		},
 		"id": 115,
@@ -1205,6 +1302,7 @@
 		"artist": "supercell 「化物語」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 111.273,
 			"genre": "POPS & ANIME"
 		},
 		"id": 116,
@@ -1219,6 +1317,7 @@
 		"artist": "M.S.S Project",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 123.759,
 			"genre": "niconico"
 		},
 		"id": 117,
@@ -1230,6 +1329,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.615,
 			"genre": "niconico"
 		},
 		"id": 118,
@@ -1244,6 +1344,7 @@
 		"artist": "じん",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 130.308,
 			"genre": "niconico"
 		},
 		"id": 119,
@@ -1257,6 +1358,7 @@
 		"artist": "koutaq",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 149.333,
 			"genre": "東方Project"
 		},
 		"id": 120,
@@ -1270,6 +1372,7 @@
 		"artist": "石鹸屋",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 147.273,
 			"genre": "東方Project"
 		},
 		"id": 121,
@@ -1284,6 +1387,7 @@
 		"artist": "どぶウサギ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 137.637,
 			"genre": "東方Project"
 		},
 		"id": 122,
@@ -1298,6 +1402,7 @@
 		"artist": "発熱巫女～ず",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 97.753,
 			"genre": "東方Project"
 		},
 		"id": 123,
@@ -1311,6 +1416,7 @@
 		"artist": "VisualArt's/Key「AIR」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 160.8,
 			"genre": "POPS & ANIME"
 		},
 		"id": 124,
@@ -1324,6 +1430,7 @@
 		"artist": "Rita",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 137.682,
 			"genre": "POPS & ANIME"
 		},
 		"id": 125,
@@ -1335,6 +1442,7 @@
 		"artist": "上原 れな",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 157.826,
 			"genre": "POPS & ANIME"
 		},
 		"id": 126,
@@ -1346,6 +1454,7 @@
 		"artist": "Junk",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.083,
 			"genre": "VARIETY"
 		},
 		"id": 128,
@@ -1357,6 +1466,7 @@
 		"artist": "いとう かなこ 「STEINS;GATE」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.727,
 			"genre": "POPS & ANIME"
 		},
 		"id": 129,
@@ -1368,6 +1478,7 @@
 		"artist": "いとう かなこ 「STEINS;GATE」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 158.263,
 			"genre": "POPS & ANIME"
 		},
 		"id": 130,
@@ -1382,6 +1493,7 @@
 		"artist": "じん 「カゲロウプロジェクト」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 157.143,
 			"genre": "niconico"
 		},
 		"id": 131,
@@ -1395,6 +1507,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 152.4,
 			"genre": "niconico"
 		},
 		"id": 132,
@@ -1409,6 +1522,7 @@
 		"artist": "40mP",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 155.778,
 			"genre": "niconico"
 		},
 		"id": 133,
@@ -1423,6 +1537,7 @@
 		"artist": "orangentle",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.072,
 			"genre": "VARIETY"
 		},
 		"id": 134,
@@ -1436,6 +1551,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 129.333,
 			"genre": "VARIETY"
 		},
 		"id": 135,
@@ -1447,6 +1563,7 @@
 		"artist": "Grand Thaw / Rigel Theatre",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 161.935,
 			"genre": "VARIETY"
 		},
 		"id": 136,
@@ -1460,6 +1577,7 @@
 		"artist": "LV.4",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 145.941,
 			"genre": "VARIETY"
 		},
 		"id": 137,
@@ -1471,6 +1589,7 @@
 		"artist": "siromaru + cranky",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 152.25,
 			"genre": "VARIETY"
 		},
 		"id": 138,
@@ -1482,6 +1601,7 @@
 		"artist": "MintJam",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.93,
 			"genre": "ORIGINAL"
 		},
 		"id": 140,
@@ -1493,6 +1613,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 140.846,
 			"genre": "ORIGINAL"
 		},
 		"id": 141,
@@ -1510,6 +1631,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 154.2,
 			"genre": "VARIETY"
 		},
 		"id": 142,
@@ -1521,6 +1643,7 @@
 		"artist": "ryo(supercell)",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 166.889,
 			"genre": "niconico"
 		},
 		"id": 143,
@@ -1532,6 +1655,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 122.044,
 			"genre": "VARIETY"
 		},
 		"id": 144,
@@ -1543,6 +1667,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 159.375,
 			"genre": "イロドリミドリ"
 		},
 		"id": 145,
@@ -1554,6 +1679,7 @@
 		"artist": "40mP feat.シャノ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.213,
 			"genre": "ORIGINAL"
 		},
 		"id": 146,
@@ -1567,6 +1693,7 @@
 		"artist": "ふわりP",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 178.977,
 			"genre": "ORIGINAL"
 		},
 		"id": 147,
@@ -1580,6 +1707,7 @@
 		"artist": "植松 伸夫",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 165.109,
 			"genre": "ORIGINAL"
 		},
 		"id": 148,
@@ -1593,6 +1721,7 @@
 		"artist": "岸田教団＆THE明星ロケッツ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 145.686,
 			"genre": "東方Project"
 		},
 		"id": 149,
@@ -1606,6 +1735,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.674,
 			"genre": "イロドリミドリ"
 		},
 		"id": 150,
@@ -1617,6 +1747,7 @@
 		"artist": "光田 康典",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 137.955,
 			"genre": "ORIGINAL"
 		},
 		"id": 151,
@@ -1628,6 +1759,7 @@
 		"artist": "伊藤 賢治",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 140.962,
 			"genre": "ORIGINAL"
 		},
 		"id": 152,
@@ -1639,6 +1771,7 @@
 		"artist": "ナノ feat.MY FIRST STORY 「蒼き鋼のアルペジオ ‐アルス・ノヴァ‐」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 150.295,
 			"genre": "POPS & ANIME"
 		},
 		"id": 154,
@@ -1650,6 +1783,7 @@
 		"artist": "Trident 「蒼き鋼のアルペジオ ‐アルス・ノヴァ‐」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 165.842,
 			"genre": "POPS & ANIME"
 		},
 		"id": 155,
@@ -1663,6 +1797,7 @@
 		"artist": "Mitchie M",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.884,
 			"genre": "niconico"
 		},
 		"id": 156,
@@ -1674,6 +1809,7 @@
 		"artist": "ギガ",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 135.158,
 			"genre": "niconico"
 		},
 		"id": 157,
@@ -1687,6 +1823,7 @@
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 145.041,
 			"genre": "イロドリミドリ"
 		},
 		"id": 158,
@@ -1700,6 +1837,7 @@
 		"artist": "SEGA Sound Unit[H.]",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 111.678,
 			"genre": "POPS & ANIME"
 		},
 		"id": 159,
@@ -1714,6 +1852,7 @@
 		"artist": "S!N・高橋菜々×ひとしずく・やま△",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 165.915,
 			"genre": "ゲキマイ"
 		},
 		"id": 160,
@@ -1727,6 +1866,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 148.74,
 			"genre": "イロドリミドリ"
 		},
 		"id": 161,
@@ -1742,6 +1882,7 @@
 		"artist": "M.S.S Project",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 153.143,
 			"genre": "ORIGINAL"
 		},
 		"id": 163,
@@ -1756,6 +1897,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.377,
 			"genre": "niconico"
 		},
 		"id": 165,
@@ -1771,6 +1913,7 @@
 		"artist": "wowaka",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 123.208,
 			"genre": "niconico"
 		},
 		"id": 166,
@@ -1784,6 +1927,7 @@
 		"artist": "れるりり",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 154.645,
 			"genre": "niconico"
 		},
 		"id": 167,
@@ -1799,6 +1943,7 @@
 		"artist": "さつき が てんこもり",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 156.857,
 			"genre": "niconico"
 		},
 		"id": 168,
@@ -1814,6 +1959,7 @@
 		"artist": "Junk",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 124.286,
 			"genre": "VARIETY"
 		},
 		"id": 169,
@@ -1825,6 +1971,7 @@
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 146.453,
 			"genre": "イロドリミドリ"
 		},
 		"id": 170,
@@ -1838,6 +1985,7 @@
 		"artist": "from PACA PACA PASSION",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 155.472,
 			"genre": "VARIETY"
 		},
 		"id": 171,
@@ -1849,6 +1997,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 159.421,
 			"genre": "VARIETY"
 		},
 		"id": 173,
@@ -1860,6 +2009,7 @@
 		"artist": "小塚良太「ペルソナ4 ダンシング・オールナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 138.161,
 			"genre": "VARIETY"
 		},
 		"id": 176,
@@ -1871,6 +2021,7 @@
 		"artist": "じまんぐ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 157.683,
 			"genre": "東方Project"
 		},
 		"id": 177,
@@ -1882,6 +2033,7 @@
 		"artist": "marasy",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 139.727,
 			"genre": "ORIGINAL"
 		},
 		"id": 178,
@@ -1893,6 +2045,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 145.076,
 			"genre": "niconico"
 		},
 		"id": 179,
@@ -1906,6 +2059,7 @@
 		"artist": "光吉猛修",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 150.326,
 			"genre": "ORIGINAL"
 		},
 		"id": 180,
@@ -1920,6 +2074,7 @@
 		"artist": "こじろー",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 142.273,
 			"genre": "niconico"
 		},
 		"id": 181,
@@ -1934,6 +2089,7 @@
 		"artist": "小木曽 雪菜(CV:米澤 円) 「WHITE ALBUM2」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 134.212,
 			"genre": "POPS & ANIME"
 		},
 		"id": 182,
@@ -1945,6 +2101,7 @@
 		"artist": "ELISA「ef - a tale of memories.」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 145.6,
 			"genre": "POPS & ANIME"
 		},
 		"id": 183,
@@ -1958,6 +2115,7 @@
 		"artist": "彩菜",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 152.259,
 			"genre": "POPS & ANIME"
 		},
 		"id": 184,
@@ -1969,6 +2127,7 @@
 		"artist": "黒崎 真音 「グリザイアの果実」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 153.871,
 			"genre": "POPS & ANIME"
 		},
 		"id": 185,
@@ -1982,6 +2141,7 @@
 		"artist": "石鹸屋",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 126.923,
 			"genre": "東方Project"
 		},
 		"id": 186,
@@ -1995,6 +2155,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 133.5,
 			"genre": "東方Project"
 		},
 		"id": 187,
@@ -2010,6 +2171,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 147.667,
 			"genre": "東方Project"
 		},
 		"id": 189,
@@ -2023,6 +2185,7 @@
 		"artist": "IRON ATTACK!",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 147.472,
 			"genre": "東方Project"
 		},
 		"id": 190,
@@ -2037,6 +2200,7 @@
 		"artist": "セブンスヘブンMAXION",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 143.5,
 			"genre": "東方Project"
 		},
 		"id": 191,
@@ -2050,6 +2214,7 @@
 		"artist": "矢鴇つかさ feat. 三澤秋",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 125.667,
 			"genre": "東方Project"
 		},
 		"id": 192,
@@ -2061,6 +2226,7 @@
 		"artist": "void＋夕野ヨシミ (IOSYS) feat.藤原鞠菜",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 103.714,
 			"genre": "東方Project"
 		},
 		"id": 193,
@@ -2075,6 +2241,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 135.357,
 			"genre": "東方Project"
 		},
 		"id": 194,
@@ -2086,6 +2253,7 @@
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 140.903,
 			"genre": "東方Project"
 		},
 		"id": 195,
@@ -2099,6 +2267,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 146.881,
 			"genre": "VARIETY"
 		},
 		"id": 196,
@@ -2112,6 +2281,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 143.416,
 			"genre": "VARIETY"
 		},
 		"id": 197,
@@ -2123,6 +2293,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 151.733,
 			"genre": "VARIETY"
 		},
 		"id": 198,
@@ -2134,6 +2305,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 151.706,
 			"genre": "イロドリミドリ"
 		},
 		"id": 199,
@@ -2147,6 +2319,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 149.778,
 			"genre": "イロドリミドリ"
 		},
 		"id": 200,
@@ -2162,6 +2335,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 145.802,
 			"genre": "ORIGINAL"
 		},
 		"id": 201,
@@ -2175,6 +2349,7 @@
 		"artist": "Tatsh",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 149.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 202,
@@ -2186,6 +2361,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 124.162,
 			"genre": "VARIETY"
 		},
 		"id": 203,
@@ -2197,6 +2373,7 @@
 		"artist": "日向美ビタースイーツ♪",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 116.634,
 			"genre": "VARIETY"
 		},
 		"id": 204,
@@ -2210,6 +2387,7 @@
 		"artist": "Masayoshi Minoshima feat.Mei Ayakura",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 141.628,
 			"genre": "ORIGINAL"
 		},
 		"id": 205,
@@ -2221,6 +2399,7 @@
 		"artist": "目黒将司「ペルソナ4 ダンシング・オールナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 143.119,
 			"genre": "VARIETY"
 		},
 		"id": 206,
@@ -2232,6 +2411,7 @@
 		"artist": "目黒将司 Remixed by 浅倉大介「ペルソナ4 ダンシング・オールナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM",
+			"duration": 144.783,
 			"genre": "VARIETY"
 		},
 		"id": 207,
@@ -2243,6 +2423,7 @@
 		"artist": "DOT96",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 110.921,
 			"genre": "VARIETY"
 		},
 		"id": 208,
@@ -2254,6 +2435,7 @@
 		"artist": "春奈 るな 「冴えない彼女の育てかた」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 92.561,
 			"genre": "POPS & ANIME"
 		},
 		"id": 209,
@@ -2267,6 +2449,7 @@
 		"artist": "Orangestar",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 161.189,
 			"genre": "niconico"
 		},
 		"id": 210,
@@ -2281,6 +2464,7 @@
 		"artist": "ゆうゆ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 159.31,
 			"genre": "niconico"
 		},
 		"id": 211,
@@ -2295,6 +2479,7 @@
 		"artist": "銀サク",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 141.386,
 			"genre": "niconico"
 		},
 		"id": 212,
@@ -2309,6 +2494,7 @@
 		"artist": "otetsu",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 145.375,
 			"genre": "niconico"
 		},
 		"id": 213,
@@ -2323,6 +2509,7 @@
 		"artist": "プラズマジカ 「SHOW BY ROCK!!」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 161.163,
 			"genre": "POPS & ANIME"
 		},
 		"id": 214,
@@ -2336,6 +2523,7 @@
 		"artist": "シンガンクリムゾンズ 「SHOW BY ROCK!!」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 96,
 			"genre": "POPS & ANIME"
 		},
 		"id": 215,
@@ -2347,6 +2535,7 @@
 		"artist": "放課後楽園部 「ミカグラ学園組曲」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 158.049,
 			"genre": "niconico"
 		},
 		"id": 216,
@@ -2361,6 +2550,7 @@
 		"artist": "放課後楽園部 「ミカグラ学園組曲」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 147.333,
 			"genre": "niconico"
 		},
 		"id": 217,
@@ -2375,6 +2565,7 @@
 		"artist": "tilt-six feat.バル",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.853,
 			"genre": "ORIGINAL"
 		},
 		"id": 218,
@@ -2389,6 +2580,7 @@
 		"artist": "きくお",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 153.692,
 			"genre": "ORIGINAL"
 		},
 		"id": 219,
@@ -2405,6 +2597,7 @@
 		"artist": "じん 「カゲロウプロジェクト」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 147.6,
 			"genre": "niconico"
 		},
 		"id": 220,
@@ -2418,6 +2611,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 160.519,
 			"genre": "niconico"
 		},
 		"id": 222,
@@ -2429,6 +2623,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 146.601,
 			"genre": "niconico"
 		},
 		"id": 223,
@@ -2443,6 +2638,7 @@
 		"artist": "40mP",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 152.015,
 			"genre": "niconico"
 		},
 		"id": 224,
@@ -2456,6 +2652,7 @@
 		"artist": "n-buna",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 135.75,
 			"genre": "niconico"
 		},
 		"id": 225,
@@ -2470,6 +2667,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 128.438,
 			"genre": "ゲキマイ"
 		},
 		"id": 226,
@@ -2485,6 +2683,7 @@
 		"artist": "ゆりん・柿チョコ×Neru",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 162.404,
 			"genre": "ゲキマイ"
 		},
 		"id": 227,
@@ -2498,6 +2697,7 @@
 		"artist": "n.k",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 158.487,
 			"genre": "niconico"
 		},
 		"id": 228,
@@ -2511,6 +2711,7 @@
 		"artist": "-45",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 155.818,
 			"genre": "ORIGINAL"
 		},
 		"id": 229,
@@ -2524,6 +2725,7 @@
 		"artist": "Maozon",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 158.437,
 			"genre": "ORIGINAL"
 		},
 		"id": 230,
@@ -2535,6 +2737,7 @@
 		"artist": "沢井 美空 「冴えない彼女の育てかた」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 155.686,
 			"genre": "POPS & ANIME"
 		},
 		"id": 231,
@@ -2548,6 +2751,7 @@
 		"artist": "dj TAKA meets DJ YOSHITAKA",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 132.453,
 			"genre": "VARIETY"
 		},
 		"id": 232,
@@ -2559,6 +2763,7 @@
 		"artist": "TAG",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 125.625,
 			"genre": "VARIETY"
 		},
 		"id": 233,
@@ -2572,6 +2777,7 @@
 		"artist": "INNOCENT NOIZE",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 143.25,
 			"genre": "ORIGINAL"
 		},
 		"id": 234,
@@ -2583,6 +2789,7 @@
 		"artist": "新庄 かなえ(CV:三森 すずこ) 「てーきゅう」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 150.938,
 			"genre": "POPS & ANIME"
 		},
 		"id": 235,
@@ -2596,6 +2803,7 @@
 		"artist": "レベッカ [covered by 光吉猛修]",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 143.694,
 			"genre": "POPS & ANIME"
 		},
 		"id": 238,
@@ -2609,6 +2817,7 @@
 		"artist": "じん 「カゲロウプロジェクト」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 139.615,
 			"genre": "niconico"
 		},
 		"id": 240,
@@ -2623,6 +2832,7 @@
 		"artist": "UNISON SQUARE GARDEN",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 151.186,
 			"genre": "POPS & ANIME"
 		},
 		"id": 243,
@@ -2636,6 +2846,7 @@
 		"artist": "歌組雪月花 夜々(原田 ひとみ)/いろり(茅野 愛衣)/小紫(小倉 唯) 「機巧少女は傷つかない」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 141.375,
 			"genre": "POPS & ANIME"
 		},
 		"id": 244,
@@ -2650,6 +2861,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 166.547,
 			"genre": "イロドリミドリ"
 		},
 		"id": 245,
@@ -2663,6 +2875,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 161.667,
 			"genre": "イロドリミドリ"
 		},
 		"id": 246,
@@ -2678,6 +2891,7 @@
 		"artist": "蒼井 翔太 「ファンタシースターオンライン2 ジ アニメーション」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 137.836,
 			"genre": "POPS & ANIME"
 		},
 		"id": 247,
@@ -2692,6 +2906,7 @@
 		"artist": "Katzeohr & Spiegel",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 154.701,
 			"genre": "ORIGINAL"
 		},
 		"id": 248,
@@ -2706,6 +2921,7 @@
 		"artist": "並木晃一",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 167.411,
 			"genre": "ORIGINAL"
 		},
 		"id": 249,
@@ -2719,6 +2935,7 @@
 		"artist": "少女病",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 141.103,
 			"genre": "ORIGINAL"
 		},
 		"id": 250,
@@ -2730,6 +2947,7 @@
 		"artist": "ひとしずく×やま△",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 136.471,
 			"genre": "niconico"
 		},
 		"id": 251,
@@ -2741,6 +2959,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 136.429,
 			"genre": "niconico"
 		},
 		"id": 252,
@@ -2754,6 +2973,7 @@
 		"artist": "YATAGARASU",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 146.211,
 			"genre": "ORIGINAL"
 		},
 		"id": 253,
@@ -2765,6 +2985,7 @@
 		"artist": "n-buna feat.ヤギヌマカナ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 160.091,
 			"genre": "ORIGINAL"
 		},
 		"id": 254,
@@ -2780,6 +3001,7 @@
 		"artist": "ミルキィホームズ 「劇場版 探偵オペラ ミルキィホームズ ～逆襲のミルキィホームズ～」",
 		"data": {
 			"displayVersion": "CHUNITHM PLUS",
+			"duration": 147.718,
 			"genre": "POPS & ANIME"
 		},
 		"id": 255,
@@ -2793,6 +3015,7 @@
 		"artist": "ひーちゃんとあーちゃんとたーちゃん",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 146.739,
 			"genre": "ORIGINAL"
 		},
 		"id": 256,
@@ -2806,6 +3029,7 @@
 		"artist": "じーざすP feat.kradness",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 150.479,
 			"genre": "ORIGINAL"
 		},
 		"id": 257,
@@ -2817,6 +3041,7 @@
 		"artist": "Team Grimoire",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 152.125,
 			"genre": "ORIGINAL"
 		},
 		"id": 258,
@@ -2830,6 +3055,7 @@
 		"artist": "Cranky",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 140.21,
 			"genre": "ORIGINAL"
 		},
 		"id": 259,
@@ -2841,6 +3067,7 @@
 		"artist": "さつき が てんこもり feat.YURiCa/花たん",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.743,
 			"genre": "ORIGINAL"
 		},
 		"id": 260,
@@ -2852,6 +3079,7 @@
 		"artist": "lumo",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 165,
 			"genre": "ORIGINAL"
 		},
 		"id": 261,
@@ -2865,6 +3093,7 @@
 		"artist": "D-Cee",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 121.357,
 			"genre": "ORIGINAL"
 		},
 		"id": 262,
@@ -2876,6 +3105,7 @@
 		"artist": "livetune",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 161.016,
 			"genre": "niconico"
 		},
 		"id": 263,
@@ -2887,6 +3117,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 164.276,
 			"genre": "イロドリミドリ"
 		},
 		"id": 264,
@@ -2898,6 +3129,7 @@
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 144.75,
 			"genre": "イロドリミドリ"
 		},
 		"id": 265,
@@ -2911,6 +3143,7 @@
 		"artist": "solfa feat.茶太",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 138,
 			"genre": "ORIGINAL"
 		},
 		"id": 266,
@@ -2924,6 +3157,7 @@
 		"artist": "Orangestar",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 153,
 			"genre": "ORIGINAL"
 		},
 		"id": 267,
@@ -2938,6 +3172,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 129,
 			"genre": "イロドリミドリ"
 		},
 		"id": 268,
@@ -2949,6 +3184,7 @@
 		"artist": "隣人部「僕は友達が少ないNEXT」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 120.816,
 			"genre": "POPS & ANIME"
 		},
 		"id": 269,
@@ -2963,6 +3199,7 @@
 		"artist": "トーマ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 145.875,
 			"genre": "niconico"
 		},
 		"id": 270,
@@ -2976,6 +3213,7 @@
 		"artist": "じーざすP（ワンダフル☆オポチュニティ！）",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 143.703,
 			"genre": "niconico"
 		},
 		"id": 271,
@@ -2990,6 +3228,7 @@
 		"artist": "Last Note.",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 145.038,
 			"genre": "niconico"
 		},
 		"id": 272,
@@ -3004,6 +3243,7 @@
 		"artist": "Mitchie M",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 136.622,
 			"genre": "niconico"
 		},
 		"id": 273,
@@ -3017,6 +3257,7 @@
 		"artist": "霜月はるか",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 154.712,
 			"genre": "ORIGINAL"
 		},
 		"id": 274,
@@ -3030,6 +3271,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 149.781,
 			"genre": "niconico"
 		},
 		"id": 275,
@@ -3045,6 +3287,7 @@
 		"artist": "田口囁一／感傷ベクトル",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 149.1,
 			"genre": "ORIGINAL"
 		},
 		"id": 276,
@@ -3058,6 +3301,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 159.158,
 			"genre": "イロドリミドリ"
 		},
 		"id": 277,
@@ -3069,6 +3313,7 @@
 		"artist": "40mP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 157.353,
 			"genre": "niconico"
 		},
 		"id": 278,
@@ -3082,6 +3327,7 @@
 		"artist": "ゆうゆ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 144.964,
 			"genre": "niconico"
 		},
 		"id": 279,
@@ -3096,6 +3342,7 @@
 		"artist": "じーざすP（ワンダフル☆オポチュニティ！）",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 156.364,
 			"genre": "niconico"
 		},
 		"id": 280,
@@ -3110,6 +3357,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 155.276,
 			"genre": "niconico"
 		},
 		"id": 281,
@@ -3124,6 +3372,7 @@
 		"artist": "Last Note.",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 148.56,
 			"genre": "niconico"
 		},
 		"id": 282,
@@ -3138,6 +3387,7 @@
 		"artist": "おにゅうP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 148.896,
 			"genre": "niconico"
 		},
 		"id": 283,
@@ -3152,6 +3402,7 @@
 		"artist": "うたたP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 149.155,
 			"genre": "niconico"
 		},
 		"id": 284,
@@ -3168,6 +3419,7 @@
 		"artist": "supercell",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 162.706,
 			"genre": "niconico"
 		},
 		"id": 285,
@@ -3182,6 +3434,7 @@
 		"artist": "livetune",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 159.4,
 			"genre": "niconico"
 		},
 		"id": 286,
@@ -3193,6 +3446,7 @@
 		"artist": "doriko",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 153,
 			"genre": "niconico"
 		},
 		"id": 287,
@@ -3206,6 +3460,7 @@
 		"artist": "折戸伸治 feat.北沢綾香",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 173.182,
 			"genre": "ORIGINAL"
 		},
 		"id": 288,
@@ -3217,6 +3472,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 155.585,
 			"genre": "ORIGINAL"
 		},
 		"id": 289,
@@ -3230,6 +3486,7 @@
 		"artist": "真宮寺さくら（横山智佐）＆帝国歌劇団「サクラ大戦」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 159.467,
 			"genre": "VARIETY"
 		},
 		"id": 290,
@@ -3243,6 +3500,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 157.308,
 			"genre": "VARIETY"
 		},
 		"id": 291,
@@ -3254,6 +3512,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 129.205,
 			"genre": "東方Project"
 		},
 		"id": 292,
@@ -3267,6 +3526,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 133.75,
 			"genre": "niconico"
 		},
 		"id": 293,
@@ -3280,6 +3540,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 153.15,
 			"genre": "niconico"
 		},
 		"id": 294,
@@ -3293,6 +3554,7 @@
 		"artist": "志方あきこ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 161.593,
 			"genre": "ORIGINAL"
 		},
 		"id": 295,
@@ -3306,6 +3568,7 @@
 		"artist": "土間うまる [CV.田中あいみ]「干物妹！うまるちゃん」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 132.324,
 			"genre": "POPS & ANIME"
 		},
 		"id": 296,
@@ -3319,6 +3582,7 @@
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.62,
 			"genre": "VARIETY"
 		},
 		"id": 297,
@@ -3332,6 +3596,7 @@
 		"artist": "from PACA PACA PASSION 2",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 151.718,
 			"genre": "VARIETY"
 		},
 		"id": 298,
@@ -3343,6 +3608,7 @@
 		"artist": "本間芽衣子(茅野愛衣)、安城鳴子(戸松遥)、鶴見知利子(早見沙織)「あの日見た花の名前を僕達はまだ知らない。」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.884,
 			"genre": "POPS & ANIME"
 		},
 		"id": 299,
@@ -3356,6 +3622,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 149.448,
 			"genre": "東方Project"
 		},
 		"id": 300,
@@ -3367,6 +3634,7 @@
 		"artist": "のぼる↑",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 133.5,
 			"genre": "niconico"
 		},
 		"id": 301,
@@ -3380,6 +3648,7 @@
 		"artist": "Feryquitous feat.Sennzai",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 131.309,
 			"genre": "VARIETY"
 		},
 		"id": 302,
@@ -3391,6 +3660,7 @@
 		"artist": "Tomoko Sasaki「NiGHTS～星降る夜の物語～」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.844,
 			"genre": "VARIETY"
 		},
 		"id": 303,
@@ -3404,6 +3674,7 @@
 		"artist": "電脳戦機バーチャロンフォース",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 146.797,
 			"genre": "VARIETY"
 		},
 		"id": 304,
@@ -3417,6 +3688,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 141.522,
 			"genre": "東方Project"
 		},
 		"id": 305,
@@ -3433,6 +3705,7 @@
 		"artist": "紅色リトマス",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 125.153,
 			"genre": "VARIETY"
 		},
 		"id": 306,
@@ -3446,6 +3719,7 @@
 		"artist": "owl＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 144.545,
 			"genre": "ORIGINAL"
 		},
 		"id": 307,
@@ -3457,6 +3731,7 @@
 		"artist": "カラスは真っ白",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 145.385,
 			"genre": "POPS & ANIME"
 		},
 		"id": 308,
@@ -3468,6 +3743,7 @@
 		"artist": "LiSA",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 120.789,
 			"genre": "POPS & ANIME"
 		},
 		"id": 309,
@@ -3479,6 +3755,7 @@
 		"artist": "マチゲリータ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 144.6,
 			"genre": "ORIGINAL"
 		},
 		"id": 310,
@@ -3492,6 +3769,7 @@
 		"artist": "隣人部「僕は友達が少ないNEXT」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 120,
 			"genre": "POPS & ANIME"
 		},
 		"id": 311,
@@ -3503,6 +3781,7 @@
 		"artist": "羽瀬川小鳩（CV:花澤香菜）・高山マリア（CV:井口裕香）「僕は友達が少ないNEXT」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 149.098,
 			"genre": "POPS & ANIME"
 		},
 		"id": 312,
@@ -3516,6 +3795,7 @@
 		"artist": "妹S（シスターズ）（土間うまる [CV.田中あいみ]、海老名菜々 [CV.影山灯]、本場切絵 [CV.白石晴香]、橘・シルフィンフォード [CV.古川由利奈]）「干物妹！うまるちゃん」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 92.687,
 			"genre": "POPS & ANIME"
 		},
 		"id": 313,
@@ -3529,6 +3809,7 @@
 		"artist": "鈴木このみ「ノーゲーム・ノーライフ」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 137.603,
 			"genre": "POPS & ANIME"
 		},
 		"id": 314,
@@ -3540,6 +3821,7 @@
 		"artist": "白（CV:茅野愛衣）「ノーゲーム・ノーライフ」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 159.961,
 			"genre": "POPS & ANIME"
 		},
 		"id": 315,
@@ -3553,6 +3835,7 @@
 		"artist": "ika",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 101.625,
 			"genre": "niconico"
 		},
 		"id": 316,
@@ -3566,6 +3849,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 152.865,
 			"genre": "VARIETY"
 		},
 		"id": 317,
@@ -3577,6 +3861,7 @@
 		"artist": "Lunatic Sounds",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 125.833,
 			"genre": "VARIETY"
 		},
 		"id": 318,
@@ -3590,6 +3875,7 @@
 		"artist": "ETIA. feat.Jenga",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 138.821,
 			"genre": "VARIETY"
 		},
 		"id": 319,
@@ -3601,6 +3887,7 @@
 		"artist": "eoll",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 139.5,
 			"genre": "VARIETY"
 		},
 		"id": 320,
@@ -3612,6 +3899,7 @@
 		"artist": "Grand Thaw / Rigel Theatre",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 157.597,
 			"genre": "VARIETY"
 		},
 		"id": 321,
@@ -3625,6 +3913,7 @@
 		"artist": "ゆうゆ / 篠螺悠那",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 136.025,
 			"genre": "東方Project"
 		},
 		"id": 322,
@@ -3639,6 +3928,7 @@
 		"artist": "Mastermind(xi+nora2r)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 140.938,
 			"genre": "VARIETY"
 		},
 		"id": 323,
@@ -3650,6 +3940,7 @@
 		"artist": "Ras",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 136.438,
 			"genre": "VARIETY"
 		},
 		"id": 324,
@@ -3661,6 +3952,7 @@
 		"artist": "naotyu-",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 140.135,
 			"genre": "VARIETY"
 		},
 		"id": 325,
@@ -3672,6 +3964,7 @@
 		"artist": "Street",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 119.143,
 			"genre": "VARIETY"
 		},
 		"id": 326,
@@ -3683,6 +3976,7 @@
 		"artist": "Queen P.A.L.",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 119.216,
 			"genre": "VARIETY"
 		},
 		"id": 327,
@@ -3694,6 +3988,7 @@
 		"artist": "ねこみみ魔法使い",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 131.25,
 			"genre": "VARIETY"
 		},
 		"id": 328,
@@ -3705,6 +4000,7 @@
 		"artist": "Yosh(Survive Said The Prophet)「ボーダーブレイク」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 124.2,
 			"genre": "VARIETY"
 		},
 		"id": 329,
@@ -3716,6 +4012,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 156.429,
 			"genre": "イロドリミドリ"
 		},
 		"id": 330,
@@ -3729,6 +4026,7 @@
 		"artist": "月鈴 那知(CV:今村 彩夏)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 148.101,
 			"genre": "イロドリミドリ"
 		},
 		"id": 331,
@@ -3744,6 +4042,7 @@
 		"artist": "un:c・ろん×じーざすP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 135.806,
 			"genre": "ゲキマイ"
 		},
 		"id": 332,
@@ -3757,6 +4056,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 122.842,
 			"genre": "ゲキマイ"
 		},
 		"id": 333,
@@ -3770,6 +4070,7 @@
 		"artist": "from PACA PACA PASSION",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 159.449,
 			"genre": "VARIETY"
 		},
 		"id": 334,
@@ -3781,6 +4082,7 @@
 		"artist": "Massive New Krew",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 122.71,
 			"genre": "ORIGINAL"
 		},
 		"id": 335,
@@ -3792,6 +4094,7 @@
 		"artist": "OSTER project",
 		"data": {
 			"displayVersion": "CHUNITHM AIR",
+			"duration": 138,
 			"genre": "niconico"
 		},
 		"id": 336,
@@ -3805,6 +4108,7 @@
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 157.2,
 			"genre": "イロドリミドリ"
 		},
 		"id": 337,
@@ -3816,6 +4120,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 117.521,
 			"genre": "イロドリミドリ"
 		},
 		"id": 338,
@@ -3827,6 +4132,7 @@
 		"artist": "れるりり feat.ろん",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 160.816,
 			"genre": "ORIGINAL"
 		},
 		"id": 339,
@@ -3838,6 +4144,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 154.091,
 			"genre": "イロドリミドリ"
 		},
 		"id": 340,
@@ -3849,6 +4156,7 @@
 		"artist": "かたほとり feat.桃箱",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 169.219,
 			"genre": "ORIGINAL"
 		},
 		"id": 341,
@@ -3862,6 +4170,7 @@
 		"artist": "ULTRA-PRISM",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 161.538,
 			"genre": "ORIGINAL"
 		},
 		"id": 342,
@@ -3875,6 +4184,7 @@
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？？」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 109.6,
 			"genre": "POPS & ANIME"
 		},
 		"id": 343,
@@ -3886,6 +4196,7 @@
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？？」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 143.544,
 			"genre": "POPS & ANIME"
 		},
 		"id": 344,
@@ -3899,6 +4210,7 @@
 		"artist": "DALI [covered by 光吉猛修]",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 127.742,
 			"genre": "POPS & ANIME"
 		},
 		"id": 345,
@@ -3913,6 +4225,7 @@
 		"artist": "Rhodanthe*",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 91.886,
 			"genre": "POPS & ANIME"
 		},
 		"id": 348,
@@ -3924,6 +4237,7 @@
 		"artist": "Wake Up, Girls！",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 144.755,
 			"genre": "POPS & ANIME"
 		},
 		"id": 349,
@@ -3938,6 +4252,7 @@
 		"artist": "佐咲紗花",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 155.769,
 			"genre": "POPS & ANIME"
 		},
 		"id": 350,
@@ -3949,6 +4264,7 @@
 		"artist": "佐倉羽音(CV.上田麗奈)、鈴乃木凜(CV.東山奈央)、天野恩紗(CV.内山夕実)、三ノ輪聖(CV.山口立花子)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 136.931,
 			"genre": "POPS & ANIME"
 		},
 		"id": 351,
@@ -3962,6 +4278,7 @@
 		"artist": "セブンスシスターズ「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 124.035,
 			"genre": "POPS & ANIME"
 		},
 		"id": 352,
@@ -3973,6 +4290,7 @@
 		"artist": "777☆SISTERS「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 123.43,
 			"genre": "POPS & ANIME"
 		},
 		"id": 353,
@@ -3984,6 +4302,7 @@
 		"artist": "あべにゅうぷろじぇくと feat.佐倉紗織&井上みゆ「パチスロ快盗天使ツインエンジェル」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 145.318,
 			"genre": "POPS & ANIME"
 		},
 		"id": 354,
@@ -3997,6 +4316,7 @@
 		"artist": "茶太「CLANNAD -クラナド-」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 90.9,
 			"genre": "POPS & ANIME"
 		},
 		"id": 355,
@@ -4010,6 +4330,7 @@
 		"artist": "とりぷる♣ふぃーりんぐ(和久井 優／金澤まい／今村彩夏)「三者三葉」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 103.034,
 			"genre": "POPS & ANIME"
 		},
 		"id": 356,
@@ -4023,6 +4344,7 @@
 		"artist": "とりぷる♣ふぃーりんぐ(和久井 優／金澤まい／今村彩夏)「三者三葉」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 147.465,
 			"genre": "POPS & ANIME"
 		},
 		"id": 357,
@@ -4036,6 +4358,7 @@
 		"artist": "Lia「Angel Beats!」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 161.586,
 			"genre": "POPS & ANIME"
 		},
 		"id": 358,
@@ -4047,6 +4370,7 @@
 		"artist": "Girls Dead Monster「Angel Beats!」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 117.439,
 			"genre": "POPS & ANIME"
 		},
 		"id": 359,
@@ -4058,6 +4382,7 @@
 		"artist": "Suara「うたわれるもの」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 157.612,
 			"genre": "POPS & ANIME"
 		},
 		"id": 360,
@@ -4071,6 +4396,7 @@
 		"artist": "KOTOKO",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 139.778,
 			"genre": "POPS & ANIME"
 		},
 		"id": 362,
@@ -4082,6 +4408,7 @@
 		"artist": "ave;new feat.佐倉紗織",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 147.66,
 			"genre": "POPS & ANIME"
 		},
 		"id": 363,
@@ -4093,6 +4420,7 @@
 		"artist": "halyosy",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 145.263,
 			"genre": "niconico"
 		},
 		"id": 365,
@@ -4109,6 +4437,7 @@
 		"artist": "みきとP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 152.069,
 			"genre": "niconico"
 		},
 		"id": 367,
@@ -4123,6 +4452,7 @@
 		"artist": "ギガ/れをる",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 144.171,
 			"genre": "niconico"
 		},
 		"id": 368,
@@ -4137,6 +4467,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 155.071,
 			"genre": "niconico"
 		},
 		"id": 369,
@@ -4150,6 +4481,7 @@
 		"artist": "梅とら",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 144.851,
 			"genre": "niconico"
 		},
 		"id": 370,
@@ -4164,6 +4496,7 @@
 		"artist": "wowaka",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 119.561,
 			"genre": "niconico"
 		},
 		"id": 371,
@@ -4177,6 +4510,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 156.104,
 			"genre": "niconico"
 		},
 		"id": 372,
@@ -4191,6 +4525,7 @@
 		"artist": "ナナホシ管弦楽団",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 156.158,
 			"genre": "niconico"
 		},
 		"id": 373,
@@ -4206,6 +4541,7 @@
 		"artist": "和田たけあき(くらげP)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 150.409,
 			"genre": "niconico"
 		},
 		"id": 374,
@@ -4220,6 +4556,7 @@
 		"artist": "40mP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 140.404,
 			"genre": "niconico"
 		},
 		"id": 375,
@@ -4234,6 +4571,7 @@
 		"artist": "CIRCRUSH",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 145.929,
 			"genre": "niconico"
 		},
 		"id": 376,
@@ -4245,6 +4583,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 104.088,
 			"genre": "東方Project"
 		},
 		"id": 377,
@@ -4258,6 +4597,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 140.868,
 			"genre": "東方Project"
 		},
 		"id": 379,
@@ -4271,6 +4611,7 @@
 		"artist": "発熱巫女～ず",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 146.25,
 			"genre": "東方Project"
 		},
 		"id": 380,
@@ -4282,6 +4623,7 @@
 		"artist": "Liz Triangle",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 156.623,
 			"genre": "東方Project"
 		},
 		"id": 381,
@@ -4293,6 +4635,7 @@
 		"artist": "ビートまりお × Cranky",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 124.667,
 			"genre": "東方Project"
 		},
 		"id": 382,
@@ -4304,6 +4647,7 @@
 		"artist": "博麗神社例大祭コラボユニット",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 143.063,
 			"genre": "東方Project"
 		},
 		"id": 383,
@@ -4317,6 +4661,7 @@
 		"artist": "光吉猛修「東方幻想麻雀」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 139.935,
 			"genre": "東方Project"
 		},
 		"id": 384,
@@ -4330,6 +4675,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 109.784,
 			"genre": "VARIETY"
 		},
 		"id": 385,
@@ -4341,6 +4687,7 @@
 		"artist": "TJ.hangneil",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 151.571,
 			"genre": "VARIETY"
 		},
 		"id": 386,
@@ -4354,6 +4701,7 @@
 		"artist": "EBIMAYO",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 125.059,
 			"genre": "VARIETY"
 		},
 		"id": 388,
@@ -4365,6 +4713,7 @@
 		"artist": "void (Mournfinale) feat. コツキミヤ (Gt. えば)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 160.172,
 			"genre": "VARIETY"
 		},
 		"id": 389,
@@ -4376,6 +4725,7 @@
 		"artist": "syatten",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 143.977,
 			"genre": "VARIETY"
 		},
 		"id": 390,
@@ -4387,6 +4737,7 @@
 		"artist": "loos feat. 柊莉杏",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 137.143,
 			"genre": "VARIETY"
 		},
 		"id": 391,
@@ -4400,6 +4751,7 @@
 		"artist": "BACO",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 142.445,
 			"genre": "VARIETY"
 		},
 		"id": 393,
@@ -4411,6 +4763,7 @@
 		"artist": "セガ・ハード・ガールズ",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 123.334,
 			"genre": "POPS & ANIME"
 		},
 		"id": 394,
@@ -4424,6 +4777,7 @@
 		"artist": "「新豪血寺一族 -煩悩解放-」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 148.8,
 			"genre": "VARIETY"
 		},
 		"id": 395,
@@ -4438,6 +4792,7 @@
 		"artist": "月鈴姉妹(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 137.5,
 			"genre": "イロドリミドリ"
 		},
 		"id": 396,
@@ -4451,6 +4806,7 @@
 		"artist": "sampling masters MEGA「パワードリフト」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 115.2,
 			"genre": "ゲキマイ"
 		},
 		"id": 397,
@@ -4464,6 +4820,7 @@
 		"artist": "伊東歌詞太郎・ろん×れるりり",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 137.391,
 			"genre": "ゲキマイ"
 		},
 		"id": 398,
@@ -4477,6 +4834,7 @@
 		"artist": "片霧烈火",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 154.943,
 			"genre": "ORIGINAL"
 		},
 		"id": 399,
@@ -4492,6 +4850,7 @@
 		"artist": "ろん×田中秀和(MONACA)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 128.523,
 			"genre": "ゲキマイ"
 		},
 		"id": 402,
@@ -4505,6 +4864,7 @@
 		"artist": "高橋菜々×岡部啓一(MONACA)",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 135,
 			"genre": "ゲキマイ"
 		},
 		"id": 403,
@@ -4518,6 +4878,7 @@
 		"artist": "柿チョコ×みきとP",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 147.333,
 			"genre": "ゲキマイ"
 		},
 		"id": 404,
@@ -4529,6 +4890,7 @@
 		"artist": "ろん×黒魔",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 120.75,
 			"genre": "ゲキマイ"
 		},
 		"id": 405,
@@ -4542,6 +4904,7 @@
 		"artist": "伊東歌詞太郎・ろん×まらしぃ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 141.538,
 			"genre": "ゲキマイ"
 		},
 		"id": 406,
@@ -4555,6 +4918,7 @@
 		"artist": "穴山大輔",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 151.75,
 			"genre": "ORIGINAL"
 		},
 		"id": 407,
@@ -4570,6 +4934,7 @@
 		"artist": "Sta",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 113.558,
 			"genre": "VARIETY"
 		},
 		"id": 409,
@@ -4581,6 +4946,7 @@
 		"artist": "ナノ「チェインクロニクル ～ヘクセイタスの閃～」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 159.474,
 			"genre": "POPS & ANIME"
 		},
 		"id": 410,
@@ -4592,6 +4958,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 113.521,
 			"genre": "niconico"
 		},
 		"id": 411,
@@ -4606,6 +4973,7 @@
 		"artist": "Sampling Masters なる＆せりな(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 148.636,
 			"genre": "イロドリミドリ"
 		},
 		"id": 413,
@@ -4619,6 +4987,7 @@
 		"artist": "Morrigan feat.Lily",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 139.765,
 			"genre": "ORIGINAL"
 		},
 		"id": 414,
@@ -4630,6 +4999,7 @@
 		"artist": "SoundTeMP「ラグナロクオンライン」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 100.071,
 			"genre": "VARIETY"
 		},
 		"id": 416,
@@ -4641,6 +5011,7 @@
 		"artist": "鈴木このみ「Re:ゼロから始める異世界生活」",
 		"data": {
 			"displayVersion": "CHUNITHM AIR PLUS",
+			"duration": 155.368,
 			"genre": "POPS & ANIME"
 		},
 		"id": 417,
@@ -4652,6 +5023,7 @@
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 150.909,
 			"genre": "POPS & ANIME"
 		},
 		"id": 419,
@@ -4665,6 +5037,7 @@
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 148.135,
 			"genre": "POPS & ANIME"
 		},
 		"id": 420,
@@ -4676,6 +5049,7 @@
 		"artist": "RADWIMPS「君の名は。」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 117.474,
 			"genre": "POPS & ANIME"
 		},
 		"id": 421,
@@ -4690,6 +5064,7 @@
 		"artist": "藍井エイル",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 93.516,
 			"genre": "POPS & ANIME"
 		},
 		"id": 422,
@@ -4701,6 +5076,7 @@
 		"artist": "JaccaPoP",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 131.077,
 			"genre": "POPS & ANIME"
 		},
 		"id": 424,
@@ -4712,6 +5088,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 138.537,
 			"genre": "東方Project"
 		},
 		"id": 426,
@@ -4725,6 +5102,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 121.667,
 			"genre": "東方Project"
 		},
 		"id": 427,
@@ -4738,6 +5116,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 141.577,
 			"genre": "VARIETY"
 		},
 		"id": 428,
@@ -4749,6 +5128,7 @@
 		"artist": "wa.",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 111.3,
 			"genre": "VARIETY"
 		},
 		"id": 429,
@@ -4760,6 +5140,7 @@
 		"artist": "御形アリシアナオンザイロドリマンション(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 173.333,
 			"genre": "イロドリミドリ"
 		},
 		"id": 430,
@@ -4773,6 +5154,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 171.45,
 			"genre": "イロドリミドリ"
 		},
 		"id": 431,
@@ -4784,6 +5166,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 146.842,
 			"genre": "ORIGINAL"
 		},
 		"id": 432,
@@ -4798,6 +5181,7 @@
 		"artist": "青島探偵事務所器楽捜査部B担",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 146.571,
 			"genre": "ORIGINAL"
 		},
 		"id": 433,
@@ -4813,6 +5197,7 @@
 		"artist": "baker",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 136.385,
 			"genre": "ORIGINAL"
 		},
 		"id": 434,
@@ -4826,6 +5211,7 @@
 		"artist": "鬱P feat.000",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 146.813,
 			"genre": "ORIGINAL"
 		},
 		"id": 435,
@@ -4837,6 +5223,7 @@
 		"artist": "owl＊tree feat.awao＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 137.692,
 			"genre": "ORIGINAL"
 		},
 		"id": 436,
@@ -4848,6 +5235,7 @@
 		"artist": "bermei.inazawa",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 140.254,
 			"genre": "ORIGINAL"
 		},
 		"id": 437,
@@ -4862,6 +5250,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 152.824,
 			"genre": "ORIGINAL"
 		},
 		"id": 438,
@@ -4873,6 +5262,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 142.702,
 			"genre": "ORIGINAL"
 		},
 		"id": 439,
@@ -4886,6 +5276,7 @@
 		"artist": "t+pazolite feat.ななひら",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 163.317,
 			"genre": "ORIGINAL"
 		},
 		"id": 440,
@@ -4899,6 +5290,7 @@
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 167.318,
 			"genre": "ORIGINAL"
 		},
 		"id": 441,
@@ -4912,6 +5304,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 150.643,
 			"genre": "ORIGINAL"
 		},
 		"id": 442,
@@ -4925,6 +5318,7 @@
 		"artist": "tilt-six",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 119.093,
 			"genre": "niconico"
 		},
 		"id": 444,
@@ -4938,6 +5332,7 @@
 		"artist": "ゆよゆっペ/meola",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 166.833,
 			"genre": "niconico"
 		},
 		"id": 445,
@@ -4949,6 +5344,7 @@
 		"artist": "まらしぃ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 140.368,
 			"genre": "niconico"
 		},
 		"id": 446,
@@ -4962,6 +5358,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 145.5,
 			"genre": "niconico"
 		},
 		"id": 447,
@@ -4975,6 +5372,7 @@
 		"artist": "きくお",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 155.401,
 			"genre": "niconico"
 		},
 		"id": 448,
@@ -4988,6 +5386,7 @@
 		"artist": "鬱P",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 144.234,
 			"genre": "niconico"
 		},
 		"id": 449,
@@ -5004,6 +5403,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 151.854,
 			"genre": "POPS & ANIME"
 		},
 		"id": 454,
@@ -5017,6 +5417,7 @@
 		"artist": "電気式華憐音楽集団",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 151.714,
 			"genre": "POPS & ANIME"
 		},
 		"id": 455,
@@ -5028,6 +5429,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 128.363,
 			"genre": "東方Project"
 		},
 		"id": 456,
@@ -5041,6 +5443,7 @@
 		"artist": "NJK Record (3L&maria♂polo)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.214,
 			"genre": "東方Project"
 		},
 		"id": 457,
@@ -5052,6 +5455,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 144.613,
 			"genre": "東方Project"
 		},
 		"id": 458,
@@ -5065,6 +5469,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.063,
 			"genre": "東方Project"
 		},
 		"id": 459,
@@ -5079,6 +5484,7 @@
 		"artist": "あ～るの～と（いえろ～ぜぶら＆電開製作所）",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 129.677,
 			"genre": "東方Project"
 		},
 		"id": 460,
@@ -5093,6 +5499,7 @@
 		"artist": "Halozy",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 107.333,
 			"genre": "東方Project"
 		},
 		"id": 462,
@@ -5106,6 +5513,7 @@
 		"artist": "Junk",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 157.349,
 			"genre": "ORIGINAL"
 		},
 		"id": 463,
@@ -5117,6 +5525,7 @@
 		"artist": "void (Mournfinale)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 165.353,
 			"genre": "ORIGINAL"
 		},
 		"id": 464,
@@ -5130,6 +5539,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 166.359,
 			"genre": "ORIGINAL"
 		},
 		"id": 465,
@@ -5141,6 +5551,7 @@
 		"artist": "Powerless feat.kakichoco",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 159.882,
 			"genre": "ORIGINAL"
 		},
 		"id": 466,
@@ -5154,6 +5565,7 @@
 		"artist": "q/stol",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 161.358,
 			"genre": "ORIGINAL"
 		},
 		"id": 467,
@@ -5165,6 +5577,7 @@
 		"artist": "月鈴 那知(CV:今村 彩夏)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 160.696,
 			"genre": "イロドリミドリ"
 		},
 		"id": 468,
@@ -5178,6 +5591,7 @@
 		"artist": "Tatsh",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 139.57,
 			"genre": "ORIGINAL"
 		},
 		"id": 469,
@@ -5189,6 +5603,7 @@
 		"artist": "Drop＆祇羽 feat. 葉月ゆら「太鼓の達人」より",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 136.452,
 			"genre": "VARIETY"
 		},
 		"id": 470,
@@ -5202,6 +5617,7 @@
 		"artist": "cosMo VS dj TAKA「SOUND VOLTEX」より",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 124.783,
 			"genre": "VARIETY"
 		},
 		"id": 471,
@@ -5215,6 +5631,7 @@
 		"artist": "MASAKI（ZUNTATA）「グルーヴコースター 3EX ドリームパーティー」より",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 130.054,
 			"genre": "VARIETY"
 		},
 		"id": 472,
@@ -5226,6 +5643,7 @@
 		"artist": "ChouCho",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 149.82,
 			"genre": "POPS & ANIME"
 		},
 		"id": 473,
@@ -5237,6 +5655,7 @@
 		"artist": "讃州中学勇者部(照井春佳、三森すずこ、内山夕実、黒沢ともよ、長妻樹里)「結城友奈は勇者である」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 161.639,
 			"genre": "POPS & ANIME"
 		},
 		"id": 475,
@@ -5250,6 +5669,7 @@
 		"artist": "Dixie Flatline",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 147.792,
 			"genre": "niconico"
 		},
 		"id": 476,
@@ -5261,6 +5681,7 @@
 		"artist": "iroha(sasaki)／kuma(alfred)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 151.488,
 			"genre": "niconico"
 		},
 		"id": 477,
@@ -5275,6 +5696,7 @@
 		"artist": "halyosy",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 160.64,
 			"genre": "niconico"
 		},
 		"id": 478,
@@ -5286,6 +5708,7 @@
 		"artist": "シンP",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 145.415,
 			"genre": "niconico"
 		},
 		"id": 479,
@@ -5302,6 +5725,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 165.214,
 			"genre": "イロドリミドリ"
 		},
 		"id": 481,
@@ -5315,6 +5739,7 @@
 		"artist": "Hi☆sCoool! セハガール",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 134.257,
 			"genre": "POPS & ANIME"
 		},
 		"id": 482,
@@ -5328,6 +5753,7 @@
 		"artist": "光吉猛修「バーニングレンジャー」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 157.372,
 			"genre": "VARIETY"
 		},
 		"id": 483,
@@ -5343,6 +5769,7 @@
 		"artist": "クーナ(CV.喜多村英梨)「PHANTASY STAR ONLINE 2」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 151.636,
 			"genre": "POPS & ANIME"
 		},
 		"id": 485,
@@ -5354,6 +5781,7 @@
 		"artist": "Hiro「maimai」より",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 118.101,
 			"genre": "ゲキマイ"
 		},
 		"id": 486,
@@ -5365,6 +5793,7 @@
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 109.227,
 			"genre": "イロドリミドリ"
 		},
 		"id": 487,
@@ -5376,6 +5805,7 @@
 		"artist": "月鈴姉妹(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 141.463,
 			"genre": "イロドリミドリ"
 		},
 		"id": 488,
@@ -5389,6 +5819,7 @@
 		"artist": "OSTER project feat.ジェム",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 153.261,
 			"genre": "ORIGINAL"
 		},
 		"id": 489,
@@ -5400,6 +5831,7 @@
 		"artist": "HALFBY",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 147,
 			"genre": "ORIGINAL"
 		},
 		"id": 490,
@@ -5411,6 +5843,7 @@
 		"artist": "うたたP",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 148.594,
 			"genre": "ORIGINAL"
 		},
 		"id": 491,
@@ -5422,6 +5855,7 @@
 		"artist": "40mP feat.シャノ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 154.08,
 			"genre": "ORIGINAL"
 		},
 		"id": 492,
@@ -5436,6 +5870,7 @@
 		"artist": "Crusher-P",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 160.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 493,
@@ -5447,6 +5882,7 @@
 		"artist": "doriko feat.VALSHE",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.536,
 			"genre": "ORIGINAL"
 		},
 		"id": 494,
@@ -5458,6 +5894,7 @@
 		"artist": "Suara「うたわれるもの 偽りの仮面」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 156.705,
 			"genre": "POPS & ANIME"
 		},
 		"id": 495,
@@ -5472,6 +5909,7 @@
 		"artist": "HiTECH NINJA",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 141.563,
 			"genre": "ゲキマイ"
 		},
 		"id": 496,
@@ -5483,6 +5921,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 131.586,
 			"genre": "ゲキマイ"
 		},
 		"id": 497,
@@ -5496,6 +5935,7 @@
 		"artist": "EB (aka EarBreaker)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.143,
 			"genre": "ゲキマイ"
 		},
 		"id": 498,
@@ -5510,6 +5950,7 @@
 		"artist": "Project Grimoire",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.684,
 			"genre": "ゲキマイ"
 		},
 		"id": 499,
@@ -5524,6 +5965,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 156.857,
 			"genre": "イロドリミドリ"
 		},
 		"id": 500,
@@ -5537,6 +5979,7 @@
 		"artist": "Suara「うたわれるもの 二人の白皇」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 159.111,
 			"genre": "POPS & ANIME"
 		},
 		"id": 501,
@@ -5551,6 +5994,7 @@
 		"artist": "真理絵",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 134.231,
 			"genre": "POPS & ANIME"
 		},
 		"id": 502,
@@ -5562,6 +6006,7 @@
 		"artist": "ろん×Junky",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 143.153,
 			"genre": "niconico"
 		},
 		"id": 503,
@@ -5575,6 +6020,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 136.95,
 			"genre": "東方Project"
 		},
 		"id": 504,
@@ -5586,6 +6032,7 @@
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 152.229,
 			"genre": "東方Project"
 		},
 		"id": 505,
@@ -5597,6 +6044,7 @@
 		"artist": "-45",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 160.588,
 			"genre": "VARIETY"
 		},
 		"id": 506,
@@ -5608,6 +6056,7 @@
 		"artist": "水樹奈々「戦姫絶唱シンフォギアＧ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 146.211,
 			"genre": "POPS & ANIME"
 		},
 		"id": 509,
@@ -5619,6 +6068,7 @@
 		"artist": "EZFG",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 135.731,
 			"genre": "niconico"
 		},
 		"id": 511,
@@ -5632,6 +6082,7 @@
 		"artist": "ぬゆり",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 133.228,
 			"genre": "niconico"
 		},
 		"id": 512,
@@ -5645,6 +6096,7 @@
 		"artist": "Lemm",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 126.524,
 			"genre": "niconico"
 		},
 		"id": 513,
@@ -5656,6 +6108,7 @@
 		"artist": "hanzo",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 158.4,
 			"genre": "niconico"
 		},
 		"id": 514,
@@ -5669,6 +6122,7 @@
 		"artist": "GigaReol",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 157.929,
 			"genre": "niconico"
 		},
 		"id": 515,
@@ -5682,6 +6136,7 @@
 		"artist": "niki",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 135,
 			"genre": "niconico"
 		},
 		"id": 516,
@@ -5693,6 +6148,7 @@
 		"artist": "小野隊長とJimmy親分",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 132.346,
 			"genre": "ゲキマイ"
 		},
 		"id": 517,
@@ -5709,6 +6165,7 @@
 		"artist": "水谷瑠奈（NanosizeMir）「Rewrite」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 155.625,
 			"genre": "POPS & ANIME"
 		},
 		"id": 522,
@@ -5720,6 +6177,7 @@
 		"artist": "立花響（悠木碧）、風鳴翼（水樹奈々）、雪音クリス（高垣彩陽）、マリア・カデンツァヴナ・イヴ（日笠陽子）、月読調（南條愛乃）、暁切歌（茅野愛衣）、天羽奏（高山みなみ）「戦姫絶唱シンフォギアＧ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 136.034,
 			"genre": "POPS & ANIME"
 		},
 		"id": 523,
@@ -5734,6 +6192,7 @@
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 127.864,
 			"genre": "VARIETY"
 		},
 		"id": 524,
@@ -5745,6 +6204,7 @@
 		"artist": "MYTH & ROID「Re:ゼロから始める異世界生活」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 172.537,
 			"genre": "POPS & ANIME"
 		},
 		"id": 525,
@@ -5756,6 +6216,7 @@
 		"artist": "どうぶつビスケッツ×PPP「けものフレンズ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 151.765,
 			"genre": "POPS & ANIME"
 		},
 		"id": 526,
@@ -5770,6 +6231,7 @@
 		"artist": "IOSYSと愉快な⑨周年フレンズ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 128.914,
 			"genre": "東方Project"
 		},
 		"id": 528,
@@ -5788,6 +6250,7 @@
 		"artist": "逢坂大河（CV：釘宮理恵）・櫛枝実乃梨（CV：堀江由衣）・川嶋亜美（CV：喜多村英梨）「とらドラ！」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 134.813,
 			"genre": "POPS & ANIME"
 		},
 		"id": 529,
@@ -5801,6 +6264,7 @@
 		"artist": "逢坂大河（CV：釘宮理恵）・櫛枝実乃梨（CV：堀江由衣）・川嶋亜美（CV：喜多村英梨）「とらドラ！」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 146.143,
 			"genre": "POPS & ANIME"
 		},
 		"id": 530,
@@ -5814,6 +6278,7 @@
 		"artist": "逢坂大河（CV：釘宮理恵）・川嶋亜美（CV：喜多村英梨）「とらドラ！」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 118.909,
 			"genre": "POPS & ANIME"
 		},
 		"id": 531,
@@ -5827,6 +6292,7 @@
 		"artist": "クーナ(CV.喜多村英梨)「PHANTASY STAR ONLINE 2」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 135.429,
 			"genre": "POPS & ANIME"
 		},
 		"id": 532,
@@ -5838,6 +6304,7 @@
 		"artist": "クーナ(CV.喜多村英梨)「PHANTASY STAR ONLINE 2」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 132.019,
 			"genre": "POPS & ANIME"
 		},
 		"id": 533,
@@ -5851,6 +6318,7 @@
 		"artist": "kanone",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 142.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 534,
@@ -5862,6 +6330,7 @@
 		"artist": "shu-t",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 147.91,
 			"genre": "niconico"
 		},
 		"id": 535,
@@ -5873,6 +6342,7 @@
 		"artist": "平野 綾、茅原実里、後藤邑子　TVアニメ「涼宮ハルヒの憂鬱」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 138.663,
 			"genre": "POPS & ANIME"
 		},
 		"id": 537,
@@ -5886,6 +6356,7 @@
 		"artist": "WAiKURO",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 139.784,
 			"genre": "ゲキマイ"
 		},
 		"id": 538,
@@ -5902,6 +6373,7 @@
 		"artist": "ハチ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR",
+			"duration": 126.176,
 			"genre": "niconico"
 		},
 		"id": 540,
@@ -5916,6 +6388,7 @@
 		"artist": "ClariS「エロマンガ先生」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 156.909,
 			"genre": "POPS & ANIME"
 		},
 		"id": 541,
@@ -5929,6 +6402,7 @@
 		"artist": "TrySail「エロマンガ先生」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 154.254,
 			"genre": "POPS & ANIME"
 		},
 		"id": 542,
@@ -5940,6 +6414,7 @@
 		"artist": "らびりんず【千矢（ＣＶ．原田彩楓）＆紺（ＣＶ．本渡 楓）＆小梅（ＣＶ．久保ユリカ）＆ノノ（ＣＶ．佳村はるか）】「うらら迷路帖」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 156.852,
 			"genre": "POPS & ANIME"
 		},
 		"id": 544,
@@ -5953,6 +6428,7 @@
 		"artist": "A応P「おそ松さん」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 158.903,
 			"genre": "POPS & ANIME"
 		},
 		"id": 545,
@@ -5966,6 +6442,7 @@
 		"artist": "ZAQ「劇場版トリニティセブン」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 163.01,
 			"genre": "POPS & ANIME"
 		},
 		"id": 546,
@@ -5977,6 +6454,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 153.812,
 			"genre": "niconico"
 		},
 		"id": 547,
@@ -5990,6 +6468,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 147.857,
 			"genre": "VARIETY"
 		},
 		"id": 548,
@@ -6001,6 +6480,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 128.696,
 			"genre": "東方Project"
 		},
 		"id": 549,
@@ -6014,6 +6494,7 @@
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 154.946,
 			"genre": "イロドリミドリ"
 		},
 		"id": 550,
@@ -6027,6 +6508,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 149.916,
 			"genre": "ORIGINAL"
 		},
 		"id": 551,
@@ -6038,6 +6520,7 @@
 		"artist": "Masahiro “Godspeed” Aoki",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 145.095,
 			"genre": "ORIGINAL"
 		},
 		"id": 552,
@@ -6049,6 +6532,7 @@
 		"artist": "ナユタン星人「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 151.579,
 			"genre": "niconico"
 		},
 		"id": 553,
@@ -6062,6 +6546,7 @@
 		"artist": "かいりきベア「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 143.924,
 			"genre": "niconico"
 		},
 		"id": 554,
@@ -6077,6 +6562,7 @@
 		"artist": "ポリスピカデリー「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 145.059,
 			"genre": "niconico"
 		},
 		"id": 555,
@@ -6090,6 +6576,7 @@
 		"artist": "niki「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 129.405,
 			"genre": "niconico"
 		},
 		"id": 556,
@@ -6103,6 +6590,7 @@
 		"artist": "PolyphonicBranch「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 147,
 			"genre": "niconico"
 		},
 		"id": 557,
@@ -6117,6 +6605,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 149.053,
 			"genre": "イロドリミドリ"
 		},
 		"id": 558,
@@ -6130,6 +6619,7 @@
 		"artist": "NAOKI underground",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 137.554,
 			"genre": "ORIGINAL"
 		},
 		"id": 559,
@@ -6144,6 +6634,7 @@
 		"artist": "SPRiNGS「温泉むすめ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 159.429,
 			"genre": "POPS & ANIME"
 		},
 		"id": 560,
@@ -6157,6 +6648,7 @@
 		"artist": "SPRiNGS「温泉むすめ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 148.103,
 			"genre": "POPS & ANIME"
 		},
 		"id": 561,
@@ -6170,6 +6662,7 @@
 		"artist": "SPRiNGS「温泉むすめ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 135.375,
 			"genre": "POPS & ANIME"
 		},
 		"id": 562,
@@ -6183,6 +6676,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 141.5,
 			"genre": "イロドリミドリ"
 		},
 		"id": 564,
@@ -6194,6 +6688,7 @@
 		"artist": "happy machine",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 140.214,
 			"genre": "ORIGINAL"
 		},
 		"id": 565,
@@ -6205,6 +6700,7 @@
 		"artist": "Tomggg",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 146.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 566,
@@ -6216,6 +6712,7 @@
 		"artist": "Yunomi feat.nicamoq",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 135.938,
 			"genre": "ORIGINAL"
 		},
 		"id": 567,
@@ -6230,6 +6727,7 @@
 		"artist": "YUC'e",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 131.684,
 			"genre": "ORIGINAL"
 		},
 		"id": 568,
@@ -6241,6 +6739,7 @@
 		"artist": "Pa's Lam System",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 165,
 			"genre": "ORIGINAL"
 		},
 		"id": 569,
@@ -6252,6 +6751,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 139.149,
 			"genre": "ゲキマイ"
 		},
 		"id": 570,
@@ -6267,6 +6767,7 @@
 		"artist": "暁Records",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 147.384,
 			"genre": "東方Project"
 		},
 		"id": 572,
@@ -6278,6 +6779,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.25,
 			"genre": "東方Project"
 		},
 		"id": 573,
@@ -6291,6 +6793,7 @@
 		"artist": "パトリシア・オブ・エンド(CV：高森奈津美)、黒木 未知(CV：仙台エリ)、夕莉 シャチ(CV：浅川悠)、明日原 ユウキ(CV：種﨑敦美)「ノラと皇女と野良猫ハート」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 140.44,
 			"genre": "POPS & ANIME"
 		},
 		"id": 574,
@@ -6304,6 +6807,7 @@
 		"artist": "ハチ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 143.122,
 			"genre": "niconico"
 		},
 		"id": 575,
@@ -6317,6 +6821,7 @@
 		"artist": "米津玄師",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 161.667,
 			"genre": "POPS & ANIME"
 		},
 		"id": 577,
@@ -6330,6 +6835,7 @@
 		"artist": "Grand Thaw / Rigel Theatre",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 158.955,
 			"genre": "VARIETY"
 		},
 		"id": 578,
@@ -6341,6 +6847,7 @@
 		"artist": "Baby's breath「天使の3P！」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 92.486,
 			"genre": "POPS & ANIME"
 		},
 		"id": 579,
@@ -6354,6 +6861,7 @@
 		"artist": "Baby's breath「天使の3P！」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 92.031,
 			"genre": "POPS & ANIME"
 		},
 		"id": 580,
@@ -6367,6 +6875,7 @@
 		"artist": "ターニャ・デグレチャフ(CV.悠木碧)「幼女戦記」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 154.75,
 			"genre": "POPS & ANIME"
 		},
 		"id": 581,
@@ -6378,6 +6887,7 @@
 		"artist": "いとうかなこ「CHAOS;CHILD」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 120.714,
 			"genre": "POPS & ANIME"
 		},
 		"id": 582,
@@ -6389,6 +6899,7 @@
 		"artist": "電気式華憐音楽集団",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 156.131,
 			"genre": "POPS & ANIME"
 		},
 		"id": 583,
@@ -6402,6 +6913,7 @@
 		"artist": "分島花音「劇場版selector destructed WIXOSS」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 140.985,
 			"genre": "POPS & ANIME"
 		},
 		"id": 584,
@@ -6413,6 +6925,7 @@
 		"artist": "あべにゅうぷろじぇくと feat.天月めぐる＆如月すみれ「ツインエンジェルBREAK」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 156.051,
 			"genre": "POPS & ANIME"
 		},
 		"id": 585,
@@ -6427,6 +6940,7 @@
 		"artist": "みるくちゃん「ツインエンジェルBREAK」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 136.751,
 			"genre": "POPS & ANIME"
 		},
 		"id": 586,
@@ -6440,6 +6954,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 153.251,
 			"genre": "イロドリミドリ"
 		},
 		"id": 587,
@@ -6453,6 +6968,7 @@
 		"artist": "霜月はるか",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 141.842,
 			"genre": "ORIGINAL"
 		},
 		"id": 588,
@@ -6464,6 +6980,7 @@
 		"artist": "solfa feat.茶太",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 154.125,
 			"genre": "ORIGINAL"
 		},
 		"id": 589,
@@ -6477,6 +6994,7 @@
 		"artist": "片霧烈火オンザみんマンション",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 161.582,
 			"genre": "ORIGINAL"
 		},
 		"id": 590,
@@ -6490,6 +7008,7 @@
 		"artist": "ガヴリール（富田美憂），ヴィーネ（大西沙織），サターニャ（大空直美），ラフィエル（花澤香菜）「ガヴリールドロップアウト」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 140.536,
 			"genre": "POPS & ANIME"
 		},
 		"id": 591,
@@ -6503,6 +7022,7 @@
 		"artist": "れるりり",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 144.246,
 			"genre": "niconico"
 		},
 		"id": 592,
@@ -6516,6 +7036,7 @@
 		"artist": "骨盤P",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 164.617,
 			"genre": "niconico"
 		},
 		"id": 593,
@@ -6527,6 +7048,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 151,
 			"genre": "niconico"
 		},
 		"id": 594,
@@ -6540,6 +7062,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 147.931,
 			"genre": "niconico"
 		},
 		"id": 595,
@@ -6554,6 +7077,7 @@
 		"artist": "Machico「この素晴らしい世界に祝福を！2」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 132.317,
 			"genre": "POPS & ANIME"
 		},
 		"id": 597,
@@ -6565,6 +7089,7 @@
 		"artist": "EarBreaker feat. Mes w/光吉猛修",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 126.353,
 			"genre": "VARIETY"
 		},
 		"id": 598,
@@ -6578,6 +7103,7 @@
 		"artist": "Carotte☆（ripple＆めらみぽっぷ）",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 158.667,
 			"genre": "VARIETY"
 		},
 		"id": 599,
@@ -6589,6 +7115,7 @@
 		"artist": "月鈴 那知（ヴァイオリン） 伴奏：イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 171.168,
 			"genre": "イロドリミドリ"
 		},
 		"id": 600,
@@ -6605,6 +7132,7 @@
 		"artist": "なずな師匠＆小仏亭ちゃんなぎ(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 149.575,
 			"genre": "イロドリミドリ"
 		},
 		"id": 601,
@@ -6618,6 +7146,7 @@
 		"artist": "あまね＋ビートまりお(COOL＆CREATE)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 110.211,
 			"genre": "東方Project"
 		},
 		"id": 604,
@@ -6631,6 +7160,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 149.818,
 			"genre": "東方Project"
 		},
 		"id": 605,
@@ -6644,6 +7174,7 @@
 		"artist": "3L (NJK Record)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 157.133,
 			"genre": "東方Project"
 		},
 		"id": 606,
@@ -6655,6 +7186,7 @@
 		"artist": "Tatsh feat. 月子",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 148.022,
 			"genre": "東方Project"
 		},
 		"id": 607,
@@ -6666,6 +7198,7 @@
 		"artist": "劇団ひととせ「ひなこのーと」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 148.965,
 			"genre": "POPS & ANIME"
 		},
 		"id": 609,
@@ -6679,6 +7212,7 @@
 		"artist": "劇団ひととせ「ひなこのーと」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 151.405,
 			"genre": "POPS & ANIME"
 		},
 		"id": 610,
@@ -6692,6 +7226,7 @@
 		"artist": "セブンスシスターズ「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 156.591,
 			"genre": "POPS & ANIME"
 		},
 		"id": 611,
@@ -6703,6 +7238,7 @@
 		"artist": "Lia「Charlotte」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 145.6,
 			"genre": "POPS & ANIME"
 		},
 		"id": 612,
@@ -6714,6 +7250,7 @@
 		"artist": "L.I.N.K.s（相坂優歌／石原 舞／高橋李依／生田善子／山本希望）「アンジュ・ヴィエルジュ」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 160.333,
 			"genre": "POPS & ANIME"
 		},
 		"id": 613,
@@ -6725,6 +7262,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 170.016,
 			"genre": "イロドリミドリ"
 		},
 		"id": 614,
@@ -6736,6 +7274,7 @@
 		"artist": "M2U",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 123.036,
 			"genre": "ORIGINAL"
 		},
 		"id": 615,
@@ -6747,6 +7286,7 @@
 		"artist": "Taishi",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 136.978,
 			"genre": "ORIGINAL"
 		},
 		"id": 616,
@@ -6758,6 +7298,7 @@
 		"artist": "cybermiso",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 146.069,
 			"genre": "ORIGINAL"
 		},
 		"id": 617,
@@ -6769,6 +7310,7 @@
 		"artist": "光吉猛修 VS 穴山大輔",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 162.73,
 			"genre": "ORIGINAL"
 		},
 		"id": 618,
@@ -6785,6 +7327,7 @@
 		"artist": "Cres.",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 135,
 			"genre": "VARIETY"
 		},
 		"id": 619,
@@ -6796,6 +7339,7 @@
 		"artist": "高宮なすの(CV:鳴海杏子)「てーきゅう」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 157.403,
 			"genre": "POPS & ANIME"
 		},
 		"id": 620,
@@ -6809,6 +7353,7 @@
 		"artist": "トマリン(CV:小倉唯)「てーきゅう」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 136.467,
 			"genre": "POPS & ANIME"
 		},
 		"id": 621,
@@ -6822,6 +7367,7 @@
 		"artist": "RO-KYU-BU!「ロウきゅーぶ！SS」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 153.061,
 			"genre": "POPS & ANIME"
 		},
 		"id": 622,
@@ -6833,6 +7379,7 @@
 		"artist": "RO-KYU-BU!「ロウきゅーぶ！SS」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 158.054,
 			"genre": "POPS & ANIME"
 		},
 		"id": 623,
@@ -6844,6 +7391,7 @@
 		"artist": "雀が原中学卓球部「灼熱の卓球娘」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 152.489,
 			"genre": "POPS & ANIME"
 		},
 		"id": 624,
@@ -6857,6 +7405,7 @@
 		"artist": "DETRO a.k.a ルゼ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 162.251,
 			"genre": "VARIETY"
 		},
 		"id": 625,
@@ -6868,6 +7417,7 @@
 		"artist": "wowaka",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 136.926,
 			"genre": "niconico"
 		},
 		"id": 626,
@@ -6881,6 +7431,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 138.429,
 			"genre": "東方Project"
 		},
 		"id": 627,
@@ -6894,6 +7445,7 @@
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 131.55,
 			"genre": "東方Project"
 		},
 		"id": 628,
@@ -6908,6 +7460,7 @@
 		"artist": "Kai「Wonderland Wars」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 160,
 			"genre": "VARIETY"
 		},
 		"id": 629,
@@ -6919,6 +7472,7 @@
 		"artist": "Storyteller",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 159.75,
 			"genre": "niconico"
 		},
 		"id": 631,
@@ -6934,6 +7488,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 133.167,
 			"genre": "東方Project"
 		},
 		"id": 632,
@@ -6947,6 +7502,7 @@
 		"artist": "Sou×マチゲリータ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 139.3,
 			"genre": "ゲキマイ"
 		},
 		"id": 633,
@@ -6960,6 +7516,7 @@
 		"artist": "D.watt feat. ビートまりお (COOL&CREATE)",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 137.826,
 			"genre": "東方Project"
 		},
 		"id": 635,
@@ -6973,6 +7530,7 @@
 		"artist": "Last Note.",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 134.667,
 			"genre": "niconico"
 		},
 		"id": 636,
@@ -6986,6 +7544,7 @@
 		"artist": "ゆずひこ feat.めらみぽっぷ",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 135.852,
 			"genre": "東方Project"
 		},
 		"id": 637,
@@ -6999,6 +7558,7 @@
 		"artist": "清水一人(歌：近藤佳奈子)「新甲虫王者ムシキング」",
 		"data": {
 			"displayVersion": "CHUNITHM STAR PLUS",
+			"duration": 132.644,
 			"genre": "VARIETY"
 		},
 		"id": 638,
@@ -7012,6 +7572,7 @@
 		"artist": "fripSide「とある科学の超電磁砲S」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 158.96,
 			"genre": "POPS & ANIME"
 		},
 		"id": 639,
@@ -7023,6 +7584,7 @@
 		"artist": "上坂すみれ「ポプテピピック」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 152.114,
 			"genre": "POPS & ANIME"
 		},
 		"id": 640,
@@ -7034,6 +7596,7 @@
 		"artist": "fhána",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 156.446,
 			"genre": "POPS & ANIME"
 		},
 		"id": 642,
@@ -7048,6 +7611,7 @@
 		"artist": "PAULA TERRY",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 145.656,
 			"genre": "POPS & ANIME"
 		},
 		"id": 644,
@@ -7059,6 +7623,7 @@
 		"artist": "Machico「りゅうおうのおしごと！」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 144.816,
 			"genre": "POPS & ANIME"
 		},
 		"id": 645,
@@ -7072,6 +7637,7 @@
 		"artist": "Suara「うたわれるもの斬」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 153.723,
 			"genre": "POPS & ANIME"
 		},
 		"id": 646,
@@ -7085,6 +7651,7 @@
 		"artist": "鈴木このみ「Summer Pockets」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 131.958,
 			"genre": "POPS & ANIME"
 		},
 		"id": 647,
@@ -7098,6 +7665,7 @@
 		"artist": "saya「宇宙よりも遠い場所」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 103.394,
 			"genre": "POPS & ANIME"
 		},
 		"id": 648,
@@ -7109,6 +7677,7 @@
 		"artist": "StylipS",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 156.43,
 			"genre": "POPS & ANIME"
 		},
 		"id": 649,
@@ -7120,6 +7689,7 @@
 		"artist": "橋本みゆき",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 150.553,
 			"genre": "POPS & ANIME"
 		},
 		"id": 650,
@@ -7131,6 +7701,7 @@
 		"artist": "OxT「オーバーロード」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 156.001,
 			"genre": "POPS & ANIME"
 		},
 		"id": 651,
@@ -7142,6 +7713,7 @@
 		"artist": "MYTH & ROID「オーバーロード」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 138.319,
 			"genre": "POPS & ANIME"
 		},
 		"id": 652,
@@ -7153,6 +7725,7 @@
 		"artist": "じん×kemu",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 150.477,
 			"genre": "niconico"
 		},
 		"id": 653,
@@ -7166,6 +7739,7 @@
 		"artist": "日向電工",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 133.953,
 			"genre": "niconico"
 		},
 		"id": 654,
@@ -7179,6 +7753,7 @@
 		"artist": "ねじ式",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 160,
 			"genre": "niconico"
 		},
 		"id": 655,
@@ -7192,6 +7767,7 @@
 		"artist": "Orangestar",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 138.971,
 			"genre": "niconico"
 		},
 		"id": 656,
@@ -7203,6 +7779,7 @@
 		"artist": "みきとP",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 136,
 			"genre": "niconico"
 		},
 		"id": 657,
@@ -7218,6 +7795,7 @@
 		"artist": "ろん",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 133,
 			"genre": "niconico"
 		},
 		"id": 658,
@@ -7231,6 +7809,7 @@
 		"artist": "まふまふ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 146.633,
 			"genre": "niconico"
 		},
 		"id": 659,
@@ -7244,6 +7823,7 @@
 		"artist": "バルーン",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 144,
 			"genre": "niconico"
 		},
 		"id": 660,
@@ -7257,6 +7837,7 @@
 		"artist": "石鹸屋",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 144.317,
 			"genre": "東方Project"
 		},
 		"id": 662,
@@ -7271,6 +7852,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.893,
 			"genre": "東方Project"
 		},
 		"id": 663,
@@ -7285,6 +7867,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.藤枝あかね",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 104.757,
 			"genre": "東方Project"
 		},
 		"id": 664,
@@ -7299,6 +7882,7 @@
 		"artist": "NJK Record",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.488,
 			"genre": "東方Project"
 		},
 		"id": 665,
@@ -7310,6 +7894,7 @@
 		"artist": "DiGiTAL WiNG feat. 花たん",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 139.8,
 			"genre": "東方Project"
 		},
 		"id": 666,
@@ -7321,6 +7906,7 @@
 		"artist": "ビートまりお × Cranky",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 144.833,
 			"genre": "東方Project"
 		},
 		"id": 667,
@@ -7337,6 +7923,7 @@
 		"artist": "NOMA",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 142.898,
 			"genre": "VARIETY"
 		},
 		"id": 668,
@@ -7348,6 +7935,7 @@
 		"artist": "Cranky VS MASAKI「グルーヴコースター 3EX ドリームパーティー」より",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 149.754,
 			"genre": "VARIETY"
 		},
 		"id": 669,
@@ -7361,6 +7949,7 @@
 		"artist": "BEMANI Sound Team \"TAG\"「SOUND VOLTEX」より",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 126.439,
 			"genre": "VARIETY"
 		},
 		"id": 670,
@@ -7372,6 +7961,7 @@
 		"artist": "steμ feat.siroa「太鼓の達人」より",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 134.887,
 			"genre": "VARIETY"
 		},
 		"id": 671,
@@ -7383,6 +7973,7 @@
 		"artist": "目黒将司 Remixed by 小西利樹「ペルソナ5 ダンシング・スターナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 131.186,
 			"genre": "VARIETY"
 		},
 		"id": 672,
@@ -7396,6 +7987,7 @@
 		"artist": "小塚良太「ペルソナ5 ダンシング・スターナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 102.303,
 			"genre": "VARIETY"
 		},
 		"id": 673,
@@ -7407,6 +7999,7 @@
 		"artist": "目黒将司「ペルソナ3 ダンシング・ムーンナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 139.16,
 			"genre": "VARIETY"
 		},
 		"id": 674,
@@ -7420,6 +8013,7 @@
 		"artist": "目黒将司 Remixed by 浅倉大介「ペルソナ3 ダンシング・ムーンナイト」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 134.4,
 			"genre": "VARIETY"
 		},
 		"id": 675,
@@ -7434,6 +8028,7 @@
 		"artist": "Silentroom",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 161.178,
 			"genre": "VARIETY"
 		},
 		"id": 676,
@@ -7445,6 +8040,7 @@
 		"artist": "モリモリあつし",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 127.723,
 			"genre": "VARIETY"
 		},
 		"id": 677,
@@ -7456,6 +8052,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 133.671,
 			"genre": "VARIETY"
 		},
 		"id": 678,
@@ -7467,6 +8064,7 @@
 		"artist": "papyrus (orangentle)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 176.017,
 			"genre": "VARIETY"
 		},
 		"id": 679,
@@ -7478,6 +8076,7 @@
 		"artist": "削除 feat. void (Mournfinale)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 147.6,
 			"genre": "VARIETY"
 		},
 		"id": 681,
@@ -7489,6 +8088,7 @@
 		"artist": "山本美禰子「トトリのアトリエ ～アーランドの錬金術士２～」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 145.884,
 			"genre": "VARIETY"
 		},
 		"id": 682,
@@ -7500,6 +8100,7 @@
 		"artist": "五十嵐 撫子(CV:花井 美春)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 154.2,
 			"genre": "イロドリミドリ"
 		},
 		"id": 683,
@@ -7514,6 +8115,7 @@
 		"artist": "箱部 なる(CV:M・A・O)＆月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 152.444,
 			"genre": "イロドリミドリ"
 		},
 		"id": 684,
@@ -7525,6 +8127,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)＆小仏 凪(CV:佐倉 薫)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 143.103,
 			"genre": "イロドリミドリ"
 		},
 		"id": 685,
@@ -7538,6 +8141,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)＆天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 145.714,
 			"genre": "イロドリミドリ"
 		},
 		"id": 686,
@@ -7549,6 +8153,7 @@
 		"artist": "40mP feat.シャノ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 160.172,
 			"genre": "ORIGINAL"
 		},
 		"id": 688,
@@ -7562,6 +8167,7 @@
 		"artist": "164 feat.ウォルピスカーター",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 157.8,
 			"genre": "ORIGINAL"
 		},
 		"id": 689,
@@ -7573,6 +8179,7 @@
 		"artist": "Palme",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 143.636,
 			"genre": "ORIGINAL"
 		},
 		"id": 690,
@@ -7584,6 +8191,7 @@
 		"artist": "emon(Tes.) feat.松平なな",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 137.25,
 			"genre": "ORIGINAL"
 		},
 		"id": 691,
@@ -7595,6 +8203,7 @@
 		"artist": "笑う角を曲がる",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.914,
 			"genre": "ORIGINAL"
 		},
 		"id": 692,
@@ -7610,6 +8219,7 @@
 		"artist": "Snail's House",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 136.364,
 			"genre": "ORIGINAL"
 		},
 		"id": 693,
@@ -7621,6 +8231,7 @@
 		"artist": "カヒーナムジカ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 166.807,
 			"genre": "ORIGINAL"
 		},
 		"id": 694,
@@ -7632,6 +8243,7 @@
 		"artist": "Omoi feat.+α/あるふぁきゅん。",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 149.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 695,
@@ -7645,6 +8257,7 @@
 		"artist": "TORIENA",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.229,
 			"genre": "ORIGINAL"
 		},
 		"id": 696,
@@ -7656,6 +8269,7 @@
 		"artist": "ぬゆり",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 142.65,
 			"genre": "ORIGINAL"
 		},
 		"id": 697,
@@ -7667,6 +8281,7 @@
 		"artist": "dawn-system",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 130.857,
 			"genre": "ORIGINAL"
 		},
 		"id": 698,
@@ -7680,6 +8295,7 @@
 		"artist": "NirNo",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 141,
 			"genre": "ORIGINAL"
 		},
 		"id": 699,
@@ -7693,6 +8309,7 @@
 		"artist": "technoplanet",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 132.546,
 			"genre": "ORIGINAL"
 		},
 		"id": 700,
@@ -7706,6 +8323,7 @@
 		"artist": "Feryquitous",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 143.143,
 			"genre": "ORIGINAL"
 		},
 		"id": 701,
@@ -7717,6 +8335,7 @@
 		"artist": "Acotto",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 167.857,
 			"genre": "ORIGINAL"
 		},
 		"id": 702,
@@ -7733,6 +8352,7 @@
 		"artist": "キノシタ feat.YURiCa/花たん",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 143,
 			"genre": "ORIGINAL"
 		},
 		"id": 703,
@@ -7746,6 +8366,7 @@
 		"artist": "niki feat.noire",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 142.994,
 			"genre": "ORIGINAL"
 		},
 		"id": 704,
@@ -7757,6 +8378,7 @@
 		"artist": "SLAVE.V-V-R feat.Fantastic Youth",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 140.211,
 			"genre": "ORIGINAL"
 		},
 		"id": 705,
@@ -7770,6 +8392,7 @@
 		"artist": "盛るP feat.鈴森あおい",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 154.369,
 			"genre": "ORIGINAL"
 		},
 		"id": 706,
@@ -7783,6 +8406,7 @@
 		"artist": "カルロス袴田(サイゼP) feat.あやぽんず＊",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 157.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 707,
@@ -7797,6 +8421,7 @@
 		"artist": "Relect",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 139.875,
 			"genre": "ORIGINAL"
 		},
 		"id": 708,
@@ -7808,6 +8433,7 @@
 		"artist": "Rigel Theatre feat.ミーウェル",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 159.213,
 			"genre": "ORIGINAL"
 		},
 		"id": 710,
@@ -7821,6 +8447,7 @@
 		"artist": "owl＊tree feat.yaki＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 146.885,
 			"genre": "ORIGINAL"
 		},
 		"id": 711,
@@ -7832,6 +8459,7 @@
 		"artist": "USAO",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 156.632,
 			"genre": "ORIGINAL"
 		},
 		"id": 712,
@@ -7843,6 +8471,7 @@
 		"artist": "ガリガリさむし",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 147.921,
 			"genre": "ゲキマイ"
 		},
 		"id": 713,
@@ -7854,6 +8483,7 @@
 		"artist": "Masayoshi Minoshima feat. 綾倉盟",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 123.556,
 			"genre": "ゲキマイ"
 		},
 		"id": 715,
@@ -7865,6 +8495,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 137.097,
 			"genre": "ゲキマイ"
 		},
 		"id": 716,
@@ -7878,6 +8509,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 133.012,
 			"genre": "ゲキマイ"
 		},
 		"id": 717,
@@ -7889,6 +8521,7 @@
 		"artist": "みきとP",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 142.8,
 			"genre": "niconico"
 		},
 		"id": 720,
@@ -7903,6 +8536,7 @@
 		"artist": "Endorfin.",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 127.587,
 			"genre": "ORIGINAL"
 		},
 		"id": 721,
@@ -7914,6 +8548,7 @@
 		"artist": "D-Cee",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON",
+			"duration": 125.727,
 			"genre": "ゲキマイ"
 		},
 		"id": 722,
@@ -7927,6 +8562,7 @@
 		"artist": "BUMP OF CHICKEN「グランブルーファンタジー」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 153.231,
 			"genre": "POPS & ANIME"
 		},
 		"id": 723,
@@ -7938,6 +8574,7 @@
 		"artist": "ジータ（CV:金元寿子）、ルリア（CV:東山奈央）、ヴィーラ（CV:今井麻美）、マリー（CV:長谷川明子）「グランブルーファンタジー」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 155.179,
 			"genre": "POPS & ANIME"
 		},
 		"id": 724,
@@ -7952,6 +8589,7 @@
 		"artist": "亜咲花「ゆるキャン△」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 157.091,
 			"genre": "POPS & ANIME"
 		},
 		"id": 725,
@@ -7963,6 +8601,7 @@
 		"artist": "ZAQ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.114,
 			"genre": "POPS & ANIME"
 		},
 		"id": 726,
@@ -7974,6 +8613,7 @@
 		"artist": "DA PUMP",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 150,
 			"genre": "POPS & ANIME"
 		},
 		"id": 727,
@@ -7985,6 +8625,7 @@
 		"artist": "桜高軽音部「けいおん！」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 145.193,
 			"genre": "POPS & ANIME"
 		},
 		"id": 728,
@@ -7996,6 +8637,7 @@
 		"artist": "萩原 七々瀬(CV:東城 日沙子)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 131.99,
 			"genre": "イロドリミドリ"
 		},
 		"id": 729,
@@ -8009,6 +8651,7 @@
 		"artist": "Feryquitous",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 130.16,
 			"genre": "ゲキマイ"
 		},
 		"id": 730,
@@ -8020,6 +8663,7 @@
 		"artist": "中路もとめ feat.砂糖子",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 150.462,
 			"genre": "ORIGINAL"
 		},
 		"id": 731,
@@ -8033,6 +8677,7 @@
 		"artist": "PandaBoY",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 145.862,
 			"genre": "ORIGINAL"
 		},
 		"id": 732,
@@ -8044,6 +8689,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 156.117,
 			"genre": "ORIGINAL"
 		},
 		"id": 733,
@@ -8058,6 +8704,7 @@
 		"artist": "HiTECH NINJA",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.455,
 			"genre": "ORIGINAL"
 		},
 		"id": 734,
@@ -8072,6 +8719,7 @@
 		"artist": "zts",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 156.643,
 			"genre": "ORIGINAL"
 		},
 		"id": 735,
@@ -8083,6 +8731,7 @@
 		"artist": "くらげP",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 146.135,
 			"genre": "niconico"
 		},
 		"id": 736,
@@ -8096,6 +8745,7 @@
 		"artist": "GYARI",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 126.667,
 			"genre": "niconico"
 		},
 		"id": 737,
@@ -8110,6 +8760,7 @@
 		"artist": "キノシタ feat. 音街ウナ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 150.486,
 			"genre": "niconico"
 		},
 		"id": 738,
@@ -8124,6 +8775,7 @@
 		"artist": "カルロス袴田(サイゼP)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 159.116,
 			"genre": "niconico"
 		},
 		"id": 739,
@@ -8137,6 +8789,7 @@
 		"artist": "バルーン",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 140.308,
 			"genre": "niconico"
 		},
 		"id": 740,
@@ -8151,6 +8804,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 140.899,
 			"genre": "東方Project"
 		},
 		"id": 741,
@@ -8165,6 +8819,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 139.091,
 			"genre": "東方Project"
 		},
 		"id": 742,
@@ -8176,6 +8831,7 @@
 		"artist": "暁Records",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 155.692,
 			"genre": "東方Project"
 		},
 		"id": 743,
@@ -8189,6 +8845,7 @@
 		"artist": "Pizuya's Cell",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 139.904,
 			"genre": "東方Project"
 		},
 		"id": 744,
@@ -8202,6 +8859,7 @@
 		"artist": "ARM (IOSYS)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.571,
 			"genre": "東方Project"
 		},
 		"id": 745,
@@ -8216,6 +8874,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 149.231,
 			"genre": "イロドリミドリ"
 		},
 		"id": 746,
@@ -8227,6 +8886,7 @@
 		"artist": "温泉むすめ 下呂美月 役 佐伯伊織「温泉むすめ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 162.353,
 			"genre": "POPS & ANIME"
 		},
 		"id": 747,
@@ -8241,6 +8901,7 @@
 		"artist": "削除「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 154.8,
 			"genre": "VARIETY"
 		},
 		"id": 749,
@@ -8252,6 +8913,7 @@
 		"artist": "ak+q「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 151.413,
 			"genre": "VARIETY"
 		},
 		"id": 750,
@@ -8263,6 +8925,7 @@
 		"artist": "Team Grimoire vs Laur「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 144.286,
 			"genre": "VARIETY"
 		},
 		"id": 751,
@@ -8276,6 +8939,7 @@
 		"artist": "kanone",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 137.806,
 			"genre": "VARIETY"
 		},
 		"id": 752,
@@ -8289,6 +8953,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 128.764,
 			"genre": "VARIETY"
 		},
 		"id": 753,
@@ -8300,6 +8965,7 @@
 		"artist": "月鈴 那知(CV:今村 彩夏)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.538,
 			"genre": "イロドリミドリ"
 		},
 		"id": 754,
@@ -8313,6 +8979,7 @@
 		"artist": "霜月はるか",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 142.889,
 			"genre": "ORIGINAL"
 		},
 		"id": 755,
@@ -8327,6 +8994,7 @@
 		"artist": "solfa feat.茶太",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.846,
 			"genre": "ORIGINAL"
 		},
 		"id": 756,
@@ -8341,6 +9009,7 @@
 		"artist": "片霧烈火",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 171.667,
 			"genre": "ORIGINAL"
 		},
 		"id": 757,
@@ -8352,6 +9021,7 @@
 		"artist": "4U「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 147.794,
 			"genre": "POPS & ANIME"
 		},
 		"id": 758,
@@ -8363,6 +9033,7 @@
 		"artist": "The QUEEN of PURPLE「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 154.105,
 			"genre": "POPS & ANIME"
 		},
 		"id": 759,
@@ -8374,6 +9045,7 @@
 		"artist": "じん",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 147.3,
 			"genre": "niconico"
 		},
 		"id": 760,
@@ -8388,6 +9060,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 145.99,
 			"genre": "niconico"
 		},
 		"id": 761,
@@ -8401,6 +9074,7 @@
 		"artist": "void (Mournfinale)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 140.688,
 			"genre": "ゲキマイ"
 		},
 		"id": 762,
@@ -8412,6 +9086,7 @@
 		"artist": "村川梨衣「ヒナまつり」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.475,
 			"genre": "POPS & ANIME"
 		},
 		"id": 763,
@@ -8423,6 +9098,7 @@
 		"artist": "庄司英徳「龍が如く２」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 120.828,
 			"genre": "VARIETY"
 		},
 		"id": 764,
@@ -8436,6 +9112,7 @@
 		"artist": "SoundDrive「龍が如く５　夢、叶えし者」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 138.868,
 			"genre": "VARIETY"
 		},
 		"id": 765,
@@ -8447,6 +9124,7 @@
 		"artist": "ナズナン星人 with せりな・あーりん(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 163.2,
 			"genre": "イロドリミドリ"
 		},
 		"id": 766,
@@ -8460,6 +9138,7 @@
 		"artist": "sasakure.UK x DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 119.314,
 			"genre": "niconico"
 		},
 		"id": 768,
@@ -8471,6 +9150,7 @@
 		"artist": "大空 遥（CV：優木かな）、比嘉かなた（CV：宮下早紀）「はるかなレシーブ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 138.095,
 			"genre": "POPS & ANIME"
 		},
 		"id": 769,
@@ -8482,6 +9162,7 @@
 		"artist": "大空 遥（CV：優木かな）、比嘉かなた（CV：宮下早紀）、トーマス・紅愛（CV：種﨑敦美）、トーマス・恵美理（CV：末柄里恵）「はるかなレシーブ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 137.91,
 			"genre": "POPS & ANIME"
 		},
 		"id": 770,
@@ -8493,6 +9174,7 @@
 		"artist": "mommy",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 118.261,
 			"genre": "VARIETY"
 		},
 		"id": 771,
@@ -8504,6 +9186,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 176.28,
 			"genre": "VARIETY"
 		},
 		"id": 772,
@@ -8515,6 +9198,7 @@
 		"artist": "ルゼ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 145.412,
 			"genre": "VARIETY"
 		},
 		"id": 773,
@@ -8526,6 +9210,7 @@
 		"artist": "舞ヶ原高校軽音部",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 126.626,
 			"genre": "イロドリミドリ"
 		},
 		"id": 774,
@@ -8537,6 +9222,7 @@
 		"artist": "igel",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.735,
 			"genre": "ORIGINAL"
 		},
 		"id": 775,
@@ -8550,6 +9236,7 @@
 		"artist": "Sampling Masters AYA",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.929,
 			"genre": "ORIGINAL"
 		},
 		"id": 776,
@@ -8564,6 +9251,7 @@
 		"artist": "DJ Myosuke",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 131.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 777,
@@ -8575,6 +9263,7 @@
 		"artist": "Void_Chords feat.MARU",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 157.403,
 			"genre": "POPS & ANIME"
 		},
 		"id": 778,
@@ -8586,6 +9275,7 @@
 		"artist": "セブンスシスターズ「Tokyo 7th シスターズ」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 154,
 			"genre": "POPS & ANIME"
 		},
 		"id": 779,
@@ -8597,6 +9287,7 @@
 		"artist": "DIVELA",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.882,
 			"genre": "niconico"
 		},
 		"id": 780,
@@ -8608,6 +9299,7 @@
 		"artist": "wowaka",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 147.368,
 			"genre": "niconico"
 		},
 		"id": 781,
@@ -8621,6 +9313,7 @@
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 156.387,
 			"genre": "東方Project"
 		},
 		"id": 782,
@@ -8632,6 +9325,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 160.206,
 			"genre": "イロドリミドリ"
 		},
 		"id": 783,
@@ -8643,6 +9337,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 142.222,
 			"genre": "ゲキマイ"
 		},
 		"id": 784,
@@ -8654,6 +9349,7 @@
 		"artist": "RD-Sounds feat.中恵光城",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 149.412,
 			"genre": "ORIGINAL"
 		},
 		"id": 785,
@@ -8668,6 +9364,7 @@
 		"artist": "葉月ゆら",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 143.226,
 			"genre": "ORIGINAL"
 		},
 		"id": 786,
@@ -8679,6 +9376,7 @@
 		"artist": "黒沢ダイスケ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.25,
 			"genre": "ORIGINAL"
 		},
 		"id": 787,
@@ -8690,6 +9388,7 @@
 		"artist": "Kai",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 151.68,
 			"genre": "ORIGINAL"
 		},
 		"id": 788,
@@ -8701,6 +9400,7 @@
 		"artist": "水樹奈々「魔法少女リリカルなのは Detonation」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 164.458,
 			"genre": "POPS & ANIME"
 		},
 		"id": 789,
@@ -8712,6 +9412,7 @@
 		"artist": "ぬるはち",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 144.522,
 			"genre": "東方Project"
 		},
 		"id": 791,
@@ -8723,6 +9424,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 141.167,
 			"genre": "東方Project"
 		},
 		"id": 792,
@@ -8736,6 +9438,7 @@
 		"artist": "豚乙女",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 134.25,
 			"genre": "東方Project"
 		},
 		"id": 793,
@@ -8749,6 +9452,7 @@
 		"artist": "Wake Up, May'n！「異世界食堂」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 148.126,
 			"genre": "POPS & ANIME"
 		},
 		"id": 794,
@@ -8760,6 +9464,7 @@
 		"artist": "ぬゆり",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 129.375,
 			"genre": "niconico"
 		},
 		"id": 795,
@@ -8775,6 +9480,7 @@
 		"artist": "Omoi",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 163.459,
 			"genre": "niconico"
 		},
 		"id": 796,
@@ -8788,6 +9494,7 @@
 		"artist": "盛るP",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 140,
 			"genre": "niconico"
 		},
 		"id": 797,
@@ -8801,6 +9508,7 @@
 		"artist": "lumo",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 142.909,
 			"genre": "niconico"
 		},
 		"id": 798,
@@ -8814,6 +9522,7 @@
 		"artist": "sun3",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 145.548,
 			"genre": "東方Project"
 		},
 		"id": 799,
@@ -8828,6 +9537,7 @@
 		"artist": "曲：kz(livetune)／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 157.778,
 			"genre": "ゲキマイ"
 		},
 		"id": 802,
@@ -8839,6 +9549,7 @@
 		"artist": "siqlo",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 149.231,
 			"genre": "ORIGINAL"
 		},
 		"id": 803,
@@ -8850,6 +9561,7 @@
 		"artist": "箱部孟徳 feat.小仏氏(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 168.474,
 			"genre": "イロドリミドリ"
 		},
 		"id": 804,
@@ -8863,6 +9575,7 @@
 		"artist": "wa. remixed celas",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 122.667,
 			"genre": "VARIETY"
 		},
 		"id": 806,
@@ -8877,6 +9590,7 @@
 		"artist": "M2U",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 135.577,
 			"genre": "VARIETY"
 		},
 		"id": 807,
@@ -8888,6 +9602,7 @@
 		"artist": "BUMP OF CHICKEN「グランブルーファンタジー」",
 		"data": {
 			"displayVersion": "CHUNITHM AMAZON PLUS",
+			"duration": 153.231,
 			"genre": "POPS & ANIME"
 		},
 		"id": 808,
@@ -8899,6 +9614,7 @@
 		"artist": "GARNiDELiA「魔法科高校の劣等生」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 140.662,
 			"genre": "POPS & ANIME"
 		},
 		"id": 809,
@@ -8910,6 +9626,7 @@
 		"artist": "OxT「SSSS.GRIDMAN」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 152.36,
 			"genre": "POPS & ANIME"
 		},
 		"id": 810,
@@ -8921,6 +9638,7 @@
 		"artist": "米津玄師",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 105.517,
 			"genre": "POPS & ANIME"
 		},
 		"id": 811,
@@ -8932,6 +9650,7 @@
 		"artist": "ALTIMA「アクセル・ワールド」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 160.541,
 			"genre": "POPS & ANIME"
 		},
 		"id": 812,
@@ -8943,6 +9662,7 @@
 		"artist": "Division All Stars「ヒプノシスマイク」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 125.625,
 			"genre": "POPS & ANIME"
 		},
 		"id": 813,
@@ -8956,6 +9676,7 @@
 		"artist": "麻帆良学園中等部2-A「魔法先生ネギま！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 148.712,
 			"genre": "POPS & ANIME"
 		},
 		"id": 814,
@@ -8969,6 +9690,7 @@
 		"artist": "ヨルシカ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 136.286,
 			"genre": "POPS & ANIME"
 		},
 		"id": 815,
@@ -8982,6 +9704,7 @@
 		"artist": "Eve",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 144.935,
 			"genre": "niconico"
 		},
 		"id": 816,
@@ -8995,6 +9718,7 @@
 		"artist": "じん",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 132.857,
 			"genre": "niconico"
 		},
 		"id": 817,
@@ -9009,6 +9733,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 138.9,
 			"genre": "niconico"
 		},
 		"id": 818,
@@ -9022,6 +9747,7 @@
 		"artist": "ビートまりお(COOL＆CREATE)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 135,
 			"genre": "東方Project"
 		},
 		"id": 819,
@@ -9035,6 +9761,7 @@
 		"artist": "HaNaMiNa feat.Nadeshiko",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 157.895,
 			"genre": "イロドリミドリ"
 		},
 		"id": 821,
@@ -9046,6 +9773,7 @@
 		"artist": "Project Grimoire",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 131.1,
 			"genre": "ゲキマイ"
 		},
 		"id": 822,
@@ -9061,6 +9789,7 @@
 		"artist": "かねこちはる",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 134.057,
 			"genre": "ゲキマイ"
 		},
 		"id": 823,
@@ -9072,6 +9801,7 @@
 		"artist": "NAOKI MAEDA",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 120.571,
 			"genre": "ORIGINAL"
 		},
 		"id": 824,
@@ -9087,6 +9817,7 @@
 		"artist": "じーざす（ワンダフル☆オポチュニティ！） ft.96猫",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 148.75,
 			"genre": "ORIGINAL"
 		},
 		"id": 825,
@@ -9100,6 +9831,7 @@
 		"artist": "ユリイ・カノン feat.nameless",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 143.721,
 			"genre": "ORIGINAL"
 		},
 		"id": 826,
@@ -9113,6 +9845,7 @@
 		"artist": "溝口ゆうま axel. 大瀬良あい",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 132.527,
 			"genre": "ORIGINAL"
 		},
 		"id": 827,
@@ -9127,6 +9860,7 @@
 		"artist": "ゆゆうた",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 151.579,
 			"genre": "ORIGINAL"
 		},
 		"id": 828,
@@ -9140,6 +9874,7 @@
 		"artist": "かいりきベア feat.松下",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 145.532,
 			"genre": "ORIGINAL"
 		},
 		"id": 829,
@@ -9153,6 +9888,7 @@
 		"artist": "石渡太輔／アークシステムワークス",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 168,
 			"genre": "ORIGINAL"
 		},
 		"id": 830,
@@ -9164,6 +9900,7 @@
 		"artist": "yukitani",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 138.286,
 			"genre": "ORIGINAL"
 		},
 		"id": 831,
@@ -9175,6 +9912,7 @@
 		"artist": "削除 feat. Nikki Simmons",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 162,
 			"genre": "VARIETY"
 		},
 		"id": 832,
@@ -9188,6 +9926,7 @@
 		"artist": "eicateve",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.5,
 			"genre": "VARIETY"
 		},
 		"id": 833,
@@ -9199,6 +9938,7 @@
 		"artist": "立秋",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 158.462,
 			"genre": "ORIGINAL"
 		},
 		"id": 834,
@@ -9212,6 +9952,7 @@
 		"artist": "Noah",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 144.608,
 			"genre": "ORIGINAL"
 		},
 		"id": 835,
@@ -9223,6 +9964,7 @@
 		"artist": "Acotto",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 159.588,
 			"genre": "ORIGINAL"
 		},
 		"id": 836,
@@ -9234,6 +9976,7 @@
 		"artist": "Aoi Sumito",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 139.535,
 			"genre": "ORIGINAL"
 		},
 		"id": 837,
@@ -9248,6 +9991,7 @@
 		"artist": "litmus*",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 136.154,
 			"genre": "ORIGINAL"
 		},
 		"id": 838,
@@ -9259,6 +10003,7 @@
 		"artist": "Yu-dachi",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 155.261,
 			"genre": "ORIGINAL"
 		},
 		"id": 839,
@@ -9272,6 +10017,7 @@
 		"artist": "なきゃむりゃ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 163.486,
 			"genre": "niconico"
 		},
 		"id": 840,
@@ -9285,6 +10031,7 @@
 		"artist": "GYARI",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 156.618,
 			"genre": "niconico"
 		},
 		"id": 841,
@@ -9300,6 +10047,7 @@
 		"artist": "ONE (song by ナナホシ管弦楽団)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 138.667,
 			"genre": "niconico"
 		},
 		"id": 842,
@@ -9314,6 +10062,7 @@
 		"artist": "kemu",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 154.054,
 			"genre": "niconico"
 		},
 		"id": 843,
@@ -9327,6 +10076,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.2,
 			"genre": "niconico"
 		},
 		"id": 844,
@@ -9340,6 +10090,7 @@
 		"artist": "KOTOKO「ネコぱら」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 157.895,
 			"genre": "POPS & ANIME"
 		},
 		"id": 845,
@@ -9351,6 +10102,7 @@
 		"artist": "パトリシア・オブ・エンド(CV：高森奈津美)、黒木 未知(CV：仙台エリ)、夕莉 シャチ(CV：浅川悠)、明日原 ユウキ(CV：種﨑敦美)「ノラと皇女と野良猫ハート」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 145.185,
 			"genre": "POPS & ANIME"
 		},
 		"id": 846,
@@ -9364,6 +10116,7 @@
 		"artist": "小倉 唯「変態王子と笑わない猫。」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 150,
 			"genre": "POPS & ANIME"
 		},
 		"id": 847,
@@ -9375,6 +10128,7 @@
 		"artist": "sumijun(Halozy) feat. ななひら(Confetto)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 145.327,
 			"genre": "東方Project"
 		},
 		"id": 848,
@@ -9388,6 +10142,7 @@
 		"artist": "葛城 華(CV:丸岡 和佳奈)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 158.734,
 			"genre": "イロドリミドリ"
 		},
 		"id": 849,
@@ -9402,6 +10157,7 @@
 		"artist": "Norn",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 135.273,
 			"genre": "ORIGINAL"
 		},
 		"id": 850,
@@ -9413,6 +10169,7 @@
 		"artist": "Shi Kuang Lee feat.A-Tz",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.317,
 			"genre": "ORIGINAL"
 		},
 		"id": 851,
@@ -9424,6 +10181,7 @@
 		"artist": "Bo-Xun Lin 林柏勲",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.317,
 			"genre": "ORIGINAL"
 		},
 		"id": 852,
@@ -9435,6 +10193,7 @@
 		"artist": "James Landino feat.N i i",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 139.49,
 			"genre": "ORIGINAL"
 		},
 		"id": 853,
@@ -9446,6 +10205,7 @@
 		"artist": "3R2",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.458,
 			"genre": "ORIGINAL"
 		},
 		"id": 854,
@@ -9457,6 +10217,7 @@
 		"artist": "Tia「賭ケグルイ」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 148.732,
 			"genre": "POPS & ANIME"
 		},
 		"id": 855,
@@ -9468,6 +10229,7 @@
 		"artist": "スタァライト九九組「少女☆歌劇 レヴュースタァライト」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 161.625,
 			"genre": "POPS & ANIME"
 		},
 		"id": 856,
@@ -9479,6 +10241,7 @@
 		"artist": "奥井雅美「少女革命ウテナ」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 162.656,
 			"genre": "POPS & ANIME"
 		},
 		"id": 857,
@@ -9493,6 +10256,7 @@
 		"artist": "「サクラ大戦３ ～巴里は燃えているか～」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 133.878,
 			"genre": "VARIETY"
 		},
 		"id": 858,
@@ -9506,6 +10270,7 @@
 		"artist": "小野 美苗(CV:伊藤 美来)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 155.73,
 			"genre": "イロドリミドリ"
 		},
 		"id": 859,
@@ -9519,6 +10284,7 @@
 		"artist": "MOSAIC.WAV／t+pazolite feat.ななひら",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 138.977,
 			"genre": "ORIGINAL"
 		},
 		"id": 860,
@@ -9532,6 +10298,7 @@
 		"artist": "わたてん☆5「私に天使が舞い降りた！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 148.095,
 			"genre": "POPS & ANIME"
 		},
 		"id": 861,
@@ -9545,6 +10312,7 @@
 		"artist": "わたてん☆5「私に天使が舞い降りた！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.736,
 			"genre": "POPS & ANIME"
 		},
 		"id": 862,
@@ -9558,6 +10326,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 133.875,
 			"genre": "VARIETY"
 		},
 		"id": 863,
@@ -9569,6 +10338,7 @@
 		"artist": "BlackY vs. Yooh",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 150.309,
 			"genre": "ゲキマイ"
 		},
 		"id": 865,
@@ -9580,6 +10350,7 @@
 		"artist": "岸田教団&THE明星ロケッツ「ストライク・ザ・ブラッド」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 155.93,
 			"genre": "POPS & ANIME"
 		},
 		"id": 866,
@@ -9593,6 +10364,7 @@
 		"artist": "ハチ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 129.356,
 			"genre": "niconico"
 		},
 		"id": 867,
@@ -9608,6 +10380,7 @@
 		"artist": "アゴアニキ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 141.739,
 			"genre": "niconico"
 		},
 		"id": 868,
@@ -9621,6 +10394,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 149.2,
 			"genre": "niconico"
 		},
 		"id": 869,
@@ -9634,6 +10408,7 @@
 		"artist": "minato(流星P)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 125,
 			"genre": "niconico"
 		},
 		"id": 870,
@@ -9645,6 +10420,7 @@
 		"artist": "IOSYS TRAX (uno & D.watt)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 141.563,
 			"genre": "東方Project"
 		},
 		"id": 871,
@@ -9658,6 +10434,7 @@
 		"artist": "A-One",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 128.834,
 			"genre": "東方Project"
 		},
 		"id": 872,
@@ -9669,6 +10446,7 @@
 		"artist": "発熱巫女～ず",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 124.688,
 			"genre": "東方Project"
 		},
 		"id": 873,
@@ -9682,6 +10460,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 126.258,
 			"genre": "東方Project"
 		},
 		"id": 874,
@@ -9693,6 +10472,7 @@
 		"artist": "Liz Triangle",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 152.102,
 			"genre": "東方Project"
 		},
 		"id": 875,
@@ -9706,6 +10486,7 @@
 		"artist": "Masayoshi Minoshima × Nhato",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 153.913,
 			"genre": "東方Project"
 		},
 		"id": 876,
@@ -9720,6 +10501,7 @@
 		"artist": "麹町養蚕館",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 145.241,
 			"genre": "ORIGINAL"
 		},
 		"id": 877,
@@ -9734,6 +10516,7 @@
 		"artist": "Nhato",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 162.406,
 			"genre": "ORIGINAL"
 		},
 		"id": 878,
@@ -9745,6 +10528,7 @@
 		"artist": "nora2r",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 136.114,
 			"genre": "ORIGINAL"
 		},
 		"id": 879,
@@ -9756,6 +10540,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 147.914,
 			"genre": "ORIGINAL"
 		},
 		"id": 880,
@@ -9767,6 +10552,7 @@
 		"artist": "s-don vs. 翡乃イスカ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 149.032,
 			"genre": "ORIGINAL"
 		},
 		"id": 881,
@@ -9783,6 +10569,7 @@
 		"artist": "HaNaMiNa feat.Nanase",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 150.345,
 			"genre": "イロドリミドリ"
 		},
 		"id": 882,
@@ -9794,6 +10581,7 @@
 		"artist": "フランシュシュ「ゾンビランドサガ」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 159.767,
 			"genre": "POPS & ANIME"
 		},
 		"id": 883,
@@ -9807,6 +10595,7 @@
 		"artist": "フランシュシュ「ゾンビランドサガ」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 156.138,
 			"genre": "POPS & ANIME"
 		},
 		"id": 884,
@@ -9820,6 +10609,7 @@
 		"artist": "ESTi",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 127.059,
 			"genre": "VARIETY"
 		},
 		"id": 885,
@@ -9831,6 +10621,7 @@
 		"artist": "M2U",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 134.769,
 			"genre": "VARIETY"
 		},
 		"id": 886,
@@ -9842,6 +10633,7 @@
 		"artist": "Hosoe Shinji",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 106.8,
 			"genre": "VARIETY"
 		},
 		"id": 887,
@@ -9853,6 +10645,7 @@
 		"artist": "Mili「ゴブリンスレイヤー」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 149.67,
 			"genre": "POPS & ANIME"
 		},
 		"id": 888,
@@ -9864,6 +10657,7 @@
 		"artist": "Chu☆",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 127.125,
 			"genre": "POPS & ANIME"
 		},
 		"id": 889,
@@ -9877,6 +10671,7 @@
 		"artist": "FictionJunction YUUKA｢MADLAX｣",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 138.194,
 			"genre": "POPS & ANIME"
 		},
 		"id": 890,
@@ -9888,6 +10683,7 @@
 		"artist": "ゴリライザー制作委員会",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 107.391,
 			"genre": "VARIETY"
 		},
 		"id": 891,
@@ -9901,6 +10697,7 @@
 		"artist": "ナノ「緋弾のアリアAA」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 142.151,
 			"genre": "POPS & ANIME"
 		},
 		"id": 892,
@@ -9912,6 +10709,7 @@
 		"artist": "Sobrem a.k.a. Widowmaker",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 140.549,
 			"genre": "VARIETY"
 		},
 		"id": 893,
@@ -9923,6 +10721,7 @@
 		"artist": "Aliesrite* (Ym1024 feat. lamie*)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 136.957,
 			"genre": "VARIETY"
 		},
 		"id": 894,
@@ -9934,6 +10733,7 @@
 		"artist": "Junk",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 129.925,
 			"genre": "VARIETY"
 		},
 		"id": 895,
@@ -9945,6 +10745,7 @@
 		"artist": "曲：鯨井国家／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 126,
 			"genre": "ゲキマイ"
 		},
 		"id": 896,
@@ -9959,6 +10760,7 @@
 		"artist": "曲：上松範廉(Elements Garden)／歌：三角 葵(CV：春野 杏)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 149.167,
 			"genre": "ゲキマイ"
 		},
 		"id": 897,
@@ -9970,6 +10772,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 175.875,
 			"genre": "イロドリミドリ"
 		},
 		"id": 899,
@@ -9983,6 +10786,7 @@
 		"artist": "Bitplane",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 155.294,
 			"genre": "VARIETY"
 		},
 		"id": 900,
@@ -9997,6 +10801,7 @@
 		"artist": "Sammy sound team",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL",
+			"duration": 157.452,
 			"genre": "VARIETY"
 		},
 		"id": 901,
@@ -10010,6 +10815,7 @@
 		"artist": "井口裕香「ダンジョンに出会いを求めるのは間違っているだろうかⅡ」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 156,
 			"genre": "POPS & ANIME"
 		},
 		"id": 902,
@@ -10021,6 +10827,7 @@
 		"artist": "ヘスティア（CV:水瀬いのり）「ダンジョンに出会いを求めるのは間違っているだろうか」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 158.372,
 			"genre": "POPS & ANIME"
 		},
 		"id": 903,
@@ -10034,6 +10841,7 @@
 		"artist": "紗倉ひびき（CV:ファイルーズあい）＆街雄鳴造（CV:石川界人）「ダンベル何キロ持てる？」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 155.455,
 			"genre": "POPS & ANIME"
 		},
 		"id": 904,
@@ -10047,6 +10855,7 @@
 		"artist": "LiSA",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 156.457,
 			"genre": "POPS & ANIME"
 		},
 		"id": 905,
@@ -10061,6 +10870,7 @@
 		"artist": "中野家の五つ子（花澤香菜・竹達彩奈・伊藤美来・佐倉綾音・水瀬いのり） TVアニメ「五等分の花嫁」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 139.198,
 			"genre": "POPS & ANIME"
 		},
 		"id": 907,
@@ -10074,6 +10884,7 @@
 		"artist": "涼宮ハルヒ（CV.平野 綾） TVアニメ「涼宮ハルヒの憂鬱」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 161.635,
 			"genre": "POPS & ANIME"
 		},
 		"id": 908,
@@ -10085,6 +10896,7 @@
 		"artist": "livetune",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 144.314,
 			"genre": "niconico"
 		},
 		"id": 909,
@@ -10096,6 +10908,7 @@
 		"artist": "ginkiha「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 123.934,
 			"genre": "VARIETY"
 		},
 		"id": 910,
@@ -10107,6 +10920,7 @@
 		"artist": "Laur",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 141.474,
 			"genre": "VARIETY"
 		},
 		"id": 911,
@@ -10118,6 +10932,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)＆月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.714,
 			"genre": "イロドリミドリ"
 		},
 		"id": 912,
@@ -10131,6 +10946,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 166.909,
 			"genre": "イロドリミドリ"
 		},
 		"id": 913,
@@ -10144,6 +10960,7 @@
 		"artist": "島爺×蜂屋ななし",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 131.042,
 			"genre": "ゲキマイ"
 		},
 		"id": 914,
@@ -10155,6 +10972,7 @@
 		"artist": "亜沙 feat.くろくも",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 150.779,
 			"genre": "ORIGINAL"
 		},
 		"id": 915,
@@ -10166,6 +10984,7 @@
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 152.109,
 			"genre": "ORIGINAL"
 		},
 		"id": 916,
@@ -10180,6 +10999,7 @@
 		"artist": "黒魔",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.636,
 			"genre": "ORIGINAL"
 		},
 		"id": 917,
@@ -10194,6 +11014,7 @@
 		"artist": "Spiegel vs Ice",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 165.922,
 			"genre": "ORIGINAL"
 		},
 		"id": 918,
@@ -10205,6 +11026,7 @@
 		"artist": "山崎寛子「白猫プロジェクト」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 96.364,
 			"genre": "POPS & ANIME"
 		},
 		"id": 919,
@@ -10218,6 +11040,7 @@
 		"artist": "「白猫プロジェクト」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 106.045,
 			"genre": "POPS & ANIME"
 		},
 		"id": 920,
@@ -10231,6 +11054,7 @@
 		"artist": "はるまきごはん",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 146.124,
 			"genre": "niconico"
 		},
 		"id": 921,
@@ -10244,6 +11068,7 @@
 		"artist": "GYARI",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 178.5,
 			"genre": "niconico"
 		},
 		"id": 922,
@@ -10260,6 +11085,7 @@
 		"artist": "ユリイ・カノン",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 137.379,
 			"genre": "niconico"
 		},
 		"id": 923,
@@ -10273,6 +11099,7 @@
 		"artist": "らき・あいね・みお from BEST FRIENDS！/わか・るか・せな「アイカツオンパレード！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 134.526,
 			"genre": "POPS & ANIME"
 		},
 		"id": 924,
@@ -10288,6 +11115,7 @@
 		"artist": "わか・ふうり・すなお from STAR☆ANIS「アイカツ！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 111.245,
 			"genre": "POPS & ANIME"
 		},
 		"id": 925,
@@ -10301,6 +11129,7 @@
 		"artist": "榊原 ゆい「Dies irae」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 153.391,
 			"genre": "POPS & ANIME"
 		},
 		"id": 926,
@@ -10312,6 +11141,7 @@
 		"artist": "LeaF & Optie & Fiz",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 149.142,
 			"genre": "VARIETY"
 		},
 		"id": 927,
@@ -10323,6 +11153,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)＆箱部 なる(CV:M・A・O)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 150,
 			"genre": "イロドリミドリ"
 		},
 		"id": 928,
@@ -10334,6 +11165,7 @@
 		"artist": "激戦の人",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 139.251,
 			"genre": "東方Project"
 		},
 		"id": 929,
@@ -10348,6 +11180,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 158.333,
 			"genre": "東方Project"
 		},
 		"id": 930,
@@ -10359,6 +11192,7 @@
 		"artist": "岸田教団&THE明星ロケッツ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 143.478,
 			"genre": "東方Project"
 		},
 		"id": 931,
@@ -10373,6 +11207,7 @@
 		"artist": "Alstroemeria Records",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 143.917,
 			"genre": "東方Project"
 		},
 		"id": 932,
@@ -10386,6 +11221,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 120,
 			"genre": "東方Project"
 		},
 		"id": 933,
@@ -10399,6 +11235,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 160.216,
 			"genre": "イロドリミドリ"
 		},
 		"id": 934,
@@ -10412,6 +11249,7 @@
 		"artist": "はるまきごはん feat.めらみぽっぷ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 139.2,
 			"genre": "ORIGINAL"
 		},
 		"id": 935,
@@ -10425,6 +11263,7 @@
 		"artist": "YM feat.かんせる",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 156.522,
 			"genre": "ORIGINAL"
 		},
 		"id": 936,
@@ -10438,6 +11277,7 @@
 		"artist": "ポリスピカデリー feat.相宮零",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 144.309,
 			"genre": "ORIGINAL"
 		},
 		"id": 937,
@@ -10452,6 +11292,7 @@
 		"artist": "うどんゲルゲ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.818,
 			"genre": "ORIGINAL"
 		},
 		"id": 938,
@@ -10463,6 +11304,7 @@
 		"artist": "八王子P「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 144.49,
 			"genre": "niconico"
 		},
 		"id": 939,
@@ -10476,6 +11318,7 @@
 		"artist": "梅とら「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 142.154,
 			"genre": "niconico"
 		},
 		"id": 940,
@@ -10487,6 +11330,7 @@
 		"artist": "buzzG「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 136.774,
 			"genre": "niconico"
 		},
 		"id": 941,
@@ -10500,6 +11344,7 @@
 		"artist": "164「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 150.857,
 			"genre": "niconico"
 		},
 		"id": 942,
@@ -10514,6 +11359,7 @@
 		"artist": "さつき が てんこもり「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 154.154,
 			"genre": "niconico"
 		},
 		"id": 943,
@@ -10528,6 +11374,7 @@
 		"artist": "onoken",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 171.667,
 			"genre": "VARIETY"
 		},
 		"id": 944,
@@ -10541,6 +11388,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)＆天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 151.059,
 			"genre": "イロドリミドリ"
 		},
 		"id": 945,
@@ -10554,6 +11402,7 @@
 		"artist": "owl＊tree feat.yu＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 155.51,
 			"genre": "ORIGINAL"
 		},
 		"id": 946,
@@ -10567,6 +11416,7 @@
 		"artist": "さつき が てんこもり feat.kana",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 151.214,
 			"genre": "ORIGINAL"
 		},
 		"id": 947,
@@ -10581,6 +11431,7 @@
 		"artist": "コバヤシユウヤ（IOSYS） feat.You-Re:",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 143.377,
 			"genre": "ORIGINAL"
 		},
 		"id": 948,
@@ -10594,6 +11445,7 @@
 		"artist": "Clean Tears feat.kukuri",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 144.8,
 			"genre": "ORIGINAL"
 		},
 		"id": 949,
@@ -10607,6 +11459,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 152.93,
 			"genre": "ORIGINAL"
 		},
 		"id": 950,
@@ -10620,6 +11473,7 @@
 		"artist": "HUiT「八月のシンデレラナイン」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 166,
 			"genre": "POPS & ANIME"
 		},
 		"id": 951,
@@ -10634,6 +11488,7 @@
 		"artist": "Clutch!「八月のシンデレラナイン」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 151.268,
 			"genre": "POPS & ANIME"
 		},
 		"id": 952,
@@ -10645,6 +11500,7 @@
 		"artist": "Omoi",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 153.45,
 			"genre": "niconico"
 		},
 		"id": 953,
@@ -10659,6 +11515,7 @@
 		"artist": "和田たけあき",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 162.829,
 			"genre": "niconico"
 		},
 		"id": 954,
@@ -10672,6 +11529,7 @@
 		"artist": "EasyPop",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 138.095,
 			"genre": "niconico"
 		},
 		"id": 955,
@@ -10683,6 +11541,7 @@
 		"artist": "分島花音「selector infected WIXOSS」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 136,
 			"genre": "POPS & ANIME"
 		},
 		"id": 956,
@@ -10694,6 +11553,7 @@
 		"artist": "井口裕香「Lostorage incited WIXOSS」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 125.714,
 			"genre": "POPS & ANIME"
 		},
 		"id": 957,
@@ -10705,6 +11565,7 @@
 		"artist": "Yunomi & nicamoq",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 140.156,
 			"genre": "VARIETY"
 		},
 		"id": 958,
@@ -10719,6 +11580,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 153.75,
 			"genre": "VARIETY"
 		},
 		"id": 959,
@@ -10730,6 +11592,7 @@
 		"artist": "HaNaMiNa",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 154.2,
 			"genre": "イロドリミドリ"
 		},
 		"id": 960,
@@ -10741,6 +11604,7 @@
 		"artist": "V.I.(Various Irodorimidori)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.59,
 			"genre": "イロドリミドリ"
 		},
 		"id": 961,
@@ -10752,6 +11616,7 @@
 		"artist": "佐倉綾音（天宮さくら）、内田真礼（東雲初穂）、山村響（望月あざみ）、福原綾香（アナスタシア・パルマ）、早見沙織（クラリス）「新サクラ大戦」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 174.965,
 			"genre": "VARIETY"
 		},
 		"id": 962,
@@ -10765,6 +11630,7 @@
 		"artist": "歌：ひばり児童合唱団、作曲：宮内國郎、作詞：ナック企画部「チャージマン研！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 143.367,
 			"genre": "POPS & ANIME"
 		},
 		"id": 963,
@@ -10778,6 +11644,7 @@
 		"artist": "作曲：宮内國郎「チャージマン研！」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 105.499,
 			"genre": "POPS & ANIME"
 		},
 		"id": 964,
@@ -10791,6 +11658,7 @@
 		"artist": "ALI PROJECT「ローゼンメイデン」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 164.628,
 			"genre": "POPS & ANIME"
 		},
 		"id": 965,
@@ -10804,6 +11672,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 135.789,
 			"genre": "VARIETY"
 		},
 		"id": 966,
@@ -10815,6 +11684,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 161.489,
 			"genre": "イロドリミドリ"
 		},
 		"id": 967,
@@ -10828,6 +11698,7 @@
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 124.966,
 			"genre": "イロドリミドリ"
 		},
 		"id": 968,
@@ -10839,6 +11710,7 @@
 		"artist": "MK&Kanae Asaba",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 142.154,
 			"genre": "ORIGINAL"
 		},
 		"id": 969,
@@ -10850,6 +11722,7 @@
 		"artist": "t+pazolite (HARDCORE TANO*C) feat.TANO*C ALL STARS",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 155.351,
 			"genre": "ORIGINAL"
 		},
 		"id": 970,
@@ -10863,6 +11736,7 @@
 		"artist": "ETIA.",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 149.486,
 			"genre": "ORIGINAL"
 		},
 		"id": 971,
@@ -10874,6 +11748,7 @@
 		"artist": "suzu",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 140.952,
 			"genre": "ORIGINAL"
 		},
 		"id": 972,
@@ -10889,6 +11764,7 @@
 		"artist": "曲：宮崎誠／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 142.088,
 			"genre": "ゲキマイ"
 		},
 		"id": 973,
@@ -10900,6 +11776,7 @@
 		"artist": "曲：ヒゲドライバー／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 156,
 			"genre": "ゲキマイ"
 		},
 		"id": 974,
@@ -10913,6 +11790,7 @@
 		"artist": "曲：TeddyLoid／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 149.2,
 			"genre": "ゲキマイ"
 		},
 		"id": 975,
@@ -10924,6 +11802,7 @@
 		"artist": "曲：Tom-H@ck／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.44,
 			"genre": "ゲキマイ"
 		},
 		"id": 976,
@@ -10937,6 +11816,7 @@
 		"artist": "仙狐（CV：和氣あず未）、シロ（CV：内田真礼）「世話やきキツネの仙狐さん」",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 138.641,
 			"genre": "POPS & ANIME"
 		},
 		"id": 977,
@@ -10950,6 +11830,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 168,
 			"genre": "VARIETY"
 		},
 		"id": 978,
@@ -10961,6 +11842,7 @@
 		"artist": "REDALiCE & aran",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 126.316,
 			"genre": "東方Project"
 		},
 		"id": 979,
@@ -10972,6 +11854,7 @@
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 149.143,
 			"genre": "東方Project"
 		},
 		"id": 980,
@@ -10985,6 +11868,7 @@
 		"artist": "光吉猛修の弟",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 125.902,
 			"genre": "VARIETY"
 		},
 		"id": 981,
@@ -10998,6 +11882,7 @@
 		"artist": "光吉猛修 VS 目黒将司",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 154.105,
 			"genre": "ORIGINAL"
 		},
 		"id": 982,
@@ -11011,6 +11896,7 @@
 		"artist": "カンザキイオリ",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 158.4,
 			"genre": "niconico"
 		},
 		"id": 983,
@@ -11024,6 +11910,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 157.164,
 			"genre": "niconico"
 		},
 		"id": 984,
@@ -11039,6 +11926,7 @@
 		"artist": "菅田将暉",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 117.677,
 			"genre": "POPS & ANIME"
 		},
 		"id": 986,
@@ -11052,6 +11940,7 @@
 		"artist": "ぬゆり",
 		"data": {
 			"displayVersion": "CHUNITHM CRYSTAL PLUS",
+			"duration": 144,
 			"genre": "niconico"
 		},
 		"id": 987,
@@ -11065,6 +11954,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 151.714,
 			"genre": "ORIGINAL"
 		},
 		"id": 988,
@@ -11078,6 +11968,7 @@
 		"artist": "達見 恵 featured by 佐野宏晃",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 161.486,
 			"genre": "ORIGINAL"
 		},
 		"id": 989,
@@ -11089,6 +11980,7 @@
 		"artist": "TOKOTOKO（西沢さんP） feat.あやぽんず＊",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 150,
 			"genre": "ORIGINAL"
 		},
 		"id": 990,
@@ -11102,6 +11994,7 @@
 		"artist": "Virtual Cat",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 150.612,
 			"genre": "ORIGINAL"
 		},
 		"id": 991,
@@ -11113,6 +12006,7 @@
 		"artist": "KOTONOHOUSE",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 145.455,
 			"genre": "ORIGINAL"
 		},
 		"id": 992,
@@ -11124,6 +12018,7 @@
 		"artist": "DIVELA feat.いゔどっと",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 140.854,
 			"genre": "ORIGINAL"
 		},
 		"id": 993,
@@ -11137,6 +12032,7 @@
 		"artist": "Laur vs CK",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 156.05,
 			"genre": "ORIGINAL"
 		},
 		"id": 994,
@@ -11148,6 +12044,7 @@
 		"artist": "USAO「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 141.6,
 			"genre": "VARIETY"
 		},
 		"id": 997,
@@ -11159,6 +12056,7 @@
 		"artist": "Feryquitous「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 167.454,
 			"genre": "VARIETY"
 		},
 		"id": 998,
@@ -11170,6 +12068,7 @@
 		"artist": "かめりあ「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 162.178,
 			"genre": "VARIETY"
 		},
 		"id": 999,
@@ -11181,6 +12080,7 @@
 		"artist": "Official髭男dism",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 157.5,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1000,
@@ -11192,6 +12092,7 @@
 		"artist": "TrySail",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 148.095,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1001,
@@ -11205,6 +12106,7 @@
 		"artist": "ヨルシカ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 158.4,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1002,
@@ -11220,6 +12122,7 @@
 		"artist": "福山芳樹「武装錬金」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 159.405,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1003,
@@ -11233,6 +12136,7 @@
 		"artist": "Eve",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 149.144,
 			"genre": "niconico"
 		},
 		"id": 1004,
@@ -11246,6 +12150,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 151.034,
 			"genre": "niconico"
 		},
 		"id": 1005,
@@ -11259,6 +12164,7 @@
 		"artist": "作曲：カジャ　作詞：傘村トータ　編曲：ねじ式　調声：シリア",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 148.989,
 			"genre": "niconico"
 		},
 		"id": 1006,
@@ -11272,6 +12178,7 @@
 		"artist": "かいりきベア",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 142.105,
 			"genre": "niconico"
 		},
 		"id": 1007,
@@ -11285,6 +12192,7 @@
 		"artist": "ビートまりお × USAO",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 140.195,
 			"genre": "東方Project"
 		},
 		"id": 1008,
@@ -11301,6 +12209,7 @@
 		"artist": "BlackY fused with WAiKURO",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 138.893,
 			"genre": "ゲキマイ"
 		},
 		"id": 1009,
@@ -11314,6 +12223,7 @@
 		"artist": "Laur",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 160.184,
 			"genre": "ゲキマイ"
 		},
 		"id": 1010,
@@ -11327,6 +12237,7 @@
 		"artist": "owl＊tree／t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 154.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 1011,
@@ -11338,6 +12249,7 @@
 		"artist": "藤堂 陽南袴(CV:八島 さらら)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 160.552,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1012,
@@ -11349,6 +12261,7 @@
 		"artist": "くるぶっこちゃん",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 156,
 			"genre": "ORIGINAL"
 		},
 		"id": 1013,
@@ -11362,6 +12275,7 @@
 		"artist": "サルケバ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 139.263,
 			"genre": "ORIGINAL"
 		},
 		"id": 1014,
@@ -11373,6 +12287,7 @@
 		"artist": "pan vs 7mai",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 121.799,
 			"genre": "ORIGINAL"
 		},
 		"id": 1015,
@@ -11384,6 +12299,7 @@
 		"artist": "Potwi",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 139.643,
 			"genre": "ORIGINAL"
 		},
 		"id": 1016,
@@ -11395,6 +12311,7 @@
 		"artist": "sasakure.UK VS 穴山大輔",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 173.315,
 			"genre": "ORIGINAL"
 		},
 		"id": 1017,
@@ -11408,6 +12325,7 @@
 		"artist": "嘘とカメレオン「虚構推理」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 152.923,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1018,
@@ -11421,6 +12339,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 168.808,
 			"genre": "niconico"
 		},
 		"id": 1019,
@@ -11436,6 +12355,7 @@
 		"artist": "はるまきごはん",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 153.568,
 			"genre": "niconico"
 		},
 		"id": 1020,
@@ -11451,6 +12371,7 @@
 		"artist": "n-buna × Orangestar",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 154,
 			"genre": "niconico"
 		},
 		"id": 1021,
@@ -11464,6 +12385,7 @@
 		"artist": "n-buna",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 156,
 			"genre": "niconico"
 		},
 		"id": 1022,
@@ -11477,6 +12399,7 @@
 		"artist": "hololive IDOL PROJECT",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 157.857,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1023,
@@ -11488,6 +12411,7 @@
 		"artist": "hololive IDOL PROJECT",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 114.725,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1024,
@@ -11501,6 +12425,7 @@
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 133.538,
 			"genre": "東方Project"
 		},
 		"id": 1025,
@@ -11515,6 +12440,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 139.709,
 			"genre": "東方Project"
 		},
 		"id": 1026,
@@ -11528,6 +12454,7 @@
 		"artist": "暁Records",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 130.536,
 			"genre": "東方Project"
 		},
 		"id": 1027,
@@ -11539,6 +12466,7 @@
 		"artist": "桔梗 小夜曲(CV:原田 彩楓)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 135.771,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1028,
@@ -11550,6 +12478,7 @@
 		"artist": "3R2 as Katzeohr",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 146.516,
 			"genre": "ORIGINAL"
 		},
 		"id": 1029,
@@ -11561,6 +12490,7 @@
 		"artist": "Ring feat.SLSMusic",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 164.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 1030,
@@ -11572,6 +12502,7 @@
 		"artist": "空氣載體 The AirCarrier",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 156.667,
 			"genre": "ORIGINAL"
 		},
 		"id": 1031,
@@ -11583,6 +12514,7 @@
 		"artist": "Iris",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 173.25,
 			"genre": "ORIGINAL"
 		},
 		"id": 1032,
@@ -11594,6 +12526,7 @@
 		"artist": "Spiegel vs Yukino",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 147.692,
 			"genre": "ORIGINAL"
 		},
 		"id": 1033,
@@ -11605,6 +12538,7 @@
 		"artist": "Cranky feat.おもしろ三国志",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 171.94,
 			"genre": "ORIGINAL"
 		},
 		"id": 1035,
@@ -11618,6 +12552,7 @@
 		"artist": "陰陽座",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 145,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1036,
@@ -11633,6 +12568,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 167.755,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1037,
@@ -11644,6 +12580,7 @@
 		"artist": "HiTECH NINJA",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 127.983,
 			"genre": "ゲキマイ"
 		},
 		"id": 1038,
@@ -11655,6 +12592,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 175.588,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1039,
@@ -11668,6 +12606,7 @@
 		"artist": "リンカ (CV: 豊田萌絵)「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 120.989,
 			"genre": "VARIETY"
 		},
 		"id": 1040,
@@ -11679,6 +12618,7 @@
 		"artist": "IOSYS TRAX (uno with.ちよこ)「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 116.625,
 			"genre": "VARIETY"
 		},
 		"id": 1041,
@@ -11694,6 +12634,7 @@
 		"artist": "Dr. ARM (IOSYS)「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 126.857,
 			"genre": "VARIETY"
 		},
 		"id": 1042,
@@ -11705,6 +12646,7 @@
 		"artist": "Team Grimoire vs MASAKI「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 145.297,
 			"genre": "VARIETY"
 		},
 		"id": 1043,
@@ -11718,6 +12660,7 @@
 		"artist": "REDALiCE vs MASAKI「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 149.1,
 			"genre": "VARIETY"
 		},
 		"id": 1044,
@@ -11731,6 +12674,7 @@
 		"artist": "shami momo（吉田優子・千代田桃）／CV：小原好美・鬼頭明里「まちカドまぞく」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 145.818,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1045,
@@ -11745,6 +12689,7 @@
 		"artist": "東山奈央「恋する小惑星」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 127.732,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1046,
@@ -11758,6 +12703,7 @@
 		"artist": "あんどうりんご（CV:今井麻美）「ぷよぷよ!!」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 149.275,
 			"genre": "VARIETY"
 		},
 		"id": 1048,
@@ -11771,6 +12717,7 @@
 		"artist": "the peggies「青春ブタ野郎はバニーガール先輩の夢を見ない」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 152.069,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1049,
@@ -11784,6 +12731,7 @@
 		"artist": "UNISON SQUARE GARDEN",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 148.8,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1050,
@@ -11795,6 +12743,7 @@
 		"artist": "ずっと真夜中でいいのに。",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 150.234,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1051,
@@ -11809,6 +12758,7 @@
 		"artist": "泉こなた（CV.平野 綾）、柊かがみ（CV.加藤英美里）、柊つかさ（CV.福原香織）、高良みゆき（CV.遠藤 綾）「らき☆すた」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 154.8,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1053,
@@ -11822,6 +12772,7 @@
 		"artist": "まふまふ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 143.75,
 			"genre": "niconico"
 		},
 		"id": 1054,
@@ -11835,6 +12786,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.2,
 			"genre": "東方Project"
 		},
 		"id": 1055,
@@ -11846,6 +12798,7 @@
 		"artist": "HaNaMiNa feat.Hana",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 163.875,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1056,
@@ -11859,6 +12812,7 @@
 		"artist": "芒崎 奏(CV:立花 理香)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 150.857,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1057,
@@ -11870,6 +12824,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 129,
 			"genre": "ゲキマイ"
 		},
 		"id": 1058,
@@ -11884,6 +12839,7 @@
 		"artist": "Yooh",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 126.487,
 			"genre": "ゲキマイ"
 		},
 		"id": 1059,
@@ -11897,6 +12853,7 @@
 		"artist": "烏屋茶房 feat.利香",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 158.873,
 			"genre": "ORIGINAL"
 		},
 		"id": 1060,
@@ -11910,6 +12867,7 @@
 		"artist": "柏木るざりん feat.青葉りんご",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 144,
 			"genre": "ORIGINAL"
 		},
 		"id": 1061,
@@ -11923,6 +12881,7 @@
 		"artist": "煮ル果実×びす",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 156,
 			"genre": "ORIGINAL"
 		},
 		"id": 1062,
@@ -11934,6 +12893,7 @@
 		"artist": "李 龟琍椏 feat.娜娜苤來",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 161.042,
 			"genre": "ORIGINAL"
 		},
 		"id": 1063,
@@ -11947,6 +12907,7 @@
 		"artist": "Neko Hacker feat.うごくちゃん",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 141.75,
 			"genre": "ORIGINAL"
 		},
 		"id": 1064,
@@ -11960,6 +12921,7 @@
 		"artist": "LamazeP feat.月乃",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.189,
 			"genre": "ORIGINAL"
 		},
 		"id": 1065,
@@ -11971,6 +12933,7 @@
 		"artist": "かゆき",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 142.909,
 			"genre": "ORIGINAL"
 		},
 		"id": 1066,
@@ -11982,6 +12945,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.75,
 			"genre": "niconico"
 		},
 		"id": 1067,
@@ -11995,6 +12959,7 @@
 		"artist": "うたたP",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 139.219,
 			"genre": "niconico"
 		},
 		"id": 1068,
@@ -12011,6 +12976,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 151.059,
 			"genre": "niconico"
 		},
 		"id": 1069,
@@ -12024,6 +12990,7 @@
 		"artist": "Silver Forest",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 137.647,
 			"genre": "東方Project"
 		},
 		"id": 1070,
@@ -12037,6 +13004,7 @@
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 132,
 			"genre": "東方Project"
 		},
 		"id": 1071,
@@ -12048,6 +13016,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 150,
 			"genre": "東方Project"
 		},
 		"id": 1072,
@@ -12062,6 +13031,7 @@
 		"artist": "少女フラクタル",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 150.706,
 			"genre": "東方Project"
 		},
 		"id": 1073,
@@ -12075,6 +13045,7 @@
 		"artist": "HaNaMiNa",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 139.579,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1074,
@@ -12088,6 +13059,7 @@
 		"artist": "PSYQUI feat.Such",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 145.059,
 			"genre": "ORIGINAL"
 		},
 		"id": 1075,
@@ -12099,6 +13071,7 @@
 		"artist": "Feryquitous feat.藍月なくる",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 135,
 			"genre": "ORIGINAL"
 		},
 		"id": 1076,
@@ -12112,6 +13085,7 @@
 		"artist": "ぺのれり",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 144.118,
 			"genre": "ORIGINAL"
 		},
 		"id": 1077,
@@ -12123,6 +13097,7 @@
 		"artist": "Yooh",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.712,
 			"genre": "ORIGINAL"
 		},
 		"id": 1078,
@@ -12134,6 +13109,7 @@
 		"artist": "Silentroom",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 155.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 1079,
@@ -12148,6 +13124,7 @@
 		"artist": "アインズ（CV：日野 聡）、カズマ（CV：福島 潤）、スバル（CV：小林裕介）、ターニャ（CV：悠木 碧）「異世界かるてっと」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 149.189,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1080,
@@ -12161,6 +13138,7 @@
 		"artist": "HaNaMiNa feat.Minae",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 145.263,
 			"genre": "イロドリミドリ"
 		},
 		"id": 1081,
@@ -12174,6 +13152,7 @@
 		"artist": "ああああ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 131.538,
 			"genre": "ゲキマイ"
 		},
 		"id": 1082,
@@ -12190,6 +13169,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 145.185,
 			"genre": "ゲキマイ"
 		},
 		"id": 1083,
@@ -12205,6 +13185,7 @@
 		"artist": "S!N・+α/あるふぁきゅん。×ALI PROJECT",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 152.276,
 			"genre": "ゲキマイ"
 		},
 		"id": 1084,
@@ -12216,6 +13197,7 @@
 		"artist": "TANO*C Sound Team",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 132.6,
 			"genre": "VARIETY"
 		},
 		"id": 1085,
@@ -12229,6 +13211,7 @@
 		"artist": "光吉猛修 VS 穴山大輔 VS Kai VS 水野健治 VS 大国奏音",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 177.929,
 			"genre": "ORIGINAL"
 		},
 		"id": 1086,
@@ -12244,6 +13227,7 @@
 		"artist": "曲：ヒゲドライバー／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.125,
 			"genre": "ゲキマイ"
 		},
 		"id": 1087,
@@ -12255,6 +13239,7 @@
 		"artist": "曲：ZAQ／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 153.375,
 			"genre": "ゲキマイ"
 		},
 		"id": 1088,
@@ -12268,6 +13253,7 @@
 		"artist": "曲：佐藤純一（fhána）／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 156.045,
 			"genre": "ゲキマイ"
 		},
 		"id": 1089,
@@ -12279,6 +13265,7 @@
 		"artist": "曲：NAOKI／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 135.57,
 			"genre": "ゲキマイ"
 		},
 		"id": 1090,
@@ -12290,6 +13277,7 @@
 		"artist": "しーけー",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 141.391,
 			"genre": "VARIETY"
 		},
 		"id": 1091,
@@ -12303,6 +13291,7 @@
 		"artist": "しらいし",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 153,
 			"genre": "VARIETY"
 		},
 		"id": 1092,
@@ -12317,6 +13306,7 @@
 		"artist": "茅原実里",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 152.727,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1093,
@@ -12328,6 +13318,7 @@
 		"artist": "Blacklolita",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148.921,
 			"genre": "ORIGINAL"
 		},
 		"id": 1094,
@@ -12339,6 +13330,7 @@
 		"artist": "リコ（CV：富田美憂）、レグ（CV：伊瀬茉莉也）「メイドインアビス」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.889,
 			"genre": "POPS & ANIME"
 		},
 		"id": 1095,
@@ -12350,6 +13342,7 @@
 		"artist": "かめりあ feat. ななひら",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 149.531,
 			"genre": "VARIETY"
 		},
 		"id": 1096,
@@ -12368,6 +13361,7 @@
 		"artist": "おもしろ三国志",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 150,
 			"genre": "VARIETY"
 		},
 		"id": 1098,
@@ -12381,6 +13375,7 @@
 		"artist": "ピノキオピー / 初音ミク / ワンダーランズ×ショウタイム「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE",
+			"duration": 122.609,
 			"genre": "niconico"
 		},
 		"id": 1099,
@@ -12394,6 +13389,7 @@
 		"artist": "PRASTIK DANCEFLOOR",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 138.806,
 			"genre": "ORIGINAL"
 		},
 		"id": 1100,
@@ -12405,6 +13401,7 @@
 		"artist": "かしこ。 feat.Cereus",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 144.375,
 			"genre": "ORIGINAL"
 		},
 		"id": 1101,
@@ -12418,6 +13415,7 @@
 		"artist": "emon(Tes.) feat.ねんね",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 164.118,
 			"genre": "ORIGINAL"
 		},
 		"id": 1102,
@@ -12429,6 +13427,7 @@
 		"artist": "みきとP feat. victream",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 146.323,
 			"genre": "ORIGINAL"
 		},
 		"id": 1103,
@@ -12440,6 +13439,7 @@
 		"artist": "ガルナ(オワタP) feat.水槽",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 138.75,
 			"genre": "ORIGINAL"
 		},
 		"id": 1104,
@@ -12453,6 +13453,7 @@
 		"artist": "ろくろ feat.鹿乃",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 153.559,
 			"genre": "ORIGINAL"
 		},
 		"id": 1105,
@@ -12467,6 +13468,7 @@
 		"artist": "cosMo＠暴走AlterEgo",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 144.144,
 			"genre": "ゲキマイ"
 		},
 		"id": 1106,
@@ -12483,6 +13485,7 @@
 		"artist": "MisoilePunch♪",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 150.856,
 			"genre": "ゲキマイ"
 		},
 		"id": 1107,
@@ -12496,6 +13499,7 @@
 		"artist": "DISH//「僕のヒーローアカデミア」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 93.238,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2000,
@@ -12507,6 +13511,7 @@
 		"artist": "星井美希、高槻やよい、菊地 真、双海亜美、双海真美、四条貴音「アイドルマスター」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 127.643,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2001,
@@ -12521,6 +13526,7 @@
 		"artist": "島村卯月、渋谷 凛、本田未央、赤城みりあ、安部菜々「アイドルマスター シンデレラガールズ」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 123.664,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2002,
@@ -12532,6 +13538,7 @@
 		"artist": "瑛人",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 117.407,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2006,
@@ -12546,6 +13553,7 @@
 		"artist": "DISH//",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 159.439,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2007,
@@ -12559,6 +13567,7 @@
 		"artist": "Mrs. GREEN APPLE",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 146.27,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2008,
@@ -12572,6 +13581,7 @@
 		"artist": "高橋洋子「新世紀エヴァンゲリオン」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.076,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2009,
@@ -12587,6 +13597,7 @@
 		"artist": "YOASOBI",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 168.421,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2010,
@@ -12604,6 +13615,7 @@
 		"artist": "X JAPAN [covered by 光吉猛修]",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 123.23,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2012,
@@ -12617,6 +13629,7 @@
 		"artist": "放課後ティータイム「けいおん！！」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 150.181,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2013,
@@ -12628,6 +13641,7 @@
 		"artist": "Eve TVアニメ「呪術廻戦」第1クールオープニングテーマ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 150.907,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2014,
@@ -12641,6 +13655,7 @@
 		"artist": "AKINO with bless4「甘城ブリリアントパーク」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 162,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2015,
@@ -12654,6 +13669,7 @@
 		"artist": "EGOIST CX系ノイタミナ「PSYCHO-PASS サイコパス」エンディングテーマ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 155.754,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2016,
@@ -12667,6 +13683,7 @@
 		"artist": "てにをは",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 132.774,
 			"genre": "niconico"
 		},
 		"id": 2017,
@@ -12680,6 +13697,7 @@
 		"artist": "Kanaria",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 137.349,
 			"genre": "niconico"
 		},
 		"id": 2018,
@@ -12691,6 +13709,7 @@
 		"artist": "デスおはぎ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 120.921,
 			"genre": "niconico"
 		},
 		"id": 2019,
@@ -12706,6 +13725,7 @@
 		"artist": "Eve",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 129.232,
 			"genre": "niconico"
 		},
 		"id": 2020,
@@ -12719,6 +13739,7 @@
 		"artist": "まふまふ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 132.837,
 			"genre": "niconico"
 		},
 		"id": 2021,
@@ -12732,6 +13753,7 @@
 		"artist": "DECO*27×堀江晶太(kemu)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 158.319,
 			"genre": "niconico"
 		},
 		"id": 2022,
@@ -12745,6 +13767,7 @@
 		"artist": "wowaka",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 123.498,
 			"genre": "niconico"
 		},
 		"id": 2023,
@@ -12759,6 +13782,7 @@
 		"artist": "トーマ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 134.267,
 			"genre": "niconico"
 		},
 		"id": 2024,
@@ -12773,6 +13797,7 @@
 		"artist": "かいりきベア・MARETU feat.初音ミク",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 134.08,
 			"genre": "niconico"
 		},
 		"id": 2025,
@@ -12786,6 +13811,7 @@
 		"artist": "木村わいP",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 92.421,
 			"genre": "niconico"
 		},
 		"id": 2026,
@@ -12800,6 +13826,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 165.963,
 			"genre": "niconico"
 		},
 		"id": 2027,
@@ -12813,6 +13840,7 @@
 		"artist": "ビートまりお × かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 154.889,
 			"genre": "東方Project"
 		},
 		"id": 2028,
@@ -12829,6 +13857,7 @@
 		"artist": "Masayoshi Minoshima × REDALiCE",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148.235,
 			"genre": "東方Project"
 		},
 		"id": 2029,
@@ -12843,6 +13872,7 @@
 		"artist": "SOUND HOLIC Vs. Eurobeat Union feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 128.421,
 			"genre": "東方Project"
 		},
 		"id": 2030,
@@ -12856,6 +13886,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 152.204,
 			"genre": "東方Project"
 		},
 		"id": 2031,
@@ -12867,6 +13898,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.山本椛",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 97.852,
 			"genre": "東方Project"
 		},
 		"id": 2032,
@@ -12881,6 +13913,7 @@
 		"artist": "COOL&CREATE × 宝鐘マリン with ホロイズムファンタジー",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 162.923,
 			"genre": "東方Project"
 		},
 		"id": 2033,
@@ -12895,6 +13928,7 @@
 		"artist": "KIEN (STREME REVERIE)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 133.514,
 			"genre": "VARIETY"
 		},
 		"id": 2034,
@@ -12906,6 +13940,7 @@
 		"artist": "from PACA PACA PASSION Special",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 135.275,
 			"genre": "VARIETY"
 		},
 		"id": 2035,
@@ -12919,6 +13954,7 @@
 		"artist": "Æsir「Cytus Ⅱ」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 159.621,
 			"genre": "VARIETY"
 		},
 		"id": 2036,
@@ -12930,6 +13966,7 @@
 		"artist": "PolyphonicBranch",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 157.821,
 			"genre": "niconico"
 		},
 		"id": 2037,
@@ -12945,6 +13982,7 @@
 		"artist": "TAK",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 132.502,
 			"genre": "VARIETY"
 		},
 		"id": 2038,
@@ -12956,6 +13994,7 @@
 		"artist": "並木学（ナミキマナブ）「怒首領蜂大復活」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 132.687,
 			"genre": "VARIETY"
 		},
 		"id": 2039,
@@ -12969,6 +14008,7 @@
 		"artist": "xi vs MASAKI「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 128.42,
 			"genre": "VARIETY"
 		},
 		"id": 2040,
@@ -12980,6 +14020,7 @@
 		"artist": "REDALiCE「太鼓の達人」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 137.871,
 			"genre": "VARIETY"
 		},
 		"id": 2041,
@@ -12991,6 +14032,7 @@
 		"artist": "GRATEC MOUR「CROSSxBEATS」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 112.921,
 			"genre": "VARIETY"
 		},
 		"id": 2042,
@@ -13004,6 +14046,7 @@
 		"artist": "jun「CROSSxBEATS」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 108.421,
 			"genre": "VARIETY"
 		},
 		"id": 2043,
@@ -13015,6 +14058,7 @@
 		"artist": "世阿弥「ミュージックガンガン！2」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 138.278,
 			"genre": "VARIETY"
 		},
 		"id": 2044,
@@ -13028,6 +14072,7 @@
 		"artist": "Tatsh&NAOKI feat.Kent Alexander",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 150.602,
 			"genre": "VARIETY"
 		},
 		"id": 2045,
@@ -13039,6 +14084,7 @@
 		"artist": "Tatsh x NAOKI",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 122.699,
 			"genre": "VARIETY"
 		},
 		"id": 2046,
@@ -13050,6 +14096,7 @@
 		"artist": "Sound piercer feat.DAZBEE",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 174.004,
 			"genre": "VARIETY"
 		},
 		"id": 2047,
@@ -13063,6 +14110,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 162.198,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2048,
@@ -13076,6 +14124,7 @@
 		"artist": "黒沢ダイスケ VS 穴山大輔",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 174.214,
 			"genre": "ゲキマイ"
 		},
 		"id": 2049,
@@ -13092,6 +14141,7 @@
 		"artist": "大国奏音",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 136.921,
 			"genre": "ゲキマイ"
 		},
 		"id": 2050,
@@ -13108,6 +14158,7 @@
 		"artist": "eoll",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 137.747,
 			"genre": "ORIGINAL"
 		},
 		"id": 2052,
@@ -13119,6 +14170,7 @@
 		"artist": "かねこちはる",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.483,
 			"genre": "ORIGINAL"
 		},
 		"id": 2053,
@@ -13132,6 +14184,7 @@
 		"artist": "monaca:factory feat.NORISTRY",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 146.154,
 			"genre": "ORIGINAL"
 		},
 		"id": 2054,
@@ -13143,6 +14196,7 @@
 		"artist": "R Sound Design feat.向日葵",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 151.33,
 			"genre": "ORIGINAL"
 		},
 		"id": 2055,
@@ -13154,6 +14208,7 @@
 		"artist": "yksb feat.MiLO",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 159.294,
 			"genre": "ORIGINAL"
 		},
 		"id": 2056,
@@ -13165,6 +14220,7 @@
 		"artist": "C.G mix feat. RINA",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 135.215,
 			"genre": "ORIGINAL"
 		},
 		"id": 2057,
@@ -13176,6 +14232,7 @@
 		"artist": "はるなば feat.すずしろ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148.021,
 			"genre": "ORIGINAL"
 		},
 		"id": 2058,
@@ -13187,6 +14244,7 @@
 		"artist": "片霧烈火",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 167.087,
 			"genre": "ORIGINAL"
 		},
 		"id": 2059,
@@ -13198,6 +14256,7 @@
 		"artist": "きくお×cosMo＠暴走P feat.影縫英",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 143.921,
 			"genre": "ORIGINAL"
 		},
 		"id": 2060,
@@ -13213,6 +14272,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 143.256,
 			"genre": "ORIGINAL"
 		},
 		"id": 2061,
@@ -13227,6 +14287,7 @@
 		"artist": "稲葉曇 feat.Rairu",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 154.826,
 			"genre": "ORIGINAL"
 		},
 		"id": 2062,
@@ -13240,6 +14301,7 @@
 		"artist": "れるりり feat.konoco",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148.972,
 			"genre": "ORIGINAL"
 		},
 		"id": 2063,
@@ -13253,6 +14315,7 @@
 		"artist": "アリスシャッハと魔法の楽団",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 145.684,
 			"genre": "ORIGINAL"
 		},
 		"id": 2064,
@@ -13267,6 +14330,7 @@
 		"artist": "大嶋啓之",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 141.603,
 			"genre": "ORIGINAL"
 		},
 		"id": 2065,
@@ -13281,6 +14345,7 @@
 		"artist": "yuigot feat.菅野真衣",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 137.465,
 			"genre": "ORIGINAL"
 		},
 		"id": 2066,
@@ -13292,6 +14357,7 @@
 		"artist": "Aiobahn",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 143.646,
 			"genre": "ORIGINAL"
 		},
 		"id": 2067,
@@ -13303,6 +14369,7 @@
 		"artist": "Avec Avec",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 160.421,
 			"genre": "ORIGINAL"
 		},
 		"id": 2068,
@@ -13314,6 +14381,7 @@
 		"artist": "Hercelot",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 136.842,
 			"genre": "ORIGINAL"
 		},
 		"id": 2069,
@@ -13325,6 +14393,7 @@
 		"artist": "星街すいせい（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 160.615,
 			"genre": "ORIGINAL"
 		},
 		"id": 2070,
@@ -13338,6 +14407,7 @@
 		"artist": "memex",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 136.235,
 			"genre": "ORIGINAL"
 		},
 		"id": 2071,
@@ -13349,6 +14419,7 @@
 		"artist": "ぼっちぼろまる",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 143.087,
 			"genre": "ORIGINAL"
 		},
 		"id": 2072,
@@ -13362,6 +14433,7 @@
 		"artist": "KMNZ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 145.969,
 			"genre": "ORIGINAL"
 		},
 		"id": 2073,
@@ -13373,6 +14445,7 @@
 		"artist": "Marpril",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 123.429,
 			"genre": "ORIGINAL"
 		},
 		"id": 2074,
@@ -13384,6 +14457,7 @@
 		"artist": "Poppin'Party「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 165.873,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2075,
@@ -13397,6 +14471,7 @@
 		"artist": "Roselia「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 142.665,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2076,
@@ -13408,6 +14483,7 @@
 		"artist": "曲：村カワ基成／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 159.769,
 			"genre": "ゲキマイ"
 		},
 		"id": 2077,
@@ -13422,6 +14498,7 @@
 		"artist": "亜咲花「ひぐらしのなく頃に 業」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 140.87,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2078,
@@ -13433,6 +14510,7 @@
 		"artist": "ユリイ・カノン feat.GUMI",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 117.273,
 			"genre": "niconico"
 		},
 		"id": 2079,
@@ -13446,6 +14524,7 @@
 		"artist": "GYARI",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 152.376,
 			"genre": "niconico"
 		},
 		"id": 2080,
@@ -13460,6 +14539,7 @@
 		"artist": "かいりきベア",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 138.913,
 			"genre": "niconico"
 		},
 		"id": 2081,
@@ -13473,6 +14553,7 @@
 		"artist": "箱部 なる(CV:M・A・O)＆小仏 凪(CV:佐倉 薫)＆月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 126.568,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2082,
@@ -13484,6 +14565,7 @@
 		"artist": "東方LostWord feat.いとうかなこ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 155.217,
 			"genre": "東方Project"
 		},
 		"id": 2083,
@@ -13498,6 +14580,7 @@
 		"artist": "くっちー (DARKSIDE APPROACH)",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 125.134,
 			"genre": "東方Project"
 		},
 		"id": 2084,
@@ -13512,6 +14595,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 157.777,
 			"genre": "東方Project"
 		},
 		"id": 2085,
@@ -13526,6 +14610,7 @@
 		"artist": "岸田教団&THE明星ロケッツ",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 149.816,
 			"genre": "東方Project"
 		},
 		"id": 2086,
@@ -13539,6 +14624,7 @@
 		"artist": "Unlucky Morpheus",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 148.645,
 			"genre": "東方Project"
 		},
 		"id": 2087,
@@ -13552,6 +14638,7 @@
 		"artist": "angela「乙女ゲームの破滅フラグしかない悪役令嬢に転生してしまった…」",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 102.045,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2088,
@@ -13565,6 +14652,7 @@
 		"artist": "BACO",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 138,
 			"genre": "VARIETY"
 		},
 		"id": 2089,
@@ -13576,6 +14664,7 @@
 		"artist": "Warak",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 169.688,
 			"genre": "ORIGINAL"
 		},
 		"id": 2090,
@@ -13587,6 +14676,7 @@
 		"artist": "James Landino feat.Nikki Simmons",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 146.8,
 			"genre": "ORIGINAL"
 		},
 		"id": 2091,
@@ -13598,6 +14688,7 @@
 		"artist": "Iris",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 176.094,
 			"genre": "ORIGINAL"
 		},
 		"id": 2092,
@@ -13609,6 +14700,7 @@
 		"artist": "3R2",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 139.765,
 			"genre": "ORIGINAL"
 		},
 		"id": 2093,
@@ -13620,6 +14712,7 @@
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 170.571,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2094,
@@ -13631,6 +14724,7 @@
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？BLOOM」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 153.896,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2095,
@@ -13644,6 +14738,7 @@
 		"artist": "HIMEHINA",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 117.643,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2096,
@@ -13657,6 +14752,7 @@
 		"artist": "白上フブキ（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.118,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2097,
@@ -13670,6 +14766,7 @@
 		"artist": "にじさんじ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 130.769,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2098,
@@ -13681,6 +14778,7 @@
 		"artist": "黒魔",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 161.018,
 			"genre": "ゲキマイ"
 		},
 		"id": 2099,
@@ -13695,6 +14793,7 @@
 		"artist": "鈴木このみ「Re:ゼロから始める異世界生活」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 166.602,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2100,
@@ -13706,6 +14805,7 @@
 		"artist": "稲葉曇",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 153.469,
 			"genre": "niconico"
 		},
 		"id": 2101,
@@ -13719,6 +14819,7 @@
 		"artist": "Ayase",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 151.452,
 			"genre": "niconico"
 		},
 		"id": 2102,
@@ -13733,6 +14834,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 135.705,
 			"genre": "niconico"
 		},
 		"id": 2103,
@@ -13746,6 +14848,7 @@
 		"artist": "HaNaMiNa",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 159.086,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2105,
@@ -13757,6 +14860,7 @@
 		"artist": "舞ヶ原Riders",
 		"data": {
 			"displayVersion": "CHUNITHM PARADISE LOST",
+			"duration": 155.854,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2106,
@@ -13770,6 +14874,7 @@
 		"artist": "Void_Chords feat. LIO「ありふれた職業で世界最強」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 140.488,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2107,
@@ -13781,6 +14886,7 @@
 		"artist": "曲：ゆよゆっぺ／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 140.108,
 			"genre": "ゲキマイ"
 		},
 		"id": 2108,
@@ -13792,6 +14898,7 @@
 		"artist": "曲：八木雄一 feat. Marty Friedman／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148.571,
 			"genre": "ゲキマイ"
 		},
 		"id": 2109,
@@ -13803,6 +14910,7 @@
 		"artist": "曲：村井大／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 145.263,
 			"genre": "ゲキマイ"
 		},
 		"id": 2110,
@@ -13817,6 +14925,7 @@
 		"artist": "Nhato",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 146.323,
 			"genre": "ゲキマイ"
 		},
 		"id": 2111,
@@ -13828,6 +14937,7 @@
 		"artist": "ペコリーヌ（M・A・O）、コッコロ（伊藤美来）、キャル（立花理香）「プリンセスコネクト！Re:Dive」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 153.2,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2112,
@@ -13839,6 +14949,7 @@
 		"artist": "ペコリーヌ（M・A・O）、コッコロ（伊藤美来）、キャル（立花理香）、ユイ（種田梨沙）、ヒヨリ（東山奈央）、レイ（早見沙織）、シェフィ（近藤玲奈）「プリンセスコネクト！Re:Dive」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 169.333,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2113,
@@ -13850,6 +14961,7 @@
 		"artist": "Innocent Key",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 148,
 			"genre": "東方Project"
 		},
 		"id": 2114,
@@ -13863,6 +14975,7 @@
 		"artist": "uno (IOSYS)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 127.5,
 			"genre": "東方Project"
 		},
 		"id": 2115,
@@ -13874,6 +14987,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)＆御形 アリシアナ(CV:福原 綾香)＆天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 138.923,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2116,
@@ -13887,6 +15001,7 @@
 		"artist": "Juggernaut.",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.434,
 			"genre": "ORIGINAL"
 		},
 		"id": 2117,
@@ -13898,6 +15013,7 @@
 		"artist": "Getty vs DJ DiA",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 135.6,
 			"genre": "ORIGINAL"
 		},
 		"id": 2118,
@@ -13909,6 +15025,7 @@
 		"artist": "Frums",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 156.961,
 			"genre": "ORIGINAL"
 		},
 		"id": 2119,
@@ -13920,6 +15037,7 @@
 		"artist": "owl＊tree feat. ka＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 151.525,
 			"genre": "ORIGINAL"
 		},
 		"id": 2120,
@@ -13931,6 +15049,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 172.985,
 			"genre": "ORIGINAL"
 		},
 		"id": 2121,
@@ -13942,6 +15061,7 @@
 		"artist": "wa. vs ETIA.",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 116.25,
 			"genre": "VARIETY"
 		},
 		"id": 2122,
@@ -13955,6 +15075,7 @@
 		"artist": "鹿乃と宇崎ちゃん「宇崎ちゃんは遊びたい！」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 92.8,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2123,
@@ -13969,6 +15090,7 @@
 		"artist": "mommy",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 138.667,
 			"genre": "VARIETY"
 		},
 		"id": 2124,
@@ -13980,6 +15102,7 @@
 		"artist": "Ino(chronoize) feat. 柳瀬マサキ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.647,
 			"genre": "VARIETY"
 		},
 		"id": 2125,
@@ -13993,6 +15116,7 @@
 		"artist": "Shaman Cure-All",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 139.459,
 			"genre": "VARIETY"
 		},
 		"id": 2126,
@@ -14004,6 +15128,7 @@
 		"artist": "立秋 feat.ちょこ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 113.358,
 			"genre": "VARIETY"
 		},
 		"id": 2127,
@@ -14017,6 +15142,7 @@
 		"artist": "Kusemono/SWANTONE",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 151.2,
 			"genre": "niconico"
 		},
 		"id": 2128,
@@ -14031,6 +15157,7 @@
 		"artist": "ジミーサムP",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 141.951,
 			"genre": "niconico"
 		},
 		"id": 2129,
@@ -14042,6 +15169,7 @@
 		"artist": "マチゲリータ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 149.647,
 			"genre": "niconico"
 		},
 		"id": 2130,
@@ -14056,6 +15184,7 @@
 		"artist": "OSTER project",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 142.737,
 			"genre": "niconico"
 		},
 		"id": 2131,
@@ -14069,6 +15198,7 @@
 		"artist": "ラマーズP",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 147.2,
 			"genre": "niconico"
 		},
 		"id": 2132,
@@ -14083,6 +15213,7 @@
 		"artist": "Project DIVA Original Song feat.初音ミク",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 154.286,
 			"genre": "niconico"
 		},
 		"id": 2133,
@@ -14094,6 +15225,7 @@
 		"artist": "曲：Powerless／歌：柏木 咲姫(CV：石見 舞菜香)、柏木 美亜(CV:和氣 あず未)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 150.529,
 			"genre": "ゲキマイ"
 		},
 		"id": 2134,
@@ -14105,6 +15237,7 @@
 		"artist": "USAO feat.光吉猛修",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 153.497,
 			"genre": "ORIGINAL"
 		},
 		"id": 2135,
@@ -14116,6 +15249,7 @@
 		"artist": "前島麻由「Re:ゼロから始める異世界生活」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 145.778,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2136,
@@ -14127,6 +15261,7 @@
 		"artist": "Toby Fox「UNDERTALE」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 165.75,
 			"genre": "VARIETY"
 		},
 		"id": 2137,
@@ -14138,6 +15273,7 @@
 		"artist": "わかどり",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 131.551,
 			"genre": "VARIETY"
 		},
 		"id": 2138,
@@ -14149,6 +15285,7 @@
 		"artist": "鈴原るる／でびでび・でびる",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 160,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2139,
@@ -14162,6 +15299,7 @@
 		"artist": "virkato",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 131.298,
 			"genre": "VARIETY"
 		},
 		"id": 2140,
@@ -14176,6 +15314,7 @@
 		"artist": "雨宮天「七つの大罪 憤怒の審判」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 140.795,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2141,
@@ -14189,6 +15328,7 @@
 		"artist": "スペシャルウィーク （CV.和氣あず未）、サイレンススズカ （CV.高野麻里佳）、トウカイテイオー （CV.Machico）",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 135.548,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2142,
@@ -14204,6 +15344,7 @@
 		"artist": "Ado",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 136.18,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2143,
@@ -14219,6 +15360,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 140.129,
 			"genre": "ゲキマイ"
 		},
 		"id": 2144,
@@ -14233,6 +15375,7 @@
 		"artist": "USAO",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 136.186,
 			"genre": "ゲキマイ"
 		},
 		"id": 2145,
@@ -14247,6 +15390,7 @@
 		"artist": "owl＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 158.308,
 			"genre": "ゲキマイ"
 		},
 		"id": 2146,
@@ -14258,6 +15402,7 @@
 		"artist": "kanone feat. せんざい",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 139.917,
 			"genre": "ゲキマイ"
 		},
 		"id": 2147,
@@ -14275,6 +15420,7 @@
 		"artist": "Chinozo",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 127.059,
 			"genre": "niconico"
 		},
 		"id": 2148,
@@ -14288,6 +15434,7 @@
 		"artist": "すりぃ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 106.813,
 			"genre": "niconico"
 		},
 		"id": 2149,
@@ -14301,6 +15448,7 @@
 		"artist": "柊キライ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 146.824,
 			"genre": "niconico"
 		},
 		"id": 2150,
@@ -14314,6 +15462,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 99.512,
 			"genre": "niconico"
 		},
 		"id": 2151,
@@ -14330,6 +15479,7 @@
 		"artist": "R Sound Design",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 140.339,
 			"genre": "niconico"
 		},
 		"id": 2152,
@@ -14343,6 +15493,7 @@
 		"artist": "電ǂ鯨",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 160.925,
 			"genre": "niconico"
 		},
 		"id": 2153,
@@ -14357,6 +15508,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 161.928,
 			"genre": "東方Project"
 		},
 		"id": 2154,
@@ -14370,6 +15522,7 @@
 		"artist": "SOUND HOLIC Vs. ZYTOKINE feat. 星野奏子",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 130.345,
 			"genre": "東方Project"
 		},
 		"id": 2155,
@@ -14381,6 +15534,7 @@
 		"artist": "Amateras Records feat. 柚之原りえ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 154.783,
 			"genre": "東方Project"
 		},
 		"id": 2156,
@@ -14392,6 +15546,7 @@
 		"artist": "Demetori",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 144.272,
 			"genre": "東方Project"
 		},
 		"id": 2157,
@@ -14405,6 +15560,7 @@
 		"artist": "Tatsh feat.彩音",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 167.714,
 			"genre": "東方Project"
 		},
 		"id": 2158,
@@ -14418,6 +15574,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 169.091,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2160,
@@ -14429,6 +15586,7 @@
 		"artist": "TAG",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 138.875,
 			"genre": "ORIGINAL"
 		},
 		"id": 2161,
@@ -14440,6 +15598,7 @@
 		"artist": "曲：本多友紀（Arte Refact）／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 159.783,
 			"genre": "ゲキマイ"
 		},
 		"id": 2162,
@@ -14453,6 +15612,7 @@
 		"artist": "曲：やしきん／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 145.938,
 			"genre": "ゲキマイ"
 		},
 		"id": 2163,
@@ -14466,6 +15626,7 @@
 		"artist": "曲：DJ Genki／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 142.927,
 			"genre": "ゲキマイ"
 		},
 		"id": 2164,
@@ -14479,6 +15640,7 @@
 		"artist": "owl＊tree feat.chi＊tree",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 157.486,
 			"genre": "ゲキマイ"
 		},
 		"id": 2165,
@@ -14492,6 +15654,7 @@
 		"artist": "鈴木雅之",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 149.356,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2166,
@@ -14506,6 +15669,7 @@
 		"artist": "吉幾三",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 128.995,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2167,
@@ -14519,6 +15683,7 @@
 		"artist": "Cranky",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 97.955,
 			"genre": "VARIETY"
 		},
 		"id": 2168,
@@ -14530,6 +15695,7 @@
 		"artist": "杏里 [covered by 舞ヶ原シンセ研究会]",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 121.125,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2169,
@@ -14541,6 +15707,7 @@
 		"artist": "MARETU",
 		"data": {
 			"displayVersion": "CHUNITHM NEW",
+			"duration": 153.462,
 			"genre": "ゲキマイ"
 		},
 		"id": 2170,
@@ -14554,6 +15721,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 136.981,
 			"genre": "ゲキマイ"
 		},
 		"id": 2171,
@@ -14565,6 +15733,7 @@
 		"artist": "Official髭男dism TVアニメ『東京リベンジャーズ』",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 118.2,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2172,
@@ -14576,6 +15745,7 @@
 		"artist": "YOASOBI  テレビアニメ『BEASTARS』第2期",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 172.235,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2173,
@@ -14589,6 +15759,7 @@
 		"artist": "LiSA  テレビアニメ「鬼滅の刃」無限列車編",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 94.105,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2174,
@@ -14602,6 +15773,7 @@
 		"artist": "P丸様。",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 128.182,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2175,
@@ -14615,6 +15787,7 @@
 		"artist": "ARuFa",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 147.857,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2176,
@@ -14628,6 +15801,7 @@
 		"artist": "Ado",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 144.375,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2177,
@@ -14641,6 +15815,7 @@
 		"artist": "ナユタン星人 / 初音ミク / MORE MORE JUMP！「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 125.266,
 			"genre": "niconico"
 		},
 		"id": 2178,
@@ -14654,6 +15829,7 @@
 		"artist": "まふまふ / 初音ミク / 25時、ナイトコードで。「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 139.195,
 			"genre": "niconico"
 		},
 		"id": 2179,
@@ -14667,6 +15843,7 @@
 		"artist": "Kanaria",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 137.544,
 			"genre": "niconico"
 		},
 		"id": 2180,
@@ -14680,6 +15857,7 @@
 		"artist": "かいりきベア",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 144.314,
 			"genre": "niconico"
 		},
 		"id": 2181,
@@ -14693,6 +15871,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 164,
 			"genre": "niconico"
 		},
 		"id": 2182,
@@ -14707,6 +15886,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 167.993,
 			"genre": "東方Project"
 		},
 		"id": 2183,
@@ -14721,6 +15901,7 @@
 		"artist": "fallen shepherd ft. RabbiTon Strings",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 125.523,
 			"genre": "VARIETY"
 		},
 		"id": 2184,
@@ -14732,6 +15913,7 @@
 		"artist": "立秋 feat.ちょこ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 143.683,
 			"genre": "VARIETY"
 		},
 		"id": 2185,
@@ -14746,6 +15928,7 @@
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 157.5,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2186,
@@ -14757,6 +15940,7 @@
 		"artist": "天月-あまつき-",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 163.459,
 			"genre": "ORIGINAL"
 		},
 		"id": 2187,
@@ -14770,6 +15954,7 @@
 		"artist": "すりぃ feat.りょーくん",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 151.814,
 			"genre": "ORIGINAL"
 		},
 		"id": 2188,
@@ -14783,6 +15968,7 @@
 		"artist": "tilt-six feat.バル",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 133.784,
 			"genre": "ORIGINAL"
 		},
 		"id": 2189,
@@ -14794,6 +15980,7 @@
 		"artist": "Kobaryo",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 141.818,
 			"genre": "ORIGINAL"
 		},
 		"id": 2190,
@@ -14805,6 +15992,7 @@
 		"artist": "t+pazolite feat. しゃま(CV:種﨑 敦美) & みるく(CV:伊藤 あすか)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 160.541,
 			"genre": "ゲキマイ"
 		},
 		"id": 2191,
@@ -14820,6 +16008,7 @@
 		"artist": "TAKU1175 ft.駄々子",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 150.857,
 			"genre": "ゲキマイ"
 		},
 		"id": 2192,
@@ -14834,6 +16023,7 @@
 		"artist": "sasakure. UK",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 134.574,
 			"genre": "ゲキマイ"
 		},
 		"id": 2193,
@@ -14849,6 +16039,7 @@
 		"artist": "Capchii",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 135.385,
 			"genre": "ゲキマイ"
 		},
 		"id": 2194,
@@ -14863,6 +16054,7 @@
 		"artist": "雄之助 feat. Sennzai",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 138.909,
 			"genre": "ゲキマイ"
 		},
 		"id": 2195,
@@ -14874,6 +16066,7 @@
 		"artist": "yuichi NAGAO",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 151.373,
 			"genre": "ORIGINAL"
 		},
 		"id": 2196,
@@ -14887,6 +16080,7 @@
 		"artist": "FANTAGIRAFF",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 137.267,
 			"genre": "ORIGINAL"
 		},
 		"id": 2197,
@@ -14901,6 +16095,7 @@
 		"artist": "HaNaMiNa",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 153.75,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2198,
@@ -14914,6 +16109,7 @@
 		"artist": "orangentle",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 126.667,
 			"genre": "ゲキマイ"
 		},
 		"id": 2199,
@@ -14925,6 +16121,7 @@
 		"artist": "Happy Around!「D4DJ Groovy Mix」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 118.659,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2200,
@@ -14936,6 +16133,7 @@
 		"artist": "Merm4id「D4DJ Groovy Mix」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 124.688,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2201,
@@ -14947,6 +16145,7 @@
 		"artist": "すりぃ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 149.379,
 			"genre": "niconico"
 		},
 		"id": 2202,
@@ -14960,6 +16159,7 @@
 		"artist": "柊キライ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 153.191,
 			"genre": "niconico"
 		},
 		"id": 2203,
@@ -14973,6 +16173,7 @@
 		"artist": "煮ル果実",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 150,
 			"genre": "niconico"
 		},
 		"id": 2204,
@@ -14986,6 +16187,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)＆御形 アリシアナ(CV:福原 綾香)＆天王洲 なずな(CV:山本 彩乃)＆萩原 七々瀬(CV:東城 日沙子)＆芒崎 奏(CV:立花 理香)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 179.621,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2205,
@@ -14999,6 +16201,7 @@
 		"artist": "ルゼ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 140.595,
 			"genre": "ゲキマイ"
 		},
 		"id": 2206,
@@ -15010,6 +16213,7 @@
 		"artist": "かぼちゃ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 138.621,
 			"genre": "ORIGINAL"
 		},
 		"id": 2207,
@@ -15021,6 +16225,7 @@
 		"artist": "とろまる",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 134.167,
 			"genre": "ORIGINAL"
 		},
 		"id": 2208,
@@ -15032,6 +16237,7 @@
 		"artist": "Aiko Oi",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 160.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 2209,
@@ -15043,6 +16249,7 @@
 		"artist": "Masahiro \"Godspeed\" Aoki",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 158.769,
 			"genre": "ORIGINAL"
 		},
 		"id": 2210,
@@ -15054,6 +16261,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 138.247,
 			"genre": "niconico"
 		},
 		"id": 2211,
@@ -15068,6 +16276,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 135.5,
 			"genre": "niconico"
 		},
 		"id": 2212,
@@ -15082,6 +16291,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 134.4,
 			"genre": "niconico"
 		},
 		"id": 2213,
@@ -15098,6 +16308,7 @@
 		"artist": "亜沙",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 140.178,
 			"genre": "niconico"
 		},
 		"id": 2214,
@@ -15112,6 +16323,7 @@
 		"artist": "ツミキ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 134.118,
 			"genre": "niconico"
 		},
 		"id": 2215,
@@ -15125,6 +16337,7 @@
 		"artist": "fhána「小林さんちのメイドラゴンS」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 176,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2216,
@@ -15139,6 +16352,7 @@
 		"artist": "スーパーちょろゴンず「小林さんちのメイドラゴンS」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 154.286,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2217,
@@ -15153,6 +16367,7 @@
 		"artist": "uma vs. モリモリあつし",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 143.774,
 			"genre": "VARIETY"
 		},
 		"id": 2218,
@@ -15166,6 +16381,7 @@
 		"artist": "三年生チーム(イロドリミドリ)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 169.412,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2219,
@@ -15179,6 +16395,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 164.935,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2220,
@@ -15192,6 +16409,7 @@
 		"artist": "USAO",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 147.2,
 			"genre": "ゲキマイ"
 		},
 		"id": 2221,
@@ -15203,6 +16421,7 @@
 		"artist": "アンジュ・カトリーナ、戌亥とこ、リゼ・ヘルエスタ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 167.113,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2222,
@@ -15216,6 +16435,7 @@
 		"artist": "戌亥とこ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 165.149,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2223,
@@ -15229,6 +16449,7 @@
 		"artist": "リゼ・ヘルエスタ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 156.117,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2224,
@@ -15242,6 +16463,7 @@
 		"artist": "花譜",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 162.995,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2225,
@@ -15255,6 +16477,7 @@
 		"artist": "Mori Calliope（ホロライブEnglish）",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 156.774,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2226,
@@ -15269,6 +16492,7 @@
 		"artist": "曲：Q-MHz／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 159.484,
 			"genre": "ゲキマイ"
 		},
 		"id": 2227,
@@ -15280,6 +16504,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 141.184,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2228,
@@ -15293,6 +16518,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 139.934,
 			"genre": "ゲキマイ"
 		},
 		"id": 2229,
@@ -15304,6 +16530,7 @@
 		"artist": "ああ…翡翠茶漬け…",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 146.286,
 			"genre": "ORIGINAL"
 		},
 		"id": 2230,
@@ -15317,6 +16544,7 @@
 		"artist": "Zekk",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 136.216,
 			"genre": "ORIGINAL"
 		},
 		"id": 2231,
@@ -15328,6 +16556,7 @@
 		"artist": "Masayoshi Iimori",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 136.875,
 			"genre": "ORIGINAL"
 		},
 		"id": 2232,
@@ -15339,6 +16568,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 169.325,
 			"genre": "ORIGINAL"
 		},
 		"id": 2233,
@@ -15352,6 +16582,7 @@
 		"artist": "神聖かまってちゃん「進撃の巨人」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 145,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2234,
@@ -15366,6 +16597,7 @@
 		"artist": "曲：中山真斗／歌：マーチングポケッツ [日向 千夏(CV：岡咲 美保)、柏木 美亜(CV：和氣 あず未)、東雲 つむぎ(CV：和泉 風花)]",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 152.381,
 			"genre": "ゲキマイ"
 		},
 		"id": 2235,
@@ -15379,6 +16611,7 @@
 		"artist": "曲：烏屋茶房／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 151.613,
 			"genre": "ゲキマイ"
 		},
 		"id": 2236,
@@ -15392,6 +16625,7 @@
 		"artist": "曲：本田正樹(Dream Monster)／歌：7EVENDAYS⇔HOLIDAYS [井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)]",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 156.863,
 			"genre": "ゲキマイ"
 		},
 		"id": 2237,
@@ -15405,6 +16639,7 @@
 		"artist": "曲：椿山日南子／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 162.623,
 			"genre": "ゲキマイ"
 		},
 		"id": 2238,
@@ -15416,6 +16651,7 @@
 		"artist": "SAMBA MASTER 佐藤",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 146.4,
 			"genre": "VARIETY"
 		},
 		"id": 2239,
@@ -15429,6 +16665,7 @@
 		"artist": "穴山大輔 VS 光吉猛修",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 142.878,
 			"genre": "ORIGINAL"
 		},
 		"id": 2240,
@@ -15442,6 +16679,7 @@
 		"artist": "水野健治 VS 大国奏音",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 164.248,
 			"genre": "ORIGINAL"
 		},
 		"id": 2241,
@@ -15455,6 +16693,7 @@
 		"artist": "やすなとソーニャ「キルミーベイベー」",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 111.6,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2242,
@@ -15468,6 +16707,7 @@
 		"artist": "栗林みな実",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 138.955,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2243,
@@ -15479,6 +16719,7 @@
 		"artist": "綾瀬理恵",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 138.228,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2244,
@@ -15492,6 +16733,7 @@
 		"artist": "KOTOKO",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 152.5,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2245,
@@ -15505,6 +16747,7 @@
 		"artist": "曲：小高光太郎／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 160.571,
 			"genre": "ゲキマイ"
 		},
 		"id": 2246,
@@ -15516,6 +16759,7 @@
 		"artist": "SOUND HOLIC Vs. Eurobeat Union feat. 709sec.",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 128.519,
 			"genre": "東方Project"
 		},
 		"id": 2247,
@@ -15529,6 +16773,7 @@
 		"artist": "DiGiTAL WiNG feat. 花たん",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 159.2,
 			"genre": "東方Project"
 		},
 		"id": 2248,
@@ -15540,6 +16785,7 @@
 		"artist": "Liz Triangle",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 151,
 			"genre": "東方Project"
 		},
 		"id": 2249,
@@ -15553,6 +16799,7 @@
 		"artist": "石鹸屋",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 158.372,
 			"genre": "東方Project"
 		},
 		"id": 2250,
@@ -15566,6 +16813,7 @@
 		"artist": "暁Records",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 147.273,
 			"genre": "東方Project"
 		},
 		"id": 2251,
@@ -15579,6 +16827,7 @@
 		"artist": "社築 × sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM NEW PLUS",
+			"duration": 140.613,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2252,
@@ -15590,6 +16839,7 @@
 		"artist": "ドーラ × sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 159.58,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2253,
@@ -15603,6 +16853,7 @@
 		"artist": "MOB CHOIR「モブサイコ100 Ⅲ」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 151.429,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2254,
@@ -15614,6 +16865,7 @@
 		"artist": "麻枝 准×やなぎなぎ「ヘブンバーンズレッド」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 141.429,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2255,
@@ -15625,6 +16877,7 @@
 		"artist": "Official髭男dism TVアニメ『SPY×FAMILY』オープニング主題歌",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 127.2,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2257,
@@ -15638,6 +16891,7 @@
 		"artist": "Ado",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 126.538,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2258,
@@ -15651,6 +16905,7 @@
 		"artist": "meiyo",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 148.8,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2259,
@@ -15664,6 +16919,7 @@
 		"artist": "スペシャルウィーク (CV.和氣あず未)、サイレンススズカ (CV.高野麻里佳)、トウカイテイオー(CV.Machico)、ウオッカ (CV.大橋彩香)、ダイワスカーレット (CV.木村千咲)、ゴールドシップ (CV.上田 瞳)、メジロマックイーン (CV.大西沙織)／TVアニメ『ウマ娘 プリティーダービー Season 2』",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 151.81,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2260,
@@ -15677,6 +16933,7 @@
 		"artist": "黒鉄たま (CV: 秋奈)「電音部」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 123.38,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2261,
@@ -15690,6 +16947,7 @@
 		"artist": "syudou　feat.音楽的同位体　可不（KAFU）",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 133.125,
 			"genre": "niconico"
 		},
 		"id": 2262,
@@ -15703,6 +16961,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 108.169,
 			"genre": "niconico"
 		},
 		"id": 2263,
@@ -15716,6 +16975,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 125.69,
 			"genre": "niconico"
 		},
 		"id": 2264,
@@ -15729,6 +16989,7 @@
 		"artist": "七条レタスグループ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 120.75,
 			"genre": "東方Project"
 		},
 		"id": 2265,
@@ -15745,6 +17006,7 @@
 		"artist": "Ryu☆",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 102.099,
 			"genre": "VARIETY"
 		},
 		"id": 2266,
@@ -15756,6 +17018,7 @@
 		"artist": "Sobrem × Silentroom",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 137.273,
 			"genre": "VARIETY"
 		},
 		"id": 2267,
@@ -15767,6 +17030,7 @@
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 148.645,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2268,
@@ -15780,6 +17044,7 @@
 		"artist": "すりぃ×相沢",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 161.711,
 			"genre": "ゲキマイ"
 		},
 		"id": 2269,
@@ -15793,6 +17058,7 @@
 		"artist": "かねこちはる",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 144,
 			"genre": "ゲキマイ"
 		},
 		"id": 2270,
@@ -15804,6 +17070,7 @@
 		"artist": "kanone",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.5,
 			"genre": "ゲキマイ"
 		},
 		"id": 2271,
@@ -15817,6 +17084,7 @@
 		"artist": "Sound piercer “Espitz”",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 156.835,
 			"genre": "ゲキマイ"
 		},
 		"id": 2272,
@@ -15830,6 +17098,7 @@
 		"artist": "ツミキ feat.月乃",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 141.159,
 			"genre": "ORIGINAL"
 		},
 		"id": 2273,
@@ -15843,6 +17112,7 @@
 		"artist": "遼遼 feat.あじっこ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 123.125,
 			"genre": "ORIGINAL"
 		},
 		"id": 2274,
@@ -15856,6 +17126,7 @@
 		"artist": "パソコン音楽クラブ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 138,
 			"genre": "ORIGINAL"
 		},
 		"id": 2275,
@@ -15867,6 +17138,7 @@
 		"artist": "桃井はるこ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 135.938,
 			"genre": "ORIGINAL"
 		},
 		"id": 2276,
@@ -15880,6 +17152,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 147.606,
 			"genre": "ORIGINAL"
 		},
 		"id": 2277,
@@ -15893,6 +17166,7 @@
 		"artist": "山本真央樹",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.105,
 			"genre": "ORIGINAL"
 		},
 		"id": 2278,
@@ -15904,6 +17178,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 164.611,
 			"genre": "ORIGINAL"
 		},
 		"id": 2279,
@@ -15917,6 +17192,7 @@
 		"artist": "MaiR",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.174,
 			"genre": "ORIGINAL"
 		},
 		"id": 2280,
@@ -15928,6 +17204,7 @@
 		"artist": "BOOGEY VOXX feat.IURA TOI",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 141.818,
 			"genre": "ORIGINAL"
 		},
 		"id": 2281,
@@ -15939,6 +17216,7 @@
 		"artist": "Yaca × gaburyu",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.286,
 			"genre": "ORIGINAL"
 		},
 		"id": 2282,
@@ -15950,6 +17228,7 @@
 		"artist": "MonsterZ MATE",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 151.059,
 			"genre": "ORIGINAL"
 		},
 		"id": 2283,
@@ -15961,6 +17240,7 @@
 		"artist": "UNDEAD CORPORATION",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 149.379,
 			"genre": "東方Project"
 		},
 		"id": 2285,
@@ -15972,6 +17252,7 @@
 		"artist": "あ～るの～と",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 161.772,
 			"genre": "東方Project"
 		},
 		"id": 2286,
@@ -15985,6 +17266,7 @@
 		"artist": "REDALiCE feat. 野宮あゆみ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 137.341,
 			"genre": "東方Project"
 		},
 		"id": 2287,
@@ -15996,6 +17278,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 149.714,
 			"genre": "東方Project"
 		},
 		"id": 2288,
@@ -16007,6 +17290,7 @@
 		"artist": "立秋 feat.ちょこ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 136.613,
 			"genre": "VARIETY"
 		},
 		"id": 2289,
@@ -16020,6 +17304,7 @@
 		"artist": "Black Raison d'être「中二病でも恋がしたい！」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.839,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2290,
@@ -16031,6 +17316,7 @@
 		"artist": "Black Raison d'être「中二病でも恋がしたい！戀」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 158.084,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2291,
@@ -16044,6 +17330,7 @@
 		"artist": "「私」(CV：悠木碧）「蜘蛛ですが、なにか？」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 163.052,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2292,
@@ -16057,6 +17344,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)＆五十嵐 撫子(CV:花井 美春)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 163.404,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2293,
@@ -16070,6 +17358,7 @@
 		"artist": "曲：山本恭平（Arte Refact）／歌：桜井 春菜(CV：近藤 玲奈)、早乙女 彩華(CV：中島 唯)、井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 150.6,
 			"genre": "ゲキマイ"
 		},
 		"id": 2294,
@@ -16081,6 +17370,7 @@
 		"artist": "Laur",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 158.947,
 			"genre": "ゲキマイ"
 		},
 		"id": 2295,
@@ -16092,6 +17382,7 @@
 		"artist": "ぺのれり",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 139.186,
 			"genre": "ゲキマイ"
 		},
 		"id": 2296,
@@ -16103,6 +17394,7 @@
 		"artist": "REDALiCE",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 131.361,
 			"genre": "VARIETY"
 		},
 		"id": 2297,
@@ -16114,6 +17406,7 @@
 		"artist": "t+pazolite feat. ななひら",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 162.219,
 			"genre": "VARIETY"
 		},
 		"id": 2298,
@@ -16128,6 +17421,7 @@
 		"artist": "Getty & Kobaryo",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.333,
 			"genre": "VARIETY"
 		},
 		"id": 2299,
@@ -16139,6 +17433,7 @@
 		"artist": "Gram",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 146.4,
 			"genre": "VARIETY"
 		},
 		"id": 2300,
@@ -16150,6 +17445,7 @@
 		"artist": "USAO",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 147.692,
 			"genre": "VARIETY"
 		},
 		"id": 2301,
@@ -16161,6 +17457,7 @@
 		"artist": "じん / 初音ミク / Leo/need「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 134.01,
 			"genre": "niconico"
 		},
 		"id": 2302,
@@ -16174,6 +17471,7 @@
 		"artist": "Giga / 初音ミク / Vivid BAD SQUAD「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 96,
 			"genre": "niconico"
 		},
 		"id": 2303,
@@ -16185,6 +17483,7 @@
 		"artist": "Eve / 初音ミク、星乃一歌、花里みのり、小豆沢こはね、天馬司、宵崎奏「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 98.571,
 			"genre": "niconico"
 		},
 		"id": 2304,
@@ -16198,6 +17497,7 @@
 		"artist": "香椎モイミ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 117.423,
 			"genre": "niconico"
 		},
 		"id": 2305,
@@ -16211,6 +17511,7 @@
 		"artist": "柊マグネタイト feat.可不",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 152.842,
 			"genre": "niconico"
 		},
 		"id": 2306,
@@ -16224,6 +17525,7 @@
 		"artist": "Rigel Theatre feat. ミーウェル",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 148.087,
 			"genre": "ゲキマイ"
 		},
 		"id": 2307,
@@ -16237,6 +17539,7 @@
 		"artist": "プロデュース：ワンダープラネット　作曲・編曲：加藤浩義（ノイジークローク）「クラッシュフィーバー」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 138.857,
 			"genre": "VARIETY"
 		},
 		"id": 2308,
@@ -16250,6 +17553,7 @@
 		"artist": "曲：原田篤（Arte Refact）／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 165,
 			"genre": "ゲキマイ"
 		},
 		"id": 2309,
@@ -16261,6 +17565,7 @@
 		"artist": "永倉秋斗 feat.キャサリン",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.703,
 			"genre": "ORIGINAL"
 		},
 		"id": 2310,
@@ -16274,6 +17579,7 @@
 		"artist": "立秋 feat.ちょこ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 147.549,
 			"genre": "ORIGINAL"
 		},
 		"id": 2311,
@@ -16289,6 +17595,7 @@
 		"artist": "ave;new feat.佐倉紗織",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 144.951,
 			"genre": "ORIGINAL"
 		},
 		"id": 2312,
@@ -16300,6 +17607,7 @@
 		"artist": "コバヤシユウヤ（IOSYS） feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 124.954,
 			"genre": "ORIGINAL"
 		},
 		"id": 2313,
@@ -16313,6 +17621,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 155.696,
 			"genre": "niconico"
 		},
 		"id": 2314,
@@ -16326,6 +17635,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 153.83,
 			"genre": "niconico"
 		},
 		"id": 2315,
@@ -16339,6 +17649,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 161.739,
 			"genre": "niconico"
 		},
 		"id": 2316,
@@ -16352,6 +17663,7 @@
 		"artist": "いよわ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 145.636,
 			"genre": "niconico"
 		},
 		"id": 2317,
@@ -16365,6 +17677,7 @@
 		"artist": "水野あつ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 136.071,
 			"genre": "niconico"
 		},
 		"id": 2318,
@@ -16378,6 +17691,7 @@
 		"artist": "箱部 なる(CV:M・A・O)＆小野 美苗(CV:伊藤 美来)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 161.538,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2319,
@@ -16391,6 +17705,7 @@
 		"artist": "ルゼ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 156.452,
 			"genre": "ゲキマイ"
 		},
 		"id": 2320,
@@ -16407,6 +17722,7 @@
 		"artist": "ClariS「俺の妹がこんなに可愛いわけがない。」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 160.299,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2321,
@@ -16418,6 +17734,7 @@
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat. 藤枝あかね",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.971,
 			"genre": "東方Project"
 		},
 		"id": 2322,
@@ -16431,6 +17748,7 @@
 		"artist": "SOUND HOLIC feat. 匠眞",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 120.357,
 			"genre": "東方Project"
 		},
 		"id": 2323,
@@ -16444,6 +17762,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 155.6,
 			"genre": "東方Project"
 		},
 		"id": 2324,
@@ -16457,6 +17776,7 @@
 		"artist": "Kai VS 大国奏音 VS 水野健治",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 164.679,
 			"genre": "ゲキマイ"
 		},
 		"id": 2326,
@@ -16472,6 +17792,7 @@
 		"artist": "sky_delta",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 135.75,
 			"genre": "ゲキマイ"
 		},
 		"id": 2327,
@@ -16483,6 +17804,7 @@
 		"artist": "かいりきベア「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 161.397,
 			"genre": "niconico"
 		},
 		"id": 2328,
@@ -16498,6 +17820,7 @@
 		"artist": "Kanaria「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.424,
 			"genre": "niconico"
 		},
 		"id": 2329,
@@ -16511,6 +17834,7 @@
 		"artist": "syudou「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 139.355,
 			"genre": "niconico"
 		},
 		"id": 2330,
@@ -16524,6 +17848,7 @@
 		"artist": "Omoi「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 152.842,
 			"genre": "niconico"
 		},
 		"id": 2331,
@@ -16537,6 +17862,7 @@
 		"artist": "まふまふ「#コンパス」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 156.25,
 			"genre": "niconico"
 		},
 		"id": 2332,
@@ -16550,6 +17876,7 @@
 		"artist": "Sampling masters なる＆せりな feat.なでしこ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 145.59,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2333,
@@ -16564,6 +17891,7 @@
 		"artist": "AJURIKA",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 153.6,
 			"genre": "ゲキマイ"
 		},
 		"id": 2334,
@@ -16575,6 +17903,7 @@
 		"artist": "打打だいず",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 164.037,
 			"genre": "ORIGINAL"
 		},
 		"id": 2336,
@@ -16588,6 +17917,7 @@
 		"artist": "mommy",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.667,
 			"genre": "ORIGINAL"
 		},
 		"id": 2337,
@@ -16599,6 +17929,7 @@
 		"artist": "Akira Complex vs kiraku",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 162.499,
 			"genre": "ORIGINAL"
 		},
 		"id": 2338,
@@ -16610,6 +17941,7 @@
 		"artist": "Sobrem a.k.a. Widowmaker",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 144.211,
 			"genre": "ORIGINAL"
 		},
 		"id": 2339,
@@ -16621,6 +17953,7 @@
 		"artist": "uma vs. ガリガリさむし",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 140.377,
 			"genre": "ORIGINAL"
 		},
 		"id": 2340,
@@ -16634,6 +17967,7 @@
 		"artist": "名取さな",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 147.586,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2341,
@@ -16647,6 +17981,7 @@
 		"artist": "名取さな",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 157.029,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2342,
@@ -16660,6 +17995,7 @@
 		"artist": "supercell feat. 初音ミク",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 173.281,
 			"genre": "niconico"
 		},
 		"id": 2343,
@@ -16673,6 +18009,7 @@
 		"artist": "sasakure.UK feat. 初音ミク",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 164.526,
 			"genre": "niconico"
 		},
 		"id": 2344,
@@ -16686,6 +18023,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)＆葛城 華(CV:丸岡 和佳奈)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 168,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2345,
@@ -16697,6 +18035,7 @@
 		"artist": "Kobaryo",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 149.048,
 			"genre": "ゲキマイ"
 		},
 		"id": 2346,
@@ -16708,6 +18047,7 @@
 		"artist": "WAiKURO「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 138.904,
 			"genre": "VARIETY"
 		},
 		"id": 2347,
@@ -16719,6 +18059,7 @@
 		"artist": "Laur「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 160,
 			"genre": "VARIETY"
 		},
 		"id": 2348,
@@ -16730,6 +18071,7 @@
 		"artist": "Endorfin.「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 154.269,
 			"genre": "VARIETY"
 		},
 		"id": 2349,
@@ -16741,6 +18083,7 @@
 		"artist": "からとPαnchii少年 feat.はるの「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 135.273,
 			"genre": "VARIETY"
 		},
 		"id": 2350,
@@ -16754,6 +18097,7 @@
 		"artist": "Team Grimoire「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 138.811,
 			"genre": "VARIETY"
 		},
 		"id": 2351,
@@ -16765,6 +18109,7 @@
 		"artist": "曲：広川恵一 (MONACA)／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 146.571,
 			"genre": "ゲキマイ"
 		},
 		"id": 2352,
@@ -16776,6 +18121,7 @@
 		"artist": "穴山大輔「原曲:ショパン」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 153.971,
 			"genre": "VARIETY"
 		},
 		"id": 2353,
@@ -16789,6 +18135,7 @@
 		"artist": "大国奏音「原曲:ドビュッシー」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 178.634,
 			"genre": "VARIETY"
 		},
 		"id": 2354,
@@ -16802,6 +18149,7 @@
 		"artist": "光吉猛修「原曲:ヴィヴァルディ」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 122,
 			"genre": "VARIETY"
 		},
 		"id": 2355,
@@ -16816,6 +18164,7 @@
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 122.4,
 			"genre": "ゲキマイ"
 		},
 		"id": 2356,
@@ -16827,6 +18176,7 @@
 		"artist": "Cranky",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 117.338,
 			"genre": "ORIGINAL"
 		},
 		"id": 2358,
@@ -16840,6 +18190,7 @@
 		"artist": "中野家の五つ子（花澤香菜・竹達彩奈・伊藤美来・佐倉綾音・水瀬いのり）「五等分の花嫁∬」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 165.949,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2359,
@@ -16853,6 +18204,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 133.6,
 			"genre": "niconico"
 		},
 		"id": 2360,
@@ -16867,6 +18219,7 @@
 		"artist": "みきとP",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 159.6,
 			"genre": "niconico"
 		},
 		"id": 2361,
@@ -16881,6 +18234,7 @@
 		"artist": "ナユタン星人",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.921,
 			"genre": "ゲキマイ"
 		},
 		"id": 2362,
@@ -16895,6 +18249,7 @@
 		"artist": "Lime",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 136.277,
 			"genre": "ゲキマイ"
 		},
 		"id": 2363,
@@ -16908,6 +18263,7 @@
 		"artist": "EBIMAYO",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 135.135,
 			"genre": "ゲキマイ"
 		},
 		"id": 2364,
@@ -16919,6 +18275,7 @@
 		"artist": "曲：齋藤大／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 166.612,
 			"genre": "ゲキマイ"
 		},
 		"id": 2365,
@@ -16932,6 +18289,7 @@
 		"artist": "曲：ANCHOR／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 158.526,
 			"genre": "ゲキマイ"
 		},
 		"id": 2366,
@@ -16943,6 +18301,7 @@
 		"artist": "曲：中土智博／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 152.239,
 			"genre": "ゲキマイ"
 		},
 		"id": 2367,
@@ -16956,6 +18315,7 @@
 		"artist": "曲：本多友紀（Arte Refact）／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 137.143,
 			"genre": "ゲキマイ"
 		},
 		"id": 2368,
@@ -16967,6 +18327,7 @@
 		"artist": "曲：原田篤（Arte Refact）／歌：ASTERISM [星咲 あかり(CV：赤尾 ひかる)、藤沢 柚子(CV：久保田 梨沙)、三角 葵(CV：春野 杏)]",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 164.842,
 			"genre": "ゲキマイ"
 		},
 		"id": 2369,
@@ -16980,6 +18341,7 @@
 		"artist": "a_hisa",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 149.333,
 			"genre": "ゲキマイ"
 		},
 		"id": 2370,
@@ -16993,6 +18355,7 @@
 		"artist": "曲：本多友紀（Arte Refact）／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 157.808,
 			"genre": "ゲキマイ"
 		},
 		"id": 2371,
@@ -17004,6 +18367,7 @@
 		"artist": "曲：篠崎あやと、橘亮祐／歌：マーチングポケッツ [日向 千夏(CV：岡咲 美保)、柏木 美亜(CV：和氣 あず未)、東雲 つむぎ(CV：和泉 風花)]",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.125,
 			"genre": "ゲキマイ"
 		},
 		"id": 2372,
@@ -17017,6 +18381,7 @@
 		"artist": "She is Legend「ヘブンバーンズレッド」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 144.667,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2373,
@@ -17028,6 +18393,7 @@
 		"artist": "HARDCORE TANO*C & エリザベス（CV:大西沙織）「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 123.243,
 			"genre": "VARIETY"
 		},
 		"id": 2381,
@@ -17039,6 +18405,7 @@
 		"artist": "USAO「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 132,
 			"genre": "VARIETY"
 		},
 		"id": 2382,
@@ -17050,6 +18417,7 @@
 		"artist": "P*Light「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 121.2,
 			"genre": "VARIETY"
 		},
 		"id": 2383,
@@ -17061,6 +18429,7 @@
 		"artist": "Laur「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 142.154,
 			"genre": "VARIETY"
 		},
 		"id": 2384,
@@ -17072,6 +18441,7 @@
 		"artist": "\"漆黒\"の堕天使《Gram》†Versus† \"聖刻\"の熾天使《Gram》「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN",
+			"duration": 145.61,
 			"genre": "VARIETY"
 		},
 		"id": 2385,
@@ -17083,6 +18453,7 @@
 		"artist": "結束バンド「ぼっち・ざ・ろっく！」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 150.947,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2386,
@@ -17096,6 +18467,7 @@
 		"artist": "結束バンド「ぼっち・ざ・ろっく！」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 155.44,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2387,
@@ -17109,6 +18481,7 @@
 		"artist": "Aiobahn feat. KOTOKO「NEEDY GIRL OVERDOSE」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.502,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2388,
@@ -17120,6 +18493,7 @@
 		"artist": "Ado",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 121.58,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2389,
@@ -17133,6 +18507,7 @@
 		"artist": "YOASOBI「機動戦士ガンダム 水星の魔女」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 162.353,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2390,
@@ -17147,6 +18522,7 @@
 		"artist": "マキシマム ザ ホルモン「チェンソーマン」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 92.713,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2391,
@@ -17161,6 +18537,7 @@
 		"artist": "ぼっちぼろまる",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 154.576,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2392,
@@ -17175,6 +18552,7 @@
 		"artist": "syudou",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 134.182,
 			"genre": "niconico"
 		},
 		"id": 2393,
@@ -17189,6 +18567,7 @@
 		"artist": "DECO*27",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 157.674,
 			"genre": "niconico"
 		},
 		"id": 2394,
@@ -17202,6 +18581,7 @@
 		"artist": "Kanaria",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 137.739,
 			"genre": "niconico"
 		},
 		"id": 2395,
@@ -17216,6 +18596,7 @@
 		"artist": "LeaF",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 115.2,
 			"genre": "VARIETY"
 		},
 		"id": 2397,
@@ -17229,6 +18610,7 @@
 		"artist": "少年ラジオ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 153.166,
 			"genre": "VARIETY"
 		},
 		"id": 2398,
@@ -17240,6 +18622,7 @@
 		"artist": "kanone",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 135.5,
 			"genre": "ゲキマイ"
 		},
 		"id": 2399,
@@ -17251,6 +18634,7 @@
 		"artist": "BlackY",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 147.739,
 			"genre": "ゲキマイ"
 		},
 		"id": 2400,
@@ -17262,6 +18646,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 143.077,
 			"genre": "ゲキマイ"
 		},
 		"id": 2401,
@@ -17275,6 +18660,7 @@
 		"artist": "bermei.inazawa",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 138.592,
 			"genre": "ORIGINAL"
 		},
 		"id": 2403,
@@ -17288,6 +18674,7 @@
 		"artist": "薄塩指数 feat.KMNZ LIZ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 141.099,
 			"genre": "ORIGINAL"
 		},
 		"id": 2404,
@@ -17301,6 +18688,7 @@
 		"artist": "蝶々P feat.くろくも",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 142.388,
 			"genre": "ORIGINAL"
 		},
 		"id": 2405,
@@ -17312,6 +18700,7 @@
 		"artist": "cubesato",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 155.806,
 			"genre": "ORIGINAL"
 		},
 		"id": 2406,
@@ -17323,6 +18712,7 @@
 		"artist": "MisoilePunch♪",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 135.556,
 			"genre": "ORIGINAL"
 		},
 		"id": 2407,
@@ -17334,6 +18724,7 @@
 		"artist": "HaNaMiNa feat.芒崎 奏",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 158.734,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2408,
@@ -17348,6 +18739,7 @@
 		"artist": "Zekk「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 134.667,
 			"genre": "VARIETY"
 		},
 		"id": 2409,
@@ -17362,6 +18754,7 @@
 		"artist": "Kobaryo「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 139.102,
 			"genre": "VARIETY"
 		},
 		"id": 2410,
@@ -17373,6 +18766,7 @@
 		"artist": "DJ Noriken「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 125.647,
 			"genre": "VARIETY"
 		},
 		"id": 2411,
@@ -17384,6 +18778,7 @@
 		"artist": "幽閉サテライト",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 120,
 			"genre": "東方Project"
 		},
 		"id": 2412,
@@ -17397,6 +18792,7 @@
 		"artist": "Liz Triangle",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 149.539,
 			"genre": "東方Project"
 		},
 		"id": 2413,
@@ -17411,6 +18807,7 @@
 		"artist": "しぐれうい",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 164.762,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2414,
@@ -17422,6 +18819,7 @@
 		"artist": "しぐれうい",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 158.049,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2415,
@@ -17435,6 +18833,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 171.951,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2416,
@@ -17446,6 +18845,7 @@
 		"artist": "MAYA AKAI",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 137.956,
 			"genre": "ゲキマイ"
 		},
 		"id": 2417,
@@ -17457,6 +18857,7 @@
 		"artist": "koyori（電ポルP）",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 152.727,
 			"genre": "niconico"
 		},
 		"id": 2418,
@@ -17470,6 +18871,7 @@
 		"artist": "月裏, ニャン・トンロン",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 150,
 			"genre": "niconico"
 		},
 		"id": 2419,
@@ -17484,6 +18886,7 @@
 		"artist": "U149　TVアニメ「アイドルマスター シンデレラガールズ U149」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 133.278,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2420,
@@ -17495,6 +18898,7 @@
 		"artist": "U149　TVアニメ「アイドルマスター シンデレラガールズ U149」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 124.444,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2421,
@@ -17508,6 +18912,7 @@
 		"artist": "James Landino X Akira Complex「Cytus Ⅱ」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 150,
 			"genre": "VARIETY"
 		},
 		"id": 2422,
@@ -17519,6 +18924,7 @@
 		"artist": "Kevin Penkin feat. Nikki Simmons「Cytus Ⅱ」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 135.573,
 			"genre": "VARIETY"
 		},
 		"id": 2425,
@@ -17530,6 +18936,7 @@
 		"artist": "曲：橘亮祐、篠崎あやと／歌：藍原 椿(CV：橋本 ちなみ)、早乙女 彩華(CV：中島 唯)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 159.692,
 			"genre": "ゲキマイ"
 		},
 		"id": 2426,
@@ -17543,6 +18950,7 @@
 		"artist": "DJ Raisei vs. Setca. feat.nayuta",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.745,
 			"genre": "ORIGINAL"
 		},
 		"id": 2427,
@@ -17556,6 +18964,7 @@
 		"artist": "linear ring",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 135.283,
 			"genre": "ORIGINAL"
 		},
 		"id": 2428,
@@ -17570,6 +18979,7 @@
 		"artist": "くるぶっこちゃん",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 150.524,
 			"genre": "ORIGINAL"
 		},
 		"id": 2429,
@@ -17583,6 +18993,7 @@
 		"artist": "CHUBAY×打打だいず",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 154.065,
 			"genre": "ORIGINAL"
 		},
 		"id": 2430,
@@ -17594,6 +19005,7 @@
 		"artist": "Acotto",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 148.024,
 			"genre": "ORIGINAL"
 		},
 		"id": 2431,
@@ -17605,6 +19017,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 132.69,
 			"genre": "ゲキマイ"
 		},
 		"id": 2432,
@@ -17616,6 +19029,7 @@
 		"artist": "雄之助　feat. 可不",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 108.923,
 			"genre": "niconico"
 		},
 		"id": 2433,
@@ -17629,6 +19043,7 @@
 		"artist": "柊マグネタイト　feat.可不",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 162.162,
 			"genre": "niconico"
 		},
 		"id": 2434,
@@ -17643,6 +19058,7 @@
 		"artist": "いよわ　feat.星界",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 157.813,
 			"genre": "niconico"
 		},
 		"id": 2435,
@@ -17658,6 +19074,7 @@
 		"artist": "キタニタツヤ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 142.642,
 			"genre": "niconico"
 		},
 		"id": 2436,
@@ -17673,6 +19090,7 @@
 		"artist": "なきそ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 121.043,
 			"genre": "niconico"
 		},
 		"id": 2437,
@@ -17687,6 +19105,7 @@
 		"artist": "曲：穴山大輔, 水野健治／歌：藤沢 柚子(CV：久保田 梨沙)、早乙女 彩華(CV：中島 唯)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 178.729,
 			"genre": "ゲキマイ"
 		},
 		"id": 2438,
@@ -17700,6 +19119,7 @@
 		"artist": "しーけー",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 150.261,
 			"genre": "ORIGINAL"
 		},
 		"id": 2439,
@@ -17714,6 +19134,7 @@
 		"artist": "Team Grimoire",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.077,
 			"genre": "ORIGINAL"
 		},
 		"id": 2440,
@@ -17725,6 +19146,7 @@
 		"artist": "Sound piercer",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 149.565,
 			"genre": "ORIGINAL"
 		},
 		"id": 2441,
@@ -17739,6 +19161,7 @@
 		"artist": "Aoi",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 147.327,
 			"genre": "ORIGINAL"
 		},
 		"id": 2442,
@@ -17750,6 +19173,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)＆萩原 七々瀬(CV:東城 日沙子)＆芒崎 奏(CV:立花 理香)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.053,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2443,
@@ -17763,6 +19187,7 @@
 		"artist": "LV.4",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 144,
 			"genre": "ゲキマイ"
 		},
 		"id": 2444,
@@ -17774,6 +19199,7 @@
 		"artist": "▽▲TRiNITY▲▽",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 146.769,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2445,
@@ -17785,6 +19211,7 @@
 		"artist": "湊あくあ（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 148.462,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2446,
@@ -17799,6 +19226,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 125.455,
 			"genre": "niconico"
 		},
 		"id": 2447,
@@ -17813,6 +19241,7 @@
 		"artist": "前島麻由「異世界おじさん」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 162.545,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2448,
@@ -17824,6 +19253,7 @@
 		"artist": "桐生一馬(黒田崇矢)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 124.054,
 			"genre": "VARIETY"
 		},
 		"id": 2449,
@@ -17837,6 +19267,7 @@
 		"artist": "Hiro",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 109.459,
 			"genre": "VARIETY"
 		},
 		"id": 2450,
@@ -17850,6 +19281,7 @@
 		"artist": "曲：Funta7／歌：星咲 あかり(CV：赤尾 ひかる)、日向 千夏(CV：岡咲 美保)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 172.5,
 			"genre": "ゲキマイ"
 		},
 		"id": 2451,
@@ -17861,6 +19293,7 @@
 		"artist": "なみぐる",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 139.714,
 			"genre": "niconico"
 		},
 		"id": 2452,
@@ -17874,6 +19307,7 @@
 		"artist": "才歌",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 123.636,
 			"genre": "niconico"
 		},
 		"id": 2453,
@@ -17888,6 +19322,7 @@
 		"artist": "wotaku feat. SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 156.8,
 			"genre": "niconico"
 		},
 		"id": 2454,
@@ -17899,6 +19334,7 @@
 		"artist": "箱部 なる(CV:M・A・O)＆藤堂 陽南袴(CV:八島 さらら)＆天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 171.2,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2455,
@@ -17910,6 +19346,7 @@
 		"artist": "Sound Artz",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 151.409,
 			"genre": "ゲキマイ"
 		},
 		"id": 2456,
@@ -17921,6 +19358,7 @@
 		"artist": "林柏勲 Bo-Xun Lin feat.幻子 Maboroshiko",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 167.971,
 			"genre": "ORIGINAL"
 		},
 		"id": 2457,
@@ -17932,6 +19370,7 @@
 		"artist": "Victor Kong & Yukino",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 155.455,
 			"genre": "ORIGINAL"
 		},
 		"id": 2458,
@@ -17943,6 +19382,7 @@
 		"artist": "Farhan Sarasin",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 155.294,
 			"genre": "ORIGINAL"
 		},
 		"id": 2459,
@@ -17954,6 +19394,7 @@
 		"artist": "Jehezukiel (feat.Sagi & KURORAK)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 166.159,
 			"genre": "ORIGINAL"
 		},
 		"id": 2460,
@@ -17965,6 +19406,7 @@
 		"artist": "Katzeohr & Spiegel",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 154.326,
 			"genre": "ORIGINAL"
 		},
 		"id": 2461,
@@ -17976,6 +19418,7 @@
 		"artist": "曲：矢鴇つかさ & 脇眞富（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)、高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 159.706,
 			"genre": "ゲキマイ"
 		},
 		"id": 2463,
@@ -17990,6 +19433,7 @@
 		"artist": "麻枝 准×やなぎなぎ「ヘブンバーンズレッド」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 163.636,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2464,
@@ -18001,6 +19445,7 @@
 		"artist": "She is Legend「ヘブンバーンズレッド」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 135.771,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2465,
@@ -18012,6 +19457,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)＆月鈴 白奈(CV:高野 麻里佳)＆御形 アリシアナ(CV:福原 綾香)＆桔梗 小夜曲(CV:原田 彩楓)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 176.8,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2466,
@@ -18023,6 +19469,7 @@
 		"artist": "お月さま交響曲",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 132.736,
 			"genre": "ゲキマイ"
 		},
 		"id": 2467,
@@ -18034,6 +19481,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 171.679,
 			"genre": "東方Project"
 		},
 		"id": 2468,
@@ -18048,6 +19496,7 @@
 		"artist": "ビートまりお＋あまね（COOL&CREATE）",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 134.571,
 			"genre": "東方Project"
 		},
 		"id": 2469,
@@ -18061,6 +19510,7 @@
 		"artist": "TAG VS Kai",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 149.818,
 			"genre": "ORIGINAL"
 		},
 		"id": 2475,
@@ -18072,6 +19522,7 @@
 		"artist": "曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)、逢坂 茜(CV：大空 直美)、日向 千夏(CV：岡咲 美保)",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 174.4,
 			"genre": "ゲキマイ"
 		},
 		"id": 2476,
@@ -18085,6 +19536,7 @@
 		"artist": "rintaro soma",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 145.93,
 			"genre": "ゲキマイ"
 		},
 		"id": 2477,
@@ -18096,6 +19548,7 @@
 		"artist": "常陸 茉子 (CV：小鳥居 夕花) 「千恋＊万花」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 147,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2478,
@@ -18110,6 +19563,7 @@
 		"artist": "ムラサメ (CV：佐藤 みかん) 「千恋＊万花」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 155.357,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2479,
@@ -18124,6 +19578,7 @@
 		"artist": "山本真央樹",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 156.4,
 			"genre": "ゲキマイ"
 		},
 		"id": 2480,
@@ -18135,6 +19590,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 152.615,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2481,
@@ -18146,6 +19602,7 @@
 		"artist": "水夏える feat.月乃",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 104.211,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2482,
@@ -18159,6 +19616,7 @@
 		"artist": "JAM Project feat. 影山ヒロノブ・遠藤正明・きただにひろし・福山芳樹",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 125.143,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2483,
@@ -18173,6 +19631,7 @@
 		"artist": "technoplanet",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 147.6,
 			"genre": "ゲキマイ"
 		},
 		"id": 2485,
@@ -18184,6 +19643,7 @@
 		"artist": "アリスシャッハと魔法の楽団",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 124.235,
 			"genre": "ゲキマイ"
 		},
 		"id": 2486,
@@ -18198,6 +19658,7 @@
 		"artist": "魂音泉",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 149.333,
 			"genre": "ゲキマイ"
 		},
 		"id": 2487,
@@ -18209,6 +19670,7 @@
 		"artist": "An & Ryunosuke Kudo",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 131.868,
 			"genre": "ゲキマイ"
 		},
 		"id": 2488,
@@ -18220,6 +19682,7 @@
 		"artist": "佐々木千枝、櫻井桃華、市原仁奈、龍崎薫、赤城みりあ「アイドルマスター シンデレラガールズ」",
 		"data": {
 			"displayVersion": "CHUNITHM SUN PLUS",
+			"duration": 126.911,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2489,
@@ -18233,6 +19696,7 @@
 		"artist": "ClariS「リコリス・リコイル」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.368,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2490,
@@ -18244,6 +19708,7 @@
 		"artist": "HoneyWorks feat. ちゅーたん(CV:早見沙織)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 150.375,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2491,
@@ -18257,6 +19722,7 @@
 		"artist": "MAISONdes",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 123.504,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2492,
@@ -18270,6 +19736,7 @@
 		"artist": "松平健 [covered by 光吉猛修]",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 154.505,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2493,
@@ -18283,6 +19750,7 @@
 		"artist": "YOASOBI",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 154.308,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2494,
@@ -18297,6 +19765,7 @@
 		"artist": "JAM Project featuring 水木一郎、影山ヒロノブ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 100.318,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2495,
@@ -18308,6 +19777,7 @@
 		"artist": "さくゆい",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 154.5,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2496,
@@ -18321,6 +19791,7 @@
 		"artist": "えなこ feat. P丸様。「お兄ちゃんはおしまい！」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 98.323,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2497,
@@ -18334,6 +19805,7 @@
 		"artist": "ONIMAI SISTERS（高野麻里佳・石原夏織・金元寿子・津田美波）「お兄ちゃんはおしまい！」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 153.443,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2498,
@@ -18347,6 +19819,7 @@
 		"artist": "星街すいせい（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 158.786,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2499,
@@ -18358,6 +19831,7 @@
 		"artist": "花譜",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 163.881,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2500,
@@ -18372,6 +19846,7 @@
 		"artist": "花譜",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 162,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2501,
@@ -18386,6 +19861,7 @@
 		"artist": "名取さな",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 132.632,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2502,
@@ -18399,6 +19875,7 @@
 		"artist": "Aiobahn feat. KOTOKO「NEEDY GIRL OVERDOSE」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 172.541,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2503,
@@ -18410,6 +19887,7 @@
 		"artist": "みかくにんぐッ！「未確認で進行形」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 146.824,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2504,
@@ -18423,6 +19901,7 @@
 		"artist": "柊キライ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.578,
 			"genre": "niconico"
 		},
 		"id": 2505,
@@ -18437,6 +19916,7 @@
 		"artist": "ゆこぴ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 138.222,
 			"genre": "niconico"
 		},
 		"id": 2506,
@@ -18451,6 +19931,7 @@
 		"artist": "南ノ南",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 156,
 			"genre": "niconico"
 		},
 		"id": 2507,
@@ -18465,6 +19946,7 @@
 		"artist": "稲葉曇",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 165.382,
 			"genre": "niconico"
 		},
 		"id": 2508,
@@ -18478,6 +19960,7 @@
 		"artist": "海茶・多良レイト",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 165.103,
 			"genre": "niconico"
 		},
 		"id": 2509,
@@ -18491,6 +19974,7 @@
 		"artist": "ポリスピカデリー / 鏡音レン / Vivid BAD SQUAD「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 101.606,
 			"genre": "niconico"
 		},
 		"id": 2510,
@@ -18502,6 +19986,7 @@
 		"artist": "キノシタ / 巡音ルカ / ワンダーランズ×ショウタイム「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 98.931,
 			"genre": "niconico"
 		},
 		"id": 2511,
@@ -18513,6 +19998,7 @@
 		"artist": "ぬゆり / MEIKO / 25時、ナイトコードで。「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 109.091,
 			"genre": "niconico"
 		},
 		"id": 2512,
@@ -18526,6 +20012,7 @@
 		"artist": "和田たけあき / 初音ミク / Leo/need「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 136.421,
 			"genre": "niconico"
 		},
 		"id": 2513,
@@ -18540,6 +20027,7 @@
 		"artist": "DIVELA / 鏡音リン / MORE MORE JUMP！「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 115.648,
 			"genre": "niconico"
 		},
 		"id": 2514,
@@ -18554,6 +20042,7 @@
 		"artist": "かいりきベア feat.GUMI・鏡音リン",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 154.694,
 			"genre": "niconico"
 		},
 		"id": 2515,
@@ -18567,6 +20056,7 @@
 		"artist": "かいりきベア",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 145.806,
 			"genre": "niconico"
 		},
 		"id": 2517,
@@ -18580,6 +20070,7 @@
 		"artist": "OSTER project",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 145.116,
 			"genre": "niconico"
 		},
 		"id": 2518,
@@ -18593,6 +20084,7 @@
 		"artist": "supercell feat.初音ミク",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 134.792,
 			"genre": "niconico"
 		},
 		"id": 2519,
@@ -18606,6 +20098,7 @@
 		"artist": "ツユ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 162.133,
 			"genre": "niconico"
 		},
 		"id": 2520,
@@ -18619,6 +20112,7 @@
 		"artist": "R Sound Design",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 129.661,
 			"genre": "niconico"
 		},
 		"id": 2521,
@@ -18630,6 +20124,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 157.612,
 			"genre": "niconico"
 		},
 		"id": 2522,
@@ -18644,6 +20139,7 @@
 		"artist": "あやぽんず＊ feat.ビートまりお × まろん",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 124.186,
 			"genre": "東方Project"
 		},
 		"id": 2523,
@@ -18657,6 +20153,7 @@
 		"artist": "まろん × COOL&CREATE",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 110.106,
 			"genre": "東方Project"
 		},
 		"id": 2524,
@@ -18670,6 +20167,7 @@
 		"artist": "Toby Fox「UNDERTALE」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 132.8,
 			"genre": "VARIETY"
 		},
 		"id": 2525,
@@ -18683,6 +20181,7 @@
 		"artist": "Toby Fox「UNDERTALE」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 137.027,
 			"genre": "VARIETY"
 		},
 		"id": 2526,
@@ -18696,6 +20195,7 @@
 		"artist": "3R2「Cytus Ⅱ」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 138.514,
 			"genre": "VARIETY"
 		},
 		"id": 2528,
@@ -18707,6 +20207,7 @@
 		"artist": "KURORAK「Cytus Ⅱ」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 120,
 			"genre": "VARIETY"
 		},
 		"id": 2529,
@@ -18718,6 +20219,7 @@
 		"artist": "DJ YOSHITAKA",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 131.027,
 			"genre": "VARIETY"
 		},
 		"id": 2530,
@@ -18729,6 +20231,7 @@
 		"artist": "Massive New Krew「WACCA」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 136.5,
 			"genre": "VARIETY"
 		},
 		"id": 2531,
@@ -18740,6 +20243,7 @@
 		"artist": "姜米條「Phigros」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 153,
 			"genre": "VARIETY"
 		},
 		"id": 2532,
@@ -18751,6 +20255,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 170,
 			"genre": "VARIETY"
 		},
 		"id": 2533,
@@ -18762,6 +20267,7 @@
 		"artist": "Tanchiky",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 126,
 			"genre": "VARIETY"
 		},
 		"id": 2534,
@@ -18773,6 +20279,7 @@
 		"artist": "saaa + kei_iwata + stuv + わかどり",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.25,
 			"genre": "VARIETY"
 		},
 		"id": 2535,
@@ -18784,6 +20291,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 131.551,
 			"genre": "VARIETY"
 		},
 		"id": 2536,
@@ -18795,6 +20303,7 @@
 		"artist": "Blacklolita",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 153.143,
 			"genre": "VARIETY"
 		},
 		"id": 2537,
@@ -18806,6 +20315,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 170.66,
 			"genre": "VARIETY"
 		},
 		"id": 2538,
@@ -18817,6 +20327,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 144.301,
 			"genre": "VARIETY"
 		},
 		"id": 2539,
@@ -18830,6 +20341,7 @@
 		"artist": "Hommarju",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 135.446,
 			"genre": "VARIETY"
 		},
 		"id": 2540,
@@ -18841,6 +20353,7 @@
 		"artist": "Cosmograph「勝利の女神：NIKKE」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 113.151,
 			"genre": "VARIETY"
 		},
 		"id": 2542,
@@ -18852,6 +20365,7 @@
 		"artist": "Cosmograph「勝利の女神：NIKKE」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 136.588,
 			"genre": "VARIETY"
 		},
 		"id": 2543,
@@ -18863,6 +20377,7 @@
 		"artist": "立秋 feat.ちょこ「Muse Dash」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 149.143,
 			"genre": "VARIETY"
 		},
 		"id": 2544,
@@ -18877,6 +20392,7 @@
 		"artist": "iKz「Muse Dash」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 136.457,
 			"genre": "VARIETY"
 		},
 		"id": 2545,
@@ -18888,6 +20404,7 @@
 		"artist": "タケノコ少年 feat. 周央サンゴ（にじさんじ）「Muse Dash」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 124.398,
 			"genre": "VARIETY"
 		},
 		"id": 2546,
@@ -18901,6 +20418,7 @@
 		"artist": "USAO「Muse Dash」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 159.155,
 			"genre": "VARIETY"
 		},
 		"id": 2547,
@@ -18912,6 +20430,7 @@
 		"artist": "ginkiha「Muse Dash」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 135.932,
 			"genre": "VARIETY"
 		},
 		"id": 2548,
@@ -18923,6 +20442,7 @@
 		"artist": "箱部なる (CV: M・A・O)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 172.756,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2549,
@@ -18936,6 +20456,7 @@
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 146.5,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2550,
@@ -18949,6 +20470,7 @@
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.471,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2552,
@@ -18960,6 +20482,7 @@
 		"artist": "曲：塩野 海／歌：星咲 あかり(CV：赤尾 ひかる)、式宮 舞菜(CV：牧野 天音)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 167.294,
 			"genre": "ゲキマイ"
 		},
 		"id": 2553,
@@ -18973,6 +20496,7 @@
 		"artist": "MisoilePunch♪",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 158.612,
 			"genre": "ゲキマイ"
 		},
 		"id": 2554,
@@ -18984,6 +20508,7 @@
 		"artist": "かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 151.448,
 			"genre": "ゲキマイ"
 		},
 		"id": 2555,
@@ -18995,6 +20520,7 @@
 		"artist": "Laur",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 145.548,
 			"genre": "ゲキマイ"
 		},
 		"id": 2556,
@@ -19006,6 +20532,7 @@
 		"artist": "siromaru",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 144.75,
 			"genre": "ゲキマイ"
 		},
 		"id": 2557,
@@ -19017,6 +20544,7 @@
 		"artist": "曲：TAKU INOUE／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 167.077,
 			"genre": "ゲキマイ"
 		},
 		"id": 2559,
@@ -19028,6 +20556,7 @@
 		"artist": "cubesato",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 129.114,
 			"genre": "ゲキマイ"
 		},
 		"id": 2560,
@@ -19041,6 +20570,7 @@
 		"artist": "曲：宮崎誠／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 144.918,
 			"genre": "ゲキマイ"
 		},
 		"id": 2561,
@@ -19052,6 +20582,7 @@
 		"artist": "曲：下野 隼／歌：皇城 セツナ(CV：八巻 アンナ)、式宮 碧音(CV：髙橋 ミナミ)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 166.568,
 			"genre": "ゲキマイ"
 		},
 		"id": 2562,
@@ -19063,6 +20594,7 @@
 		"artist": "xi",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 137.228,
 			"genre": "ゲキマイ"
 		},
 		"id": 2563,
@@ -19074,6 +20606,7 @@
 		"artist": "PSYQUI",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 141.279,
 			"genre": "ゲキマイ"
 		},
 		"id": 2564,
@@ -19085,6 +20618,7 @@
 		"artist": "PRASTIK DANCEFLOOR",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 153.409,
 			"genre": "ゲキマイ"
 		},
 		"id": 2565,
@@ -19096,6 +20630,7 @@
 		"artist": "雄之助 feat.ねんね",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 149.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 2566,
@@ -19110,6 +20645,7 @@
 		"artist": "コバヤシユウヤ（IOSYS） feat.まるもこ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 144,
 			"genre": "ORIGINAL"
 		},
 		"id": 2567,
@@ -19123,6 +20659,7 @@
 		"artist": "キツネリ feat.わかばやし",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 160.645,
 			"genre": "ORIGINAL"
 		},
 		"id": 2568,
@@ -19134,6 +20671,7 @@
 		"artist": "higma feat.ほとけ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 143.077,
 			"genre": "ORIGINAL"
 		},
 		"id": 2569,
@@ -19145,6 +20683,7 @@
 		"artist": "Se-U-Ra",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 148.711,
 			"genre": "ORIGINAL"
 		},
 		"id": 2570,
@@ -19156,6 +20695,7 @@
 		"artist": "周防パトラ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 140.571,
 			"genre": "ORIGINAL"
 		},
 		"id": 2571,
@@ -19169,6 +20709,7 @@
 		"artist": "長瀬有花",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 142.286,
 			"genre": "ORIGINAL"
 		},
 		"id": 2572,
@@ -19183,6 +20724,7 @@
 		"artist": "somunia × nyankobrq",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.069,
 			"genre": "ORIGINAL"
 		},
 		"id": 2573,
@@ -19194,6 +20736,7 @@
 		"artist": "TEMPLIME feat.星宮とと",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 139.237,
 			"genre": "ORIGINAL"
 		},
 		"id": 2574,
@@ -19205,6 +20748,7 @@
 		"artist": "Palme",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 138.261,
 			"genre": "ORIGINAL"
 		},
 		"id": 2575,
@@ -19216,6 +20760,7 @@
 		"artist": "ミディ feat.小鈴",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 152.055,
 			"genre": "ORIGINAL"
 		},
 		"id": 2576,
@@ -19229,6 +20774,7 @@
 		"artist": "Mameyudoufu feat.Kanata.N",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 142.629,
 			"genre": "ORIGINAL"
 		},
 		"id": 2577,
@@ -19240,6 +20786,7 @@
 		"artist": "Carpainter",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 140,
 			"genre": "ORIGINAL"
 		},
 		"id": 2578,
@@ -19251,6 +20798,7 @@
 		"artist": "cosMo＠暴走P",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 168,
 			"genre": "ORIGINAL"
 		},
 		"id": 2579,
@@ -19265,6 +20813,7 @@
 		"artist": "kamome sano",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 139.862,
 			"genre": "ORIGINAL"
 		},
 		"id": 2580,
@@ -19276,6 +20825,7 @@
 		"artist": "BlackY",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 143.377,
 			"genre": "ORIGINAL"
 		},
 		"id": 2581,
@@ -19287,6 +20837,7 @@
 		"artist": "削除",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 151.111,
 			"genre": "ORIGINAL"
 		},
 		"id": 2582,
@@ -19298,6 +20849,7 @@
 		"artist": "かねこちはる",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS",
+			"duration": 138.286,
 			"genre": "ゲキマイ"
 		},
 		"id": 2583,
@@ -19309,6 +20861,7 @@
 		"artist": "YOASOBI「葬送のフリーレン」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 154.615,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2584,
@@ -19322,6 +20875,7 @@
 		"artist": "UNISON SQUARE GARDEN「ブルーロック」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 92.308,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2585,
@@ -19336,6 +20890,7 @@
 		"artist": "Ado",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 132.727,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2586,
@@ -19349,6 +20904,7 @@
 		"artist": "宝鐘マリン（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 151.059,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2587,
@@ -19362,6 +20918,7 @@
 		"artist": "sasakure.UK",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 155.92,
 			"genre": "niconico"
 		},
 		"id": 2589,
@@ -19377,6 +20934,7 @@
 		"artist": "ゆこぴ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 118.5,
 			"genre": "niconico"
 		},
 		"id": 2591,
@@ -19391,6 +20949,7 @@
 		"artist": "ビートまりおとまろん",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 135.158,
 			"genre": "東方Project"
 		},
 		"id": 2592,
@@ -19404,6 +20963,7 @@
 		"artist": "Team Grimoire「Phigros」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 135.158,
 			"genre": "VARIETY"
 		},
 		"id": 2593,
@@ -19415,6 +20975,7 @@
 		"artist": "qfeileadh feat.のあ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 161.772,
 			"genre": "VARIETY"
 		},
 		"id": 2594,
@@ -19430,6 +20991,7 @@
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 161.561,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2596,
@@ -19441,6 +21003,7 @@
 		"artist": "kanone vs. BlackY",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 164.634,
 			"genre": "ゲキマイ"
 		},
 		"id": 2597,
@@ -19452,6 +21015,7 @@
 		"artist": "Yuta Imai",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 148.103,
 			"genre": "ゲキマイ"
 		},
 		"id": 2598,
@@ -19463,6 +21027,7 @@
 		"artist": "曲：本多友紀（Arte Refact）／歌：オンゲキシューターズ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 151.447,
 			"genre": "ゲキマイ"
 		},
 		"id": 2599,
@@ -19476,6 +21041,7 @@
 		"artist": "庭師",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 162.623,
 			"genre": "ゲキマイ"
 		},
 		"id": 2600,
@@ -19489,6 +21055,7 @@
 		"artist": "マイキP",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 122.5,
 			"genre": "ORIGINAL"
 		},
 		"id": 2601,
@@ -19502,6 +21069,7 @@
 		"artist": "DJ SHARPNEL feat. 相川なつ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 155.429,
 			"genre": "ORIGINAL"
 		},
 		"id": 2602,
@@ -19517,6 +21085,7 @@
 		"artist": "Fushi feat.吉乃",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 150.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 2603,
@@ -19530,6 +21099,7 @@
 		"artist": "アオワイファイ feat.秋山雫",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 144,
 			"genre": "ORIGINAL"
 		},
 		"id": 2604,
@@ -19544,6 +21114,7 @@
 		"artist": "高瀬一矢 feat.R.I.N.A",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 147.429,
 			"genre": "ORIGINAL"
 		},
 		"id": 2605,
@@ -19558,6 +21129,7 @@
 		"artist": "sasakure.UK feat.ピリオ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 162.787,
 			"genre": "ORIGINAL"
 		},
 		"id": 2606,
@@ -19571,6 +21143,7 @@
 		"artist": "もちうつね",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 162.462,
 			"genre": "niconico"
 		},
 		"id": 2610,
@@ -19585,6 +21158,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 161.143,
 			"genre": "niconico"
 		},
 		"id": 2611,
@@ -19599,6 +21173,7 @@
 		"artist": "Lamanya",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 152.798,
 			"genre": "ORIGINAL"
 		},
 		"id": 2612,
@@ -19610,6 +21185,7 @@
 		"artist": "打打だいず",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 133.622,
 			"genre": "ORIGINAL"
 		},
 		"id": 2613,
@@ -19621,6 +21197,7 @@
 		"artist": "Felysrator",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 171.515,
 			"genre": "ORIGINAL"
 		},
 		"id": 2614,
@@ -19632,6 +21209,7 @@
 		"artist": "K-forest vs. Reku Mochizuki",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 142.581,
 			"genre": "ORIGINAL"
 		},
 		"id": 2615,
@@ -19643,6 +21221,7 @@
 		"artist": "Koke",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 149.497,
 			"genre": "ORIGINAL"
 		},
 		"id": 2616,
@@ -19657,6 +21236,7 @@
 		"artist": "TRUE「響け！ユーフォニアム３」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 111.972,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2618,
@@ -19668,6 +21248,7 @@
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 151.268,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2619,
@@ -19679,6 +21260,7 @@
 		"artist": "Frums",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 137.167,
 			"genre": "ゲキマイ"
 		},
 		"id": 2620,
@@ -19693,6 +21275,7 @@
 		"artist": "DJ Noriken",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 159.158,
 			"genre": "VARIETY"
 		},
 		"id": 2621,
@@ -19704,6 +21287,7 @@
 		"artist": "DJ Myosuke",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 161.829,
 			"genre": "VARIETY"
 		},
 		"id": 2622,
@@ -19715,6 +21299,7 @@
 		"artist": "P*Light",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 122.057,
 			"genre": "VARIETY"
 		},
 		"id": 2623,
@@ -19726,6 +21311,7 @@
 		"artist": "t+pazolite & Srav3R",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 157.333,
 			"genre": "VARIETY"
 		},
 		"id": 2624,
@@ -19737,6 +21323,7 @@
 		"artist": "Laur vs 大国奏音",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 164.478,
 			"genre": "ゲキマイ"
 		},
 		"id": 2625,
@@ -19748,6 +21335,7 @@
 		"artist": "MyGO!!!!!",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 95,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2629,
@@ -19761,6 +21349,7 @@
 		"artist": "MyGO!!!!!",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 142.414,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2630,
@@ -19774,6 +21363,7 @@
 		"artist": "STEAKA",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 148.417,
 			"genre": "niconico"
 		},
 		"id": 2631,
@@ -19788,6 +21378,7 @@
 		"artist": "なみぐる feat.ずんだもん",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 166.753,
 			"genre": "niconico"
 		},
 		"id": 2632,
@@ -19801,6 +21392,7 @@
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 130.435,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2633,
@@ -19812,6 +21404,7 @@
 		"artist": "曲：Kijibato／歌：星咲 あかり(CV：赤尾 ひかる)、珠洲島 有栖(CV：長縄 まりあ)、日向 千夏(CV：岡咲 美保)、皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 148.696,
 			"genre": "ゲキマイ"
 		},
 		"id": 2634,
@@ -19823,6 +21416,7 @@
 		"artist": "Len feat.SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 140.156,
 			"genre": "ORIGINAL"
 		},
 		"id": 2635,
@@ -19834,6 +21428,7 @@
 		"artist": "ELEMENTAS feat.miko",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 155.924,
 			"genre": "ORIGINAL"
 		},
 		"id": 2636,
@@ -19848,6 +21443,7 @@
 		"artist": "A4。 feat.yamada.",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 173.714,
 			"genre": "ORIGINAL"
 		},
 		"id": 2637,
@@ -19861,6 +21457,7 @@
 		"artist": "Shu feat. 七海うらら",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 155.4,
 			"genre": "ORIGINAL"
 		},
 		"id": 2638,
@@ -19875,6 +21472,7 @@
 		"artist": "テヅカ x Aoi feat.すずしろ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 139.528,
 			"genre": "ORIGINAL"
 		},
 		"id": 2639,
@@ -19888,6 +21486,7 @@
 		"artist": "cosMo＠暴走P「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 141.273,
 			"genre": "niconico"
 		},
 		"id": 2641,
@@ -19901,6 +21500,7 @@
 		"artist": "少女理論観測所",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 160.909,
 			"genre": "東方Project"
 		},
 		"id": 2642,
@@ -19914,6 +21514,7 @@
 		"artist": "幽閉サテライト(direction:嵯峨飛鳥)",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 106.849,
 			"genre": "東方Project"
 		},
 		"id": 2643,
@@ -19927,6 +21528,7 @@
 		"artist": "SHIKI",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 126.522,
 			"genre": "ゲキマイ"
 		},
 		"id": 2644,
@@ -19938,6 +21540,7 @@
 		"artist": "EmoCosine",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 136.875,
 			"genre": "ORIGINAL"
 		},
 		"id": 2645,
@@ -19949,6 +21552,7 @@
 		"artist": "AJURIKA",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 147.097,
 			"genre": "ORIGINAL"
 		},
 		"id": 2646,
@@ -19960,6 +21564,7 @@
 		"artist": "ルゼ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 154.737,
 			"genre": "ORIGINAL"
 		},
 		"id": 2647,
@@ -19971,6 +21576,7 @@
 		"artist": "深淵を覗きし者\"Gram\"",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 143.846,
 			"genre": "ORIGINAL"
 		},
 		"id": 2648,
@@ -19982,6 +21588,7 @@
 		"artist": "あず♪",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 157.909,
 			"genre": "ゲキマイ"
 		},
 		"id": 2650,
@@ -19993,6 +21600,7 @@
 		"artist": "Yuta Imai",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 147,
 			"genre": "ORIGINAL"
 		},
 		"id": 2651,
@@ -20004,6 +21612,7 @@
 		"artist": "t+pazolite",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 154.207,
 			"genre": "ORIGINAL"
 		},
 		"id": 2652,
@@ -20015,6 +21624,7 @@
 		"artist": "BUMP OF CHICKEN",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 92.126,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2653,
@@ -20026,6 +21636,7 @@
 		"artist": "イロドリミドリ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 150.316,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2654,
@@ -20037,6 +21648,7 @@
 		"artist": "いよわ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 146.4,
 			"genre": "niconico"
 		},
 		"id": 2657,
@@ -20051,6 +21663,7 @@
 		"artist": "いよわ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 159,
 			"genre": "niconico"
 		},
 		"id": 2658,
@@ -20065,6 +21678,7 @@
 		"artist": "いよわ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 159,
 			"genre": "niconico"
 		},
 		"id": 2659,
@@ -20078,6 +21692,7 @@
 		"artist": "Capchii",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 164.218,
 			"genre": "niconico"
 		},
 		"id": 2660,
@@ -20089,6 +21704,7 @@
 		"artist": "r-906",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 156.897,
 			"genre": "niconico"
 		},
 		"id": 2661,
@@ -20102,6 +21718,7 @@
 		"artist": "曲：白戸佑輔(Dream Monster)／歌：ASTERISM [星咲 あかり(CV：赤尾 ひかる)、藤沢 柚子(CV：久保田 梨沙)、三角 葵(CV：春野 杏)]",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 171.786,
 			"genre": "ゲキマイ"
 		},
 		"id": 2663,
@@ -20113,6 +21730,7 @@
 		"artist": "FANTAGIRAFF",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 142.038,
 			"genre": "ゲキマイ"
 		},
 		"id": 2665,
@@ -20126,6 +21744,7 @@
 		"artist": "卯花ロク",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 139.481,
 			"genre": "niconico"
 		},
 		"id": 2670,
@@ -20140,6 +21759,7 @@
 		"artist": "DECO*27, ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 140.26,
 			"genre": "niconico"
 		},
 		"id": 2671,
@@ -20154,6 +21774,7 @@
 		"artist": "KiRaRe「Re:ステージ！プリズムステップ」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 120,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2673,
@@ -20167,6 +21788,7 @@
 		"artist": "テトラルキア「Re:ステージ！プリズムステップ」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 121.263,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2674,
@@ -20178,6 +21800,7 @@
 		"artist": "北宇治カルテット [黄前久美子 (CV.黒沢ともよ)、加藤葉月 (CV.朝井彩加)、川島緑輝 (CV.豊田萌絵)、高坂麗奈 (CV.安済知佳)]「響け！ユーフォニアム」",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 162.062,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2675,
@@ -20191,6 +21814,7 @@
 		"artist": "周防パトラ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 164,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2676,
@@ -20204,6 +21828,7 @@
 		"artist": "名取さな",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 145.5,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2677,
@@ -20217,6 +21842,7 @@
 		"artist": "天音かなた（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 118.333,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2679,
@@ -20230,6 +21856,7 @@
 		"artist": "梅干茶漬け",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 124.444,
 			"genre": "ゲキマイ"
 		},
 		"id": 2680,
@@ -20241,6 +21868,7 @@
 		"artist": "テヅカ feat. 獅子神レオナ",
 		"data": {
 			"displayVersion": "CHUNITHM LUMINOUS PLUS",
+			"duration": 153.786,
 			"genre": "ゲキマイ"
 		},
 		"id": 2681,
@@ -20255,6 +21883,7 @@
 		"artist": "蓮ノ空女学院スクールアイドルクラブ「Link！Like！ラブライブ！」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 162.078,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2683,
@@ -20266,6 +21895,7 @@
 		"artist": "ヨルシカ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 91.765,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2684,
@@ -20280,6 +21910,7 @@
 		"artist": "星街すいせい（ホロライブ）",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 168,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2686,
@@ -20293,6 +21924,7 @@
 		"artist": "HIMEHINA",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 143.404,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2687,
@@ -20306,6 +21938,7 @@
 		"artist": "KMNZ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 143.622,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2688,
@@ -20317,6 +21950,7 @@
 		"artist": "サツキ feat.初音ミク・重音テト",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 156.973,
 			"genre": "niconico"
 		},
 		"id": 2689,
@@ -20330,6 +21964,7 @@
 		"artist": "メドミア",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 164.211,
 			"genre": "niconico"
 		},
 		"id": 2690,
@@ -20344,6 +21979,7 @@
 		"artist": "ンバヂ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 123,
 			"genre": "niconico"
 		},
 		"id": 2691,
@@ -20358,6 +21994,7 @@
 		"artist": "森羅万象",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 123.702,
 			"genre": "東方Project"
 		},
 		"id": 2692,
@@ -20372,6 +22009,7 @@
 		"artist": "DIA「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 145.882,
 			"genre": "VARIETY"
 		},
 		"id": 2693,
@@ -20383,6 +22021,7 @@
 		"artist": "溝口ゆうま feat. 大瀬良あい「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 138.22,
 			"genre": "VARIETY"
 		},
 		"id": 2694,
@@ -20394,6 +22033,7 @@
 		"artist": "Edelritter「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 135,
 			"genre": "VARIETY"
 		},
 		"id": 2695,
@@ -20405,6 +22045,7 @@
 		"artist": "t+pazolite「Arcaea」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 140.26,
 			"genre": "VARIETY"
 		},
 		"id": 2696,
@@ -20416,6 +22057,7 @@
 		"artist": "Se-U-Ra「Phigros」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 124.435,
 			"genre": "VARIETY"
 		},
 		"id": 2697,
@@ -20427,6 +22069,7 @@
 		"artist": "tn-shi",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 163.333,
 			"genre": "VARIETY"
 		},
 		"id": 2698,
@@ -20438,6 +22081,7 @@
 		"artist": "Lime",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 149.075,
 			"genre": "VARIETY"
 		},
 		"id": 2699,
@@ -20449,6 +22093,7 @@
 		"artist": "HaNaMiNa",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 106.8,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2700,
@@ -20462,6 +22107,7 @@
 		"artist": "曲：央海加亥／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 178.626,
 			"genre": "ゲキマイ"
 		},
 		"id": 2702,
@@ -20475,6 +22121,7 @@
 		"artist": "Feryquitous",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 135.079,
 			"genre": "ゲキマイ"
 		},
 		"id": 2703,
@@ -20486,6 +22133,7 @@
 		"artist": "水野健治",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.108,
 			"genre": "ゲキマイ"
 		},
 		"id": 2704,
@@ -20499,6 +22147,7 @@
 		"artist": "STEAKA feat.山田じぇみ子",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 128.032,
 			"genre": "ORIGINAL"
 		},
 		"id": 2705,
@@ -20513,6 +22162,7 @@
 		"artist": "OUTLOUD feat.NG。",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 158.049,
 			"genre": "ORIGINAL"
 		},
 		"id": 2706,
@@ -20526,6 +22176,7 @@
 		"artist": "いるかアイス feat.ちょこ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 135.833,
 			"genre": "ORIGINAL"
 		},
 		"id": 2707,
@@ -20539,6 +22190,7 @@
 		"artist": "MOSAIC.WAV",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 161.032,
 			"genre": "ORIGINAL"
 		},
 		"id": 2708,
@@ -20552,6 +22204,7 @@
 		"artist": "Lime",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 136.216,
 			"genre": "ORIGINAL"
 		},
 		"id": 2709,
@@ -20563,6 +22216,7 @@
 		"artist": "DJ Noriken",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 149.854,
 			"genre": "ORIGINAL"
 		},
 		"id": 2710,
@@ -20574,6 +22228,7 @@
 		"artist": "Laur",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 144,
 			"genre": "ORIGINAL"
 		},
 		"id": 2711,
@@ -20585,6 +22240,7 @@
 		"artist": "Toby Fox & かめりあ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 154.378,
 			"genre": "ORIGINAL"
 		},
 		"id": 2712,
@@ -20596,6 +22252,7 @@
 		"artist": "Nornis",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 156.647,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2713,
@@ -20609,6 +22266,7 @@
 		"artist": "スリーズブーケ[日野下花帆(CV.楡井希実)、乙宗 梢(CV.花宮初奈)、百生吟子(CV.櫻井陽菜)]「Link！Like！ラブライブ！」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 173.165,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2714,
@@ -20622,6 +22280,7 @@
 		"artist": "DOLLCHESTRA[村野さやか(CV.野中ここな)、夕霧綴理(CV.佐々木琴子)、徒町小鈴(CV.葉山風花)]「Link！Like！ラブライブ！」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 154.483,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2715,
@@ -20633,6 +22292,7 @@
 		"artist": "みらくらぱーく！[大沢瑠璃乃(CV.菅 叶和)、藤島 慈(CV.月音こな)、安養寺姫芽(CV.来栖りん)]「Link！Like！ラブライブ！」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 137.525,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2716,
@@ -20646,6 +22306,7 @@
 		"artist": "南ノ南 feat.9Lana",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.06,
 			"genre": "ORIGINAL"
 		},
 		"id": 2722,
@@ -20661,6 +22322,7 @@
 		"artist": "TERU FOX × Yukino feat. Iris",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.8,
 			"genre": "ORIGINAL"
 		},
 		"id": 2728,
@@ -20675,6 +22337,7 @@
 		"artist": "Jehezukiel × KURORAK (feat. HideKy)",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 158.298,
 			"genre": "ORIGINAL"
 		},
 		"id": 2729,
@@ -20689,6 +22352,7 @@
 		"artist": "P3-Studio",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 162.947,
 			"genre": "ORIGINAL"
 		},
 		"id": 2730,
@@ -20703,6 +22367,7 @@
 		"artist": "Black Box × Spyro Kong",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 149.333,
 			"genre": "ORIGINAL"
 		},
 		"id": 2731,
@@ -20717,6 +22382,7 @@
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 130.286,
 			"genre": "イロドリミドリ"
 		},
 		"id": 2733,
@@ -20728,6 +22394,7 @@
 		"artist": "大漠波新",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 158.849,
 			"genre": "niconico"
 		},
 		"id": 2735,
@@ -20741,6 +22408,7 @@
 		"artist": "TOKOTOKO（西沢さんP）",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 162.162,
 			"genre": "niconico"
 		},
 		"id": 2736,
@@ -20755,6 +22423,7 @@
 		"artist": "wotaku",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 158.906,
 			"genre": "niconico"
 		},
 		"id": 2737,
@@ -20768,6 +22437,7 @@
 		"artist": "s-don",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 143.226,
 			"genre": "ゲキマイ"
 		},
 		"id": 2738,
@@ -20779,6 +22449,7 @@
 		"artist": "void (Mournfinale) × 水野健治",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 164,
 			"genre": "ORIGINAL"
 		},
 		"id": 2739,
@@ -20790,6 +22461,7 @@
 		"artist": "MintJam vs Masahiro \"Godspeed\" Aoki",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 155.122,
 			"genre": "ORIGINAL"
 		},
 		"id": 2744,
@@ -20801,6 +22473,7 @@
 		"artist": "原口沙輔 feat.重音テト",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 129.6,
 			"genre": "niconico"
 		},
 		"id": 2745,
@@ -20814,6 +22487,7 @@
 		"artist": "吉田夜世",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 141.171,
 			"genre": "niconico"
 		},
 		"id": 2746,
@@ -20827,6 +22501,7 @@
 		"artist": "マサラダ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 159.882,
 			"genre": "niconico"
 		},
 		"id": 2747,
@@ -20840,6 +22515,7 @@
 		"artist": "フロクロ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 129.405,
 			"genre": "niconico"
 		},
 		"id": 2748,
@@ -20855,6 +22531,7 @@
 		"artist": "曲：eba／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 143.505,
 			"genre": "ゲキマイ"
 		},
 		"id": 2749,
@@ -20869,6 +22546,7 @@
 		"artist": "Reku Mochizuki",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 122.667,
 			"genre": "VARIETY"
 		},
 		"id": 2750,
@@ -20891,6 +22569,7 @@
 		"artist": "歌：Trickstar 作詞：松井洋平　作曲/編曲：中土智博（APDREAM）",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 134.194,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2753,
@@ -20902,6 +22581,7 @@
 		"artist": "歌：ALKALOID 作詞：こだまさおり　作曲：桑原聖（Arte Refact）、編曲：脇眞富（Arte Refact）",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 120.511,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2754,
@@ -20913,6 +22593,7 @@
 		"artist": "歌：Eden 作詞：こだま さおり　作曲 / 編曲：佐藤 厚仁（Dream Monster）",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 159.73,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2755,
@@ -20924,6 +22605,7 @@
 		"artist": "歌：Crazy:B 作詞：松井洋平　作曲 / 編曲：伊藤和馬 (Arte Refact)",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 133.333,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2756,
@@ -20935,6 +22617,7 @@
 		"artist": "Rocco808,Randy Marx,GRP,寺山善也「ストリートファイター6」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 145.333,
 			"genre": "VARIETY"
 		},
 		"id": 2793,
@@ -20946,6 +22629,7 @@
 		"artist": "COSIO「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 133.75,
 			"genre": "VARIETY"
 		},
 		"id": 2796,
@@ -20957,6 +22641,7 @@
 		"artist": "Shohei Tsuchiya(ZUNTATA)「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 140.571,
 			"genre": "VARIETY"
 		},
 		"id": 2797,
@@ -20968,6 +22653,7 @@
 		"artist": "aran「グルーヴコースター」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 128.586,
 			"genre": "VARIETY"
 		},
 		"id": 2798,
@@ -20979,6 +22665,7 @@
 		"artist": "ROKINA",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.364,
 			"genre": "VARIETY"
 		},
 		"id": 2799,
@@ -20993,6 +22680,7 @@
 		"artist": "打打だいず vs. siromaru vs. Tanchiky",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.429,
 			"genre": "ゲキマイ"
 		},
 		"id": 2800,
@@ -21008,6 +22696,7 @@
 		"artist": "歌：初星学園 作詞作曲：田淵智也 編曲：滝澤俊輔（TRYTONELABO）「学園アイドルマスター」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 148.197,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2806,
@@ -21019,6 +22708,7 @@
 		"artist": "歌：花海咲季 (CV. 長月あおい) 作詞：HIROMI　作曲・編曲：Giga「学園アイドルマスター」",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 137.273,
 			"genre": "POPS & ANIME"
 		},
 		"id": 2807,
@@ -21030,6 +22720,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 140.8,
 			"genre": "niconico"
 		},
 		"id": 2810,
@@ -21044,6 +22735,7 @@
 		"artist": "ピノキオピー",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 131.351,
 			"genre": "niconico"
 		},
 		"id": 2811,
@@ -21057,6 +22749,7 @@
 		"artist": "いよわ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 133.455,
 			"genre": "niconico"
 		},
 		"id": 2812,
@@ -21071,6 +22764,7 @@
 		"artist": "まらしぃ×じん×堀江晶太(kemu) feat.鏡音リン",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 155,
 			"genre": "niconico"
 		},
 		"id": 2813,
@@ -21085,6 +22779,7 @@
 		"artist": "柊マグネタイト",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 160.8,
 			"genre": "niconico"
 		},
 		"id": 2814,

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -22558,6 +22558,7 @@
 		"artist": "daniwellP feat. 桃音モモ",
 		"data": {
 			"displayVersion": "CHUNITHM VERSE",
+			"duration": 96.338,
 			"genre": "niconico"
 		},
 		"id": 2751,

--- a/seeds/collections/songs-ongeki.json
+++ b/seeds/collections/songs-ongeki.json
@@ -3,6 +3,7 @@
 		"altTitles": [],
 		"artist": "supercell 「化物語」",
 		"data": {
+			"duration": 111.296,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1,
@@ -15,6 +16,7 @@
 		"altTitles": [],
 		"artist": "UNISON SQUARE GARDEN",
 		"data": {
+			"duration": 151.186,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 2,
@@ -27,6 +29,7 @@
 		"altTitles": [],
 		"artist": "歌組雪月花 夜々(原田 ひとみ)/いろり(茅野 愛衣)/小紫(小倉 唯) 「機巧少女は傷つかない」",
 		"data": {
+			"duration": 141.375,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 3,
@@ -39,6 +42,7 @@
 		"altTitles": [],
 		"artist": "どうぶつビスケッツ×PPP「けものフレンズ」",
 		"data": {
+			"duration": 151.765,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 4,
@@ -51,6 +55,7 @@
 		"altTitles": [],
 		"artist": "新庄 かなえ(CV:三森 すずこ) 「てーきゅう」",
 		"data": {
+			"duration": 150.938,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 5,
@@ -63,6 +68,7 @@
 		"altTitles": [],
 		"artist": "土間うまる [CV.田中あいみ]「干物妹！うまるちゃん」",
 		"data": {
+			"duration": 132.324,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 6,
@@ -75,6 +81,7 @@
 		"altTitles": [],
 		"artist": "鈴木このみ「ノーゲーム・ノーライフ」",
 		"data": {
+			"duration": 137.603,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 7,
@@ -85,6 +92,7 @@
 		"altTitles": [],
 		"artist": "ターニャ・デグレチャフ(CV.悠木碧)「幼女戦記」",
 		"data": {
+			"duration": 155.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 8,
@@ -95,6 +103,7 @@
 		"altTitles": [],
 		"artist": "ナノ feat.MY FIRST STORY 「蒼き鋼のアルペジオ ‐アルス・ノヴァ‐」",
 		"data": {
+			"duration": 151.563,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 9,
@@ -105,6 +114,7 @@
 		"altTitles": [],
 		"artist": "fripSide",
 		"data": {
+			"duration": 121.778,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 10,
@@ -115,6 +125,7 @@
 		"altTitles": [],
 		"artist": "Lia「AIR」",
 		"data": {
+			"duration": 171.67,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 11,
@@ -127,6 +138,7 @@
 		"altTitles": [],
 		"artist": "WITCH NUMBER 4「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 127.826,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 12,
@@ -137,6 +149,7 @@
 		"altTitles": [],
 		"artist": "Poppin’Party「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 107,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 13,
@@ -149,6 +162,7 @@
 		"altTitles": [],
 		"artist": "Afterglow「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 103.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 14,
@@ -159,6 +173,7 @@
 		"altTitles": [],
 		"artist": "Pastel＊Palettes「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 101.932,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 15,
@@ -171,6 +186,7 @@
 		"altTitles": [],
 		"artist": "Roselia「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 109.622,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 16,
@@ -181,6 +197,7 @@
 		"altTitles": [],
 		"artist": "ハロー、ハッピーワールド！「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 101.957,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 17,
@@ -193,6 +210,7 @@
 		"altTitles": [],
 		"artist": "れるりり",
 		"data": {
+			"duration": 154.645,
 			"genre": "niconico"
 		},
 		"id": 18,
@@ -205,6 +223,7 @@
 		"altTitles": [],
 		"artist": "164",
 		"data": {
+			"duration": 130.5,
 			"genre": "niconico"
 		},
 		"id": 19,
@@ -217,6 +236,7 @@
 		"altTitles": [],
 		"artist": "ギガ/れをる",
 		"data": {
+			"duration": 144.171,
 			"genre": "niconico"
 		},
 		"id": 20,
@@ -229,6 +249,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 144.615,
 			"genre": "niconico"
 		},
 		"id": 21,
@@ -241,6 +262,7 @@
 		"altTitles": [],
 		"artist": "黒うさP",
 		"data": {
+			"duration": 155.844,
 			"genre": "niconico"
 		},
 		"id": 22,
@@ -253,6 +275,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 123.204,
 			"genre": "niconico"
 		},
 		"id": 23,
@@ -265,6 +288,7 @@
 		"altTitles": [],
 		"artist": "hanzo/赤飯歌唱Ver",
 		"data": {
+			"duration": 149.2,
 			"genre": "niconico"
 		},
 		"id": 24,
@@ -277,6 +301,7 @@
 		"altTitles": [],
 		"artist": "じーざすP（ワンダフル☆オポチュニティ！）",
 		"data": {
+			"duration": 143.703,
 			"genre": "niconico"
 		},
 		"id": 25,
@@ -289,6 +314,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 142.377,
 			"genre": "niconico"
 		},
 		"id": 26,
@@ -301,6 +327,7 @@
 		"altTitles": [],
 		"artist": "Storyteller",
 		"data": {
+			"duration": 159.75,
 			"genre": "niconico"
 		},
 		"id": 27,
@@ -313,6 +340,7 @@
 		"altTitles": [],
 		"artist": "GigaReol",
 		"data": {
+			"duration": 157.929,
 			"genre": "niconico"
 		},
 		"id": 28,
@@ -325,6 +353,7 @@
 		"altTitles": [],
 		"artist": "Omoi feat. 初音ミク",
 		"data": {
+			"duration": 153.45,
 			"genre": "niconico"
 		},
 		"id": 29,
@@ -337,6 +366,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 126.176,
 			"genre": "niconico"
 		},
 		"id": 30,
@@ -349,6 +379,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 151,
 			"genre": "niconico"
 		},
 		"id": 31,
@@ -361,6 +392,7 @@
 		"altTitles": [],
 		"artist": "日向電工",
 		"data": {
+			"duration": 133.256,
 			"genre": "niconico"
 		},
 		"id": 32,
@@ -373,6 +405,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
+			"duration": 133.043,
 			"genre": "東方Project"
 		},
 		"id": 33,
@@ -383,6 +416,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 113.333,
 			"genre": "東方Project"
 		},
 		"id": 34,
@@ -395,6 +429,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 140.625,
 			"genre": "東方Project"
 		},
 		"id": 35,
@@ -405,6 +440,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 141.522,
 			"genre": "東方Project"
 		},
 		"id": 36,
@@ -417,6 +453,7 @@
 		"altTitles": [],
 		"artist": "激戦の人",
 		"data": {
+			"duration": 139.251,
 			"genre": "東方Project"
 		},
 		"id": 37,
@@ -429,6 +466,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 135.947,
 			"genre": "東方Project"
 		},
 		"id": 38,
@@ -441,6 +479,7 @@
 		"altTitles": [],
 		"artist": "koutaq",
 		"data": {
+			"duration": 149.333,
 			"genre": "東方Project"
 		},
 		"id": 39,
@@ -453,6 +492,7 @@
 		"altTitles": [],
 		"artist": "ふぉれすとぴれお",
 		"data": {
+			"duration": 143.591,
 			"genre": "東方Project"
 		},
 		"id": 40,
@@ -465,6 +505,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 131.071,
 			"genre": "東方Project"
 		},
 		"id": 41,
@@ -475,6 +516,7 @@
 		"altTitles": [],
 		"artist": "さわわ",
 		"data": {
+			"duration": 151.502,
 			"genre": "東方Project"
 		},
 		"id": 42,
@@ -485,6 +527,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 135,
 			"genre": "東方Project"
 		},
 		"id": 43,
@@ -497,6 +540,7 @@
 		"altTitles": [],
 		"artist": "真宮寺さくら（横山智佐）＆帝国歌劇団「サクラ大戦」",
 		"data": {
+			"duration": 159.467,
 			"genre": "VARIETY"
 		},
 		"id": 44,
@@ -509,6 +553,7 @@
 		"altTitles": [],
 		"artist": "Junk",
 		"data": {
+			"duration": 142.083,
 			"genre": "VARIETY"
 		},
 		"id": 45,
@@ -519,6 +564,7 @@
 		"altTitles": [],
 		"artist": "NOMA",
 		"data": {
+			"duration": 118.093,
 			"genre": "VARIETY"
 		},
 		"id": 46,
@@ -529,6 +575,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 160.838,
 			"genre": "VARIETY"
 		},
 		"id": 47,
@@ -539,6 +586,7 @@
 		"altTitles": [],
 		"artist": "loos feat. 柊莉杏",
 		"data": {
+			"duration": 137.143,
 			"genre": "VARIETY"
 		},
 		"id": 48,
@@ -551,6 +599,7 @@
 		"altTitles": [],
 		"artist": "TJ.hangneil",
 		"data": {
+			"duration": 151.571,
 			"genre": "VARIETY"
 		},
 		"id": 49,
@@ -563,6 +612,7 @@
 		"altTitles": [],
 		"artist": "Grand Thaw / Rigel Theatre",
 		"data": {
+			"duration": 163.416,
 			"genre": "VARIETY"
 		},
 		"id": 50,
@@ -573,6 +623,7 @@
 		"altTitles": [],
 		"artist": "片霧烈火オンザみんマンション",
 		"data": {
+			"duration": 153.409,
 			"genre": "チュウマイ"
 		},
 		"id": 51,
@@ -585,6 +636,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 122.842,
 			"genre": "チュウマイ"
 		},
 		"id": 52,
@@ -595,6 +647,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 153,
 			"genre": "チュウマイ"
 		},
 		"id": 53,
@@ -607,6 +660,7 @@
 		"altTitles": [],
 		"artist": "M2U",
 		"data": {
+			"duration": 135.2,
 			"genre": "チュウマイ"
 		},
 		"id": 54,
@@ -617,6 +671,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 141.563,
 			"genre": "チュウマイ"
 		},
 		"id": 55,
@@ -627,6 +682,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 140.129,
 			"genre": "チュウマイ"
 		},
 		"id": 56,
@@ -639,6 +695,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 133.548,
 			"genre": "チュウマイ"
 		},
 		"id": 57,
@@ -649,6 +706,7 @@
 		"altTitles": [],
 		"artist": "WAiKURO",
 		"data": {
+			"duration": 140.74,
 			"genre": "チュウマイ"
 		},
 		"id": 58,
@@ -659,6 +717,7 @@
 		"altTitles": [],
 		"artist": "Masahiro “Godspeed” Aoki",
 		"data": {
+			"duration": 146.249,
 			"genre": "チュウマイ"
 		},
 		"id": 59,
@@ -669,6 +728,7 @@
 		"altTitles": [],
 		"artist": "折戸伸治 feat.北沢綾香",
 		"data": {
+			"duration": 173.182,
 			"genre": "チュウマイ"
 		},
 		"id": 60,
@@ -679,6 +739,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 144.545,
 			"genre": "チュウマイ"
 		},
 		"id": 61,
@@ -689,6 +750,7 @@
 		"altTitles": [],
 		"artist": "Queen P.A.L.",
 		"data": {
+			"duration": 136.875,
 			"genre": "チュウマイ"
 		},
 		"id": 62,
@@ -699,6 +761,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 141,
 			"genre": "チュウマイ"
 		},
 		"id": 63,
@@ -711,6 +774,7 @@
 		"altTitles": [],
 		"artist": "ヒゲドライバー",
 		"data": {
+			"duration": 115.2,
 			"genre": "チュウマイ"
 		},
 		"id": 64,
@@ -721,6 +785,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 131.7,
 			"genre": "チュウマイ"
 		},
 		"id": 65,
@@ -731,6 +796,7 @@
 		"altTitles": [],
 		"artist": "あべにゅうぷろじぇくと feat.佐倉 紗織　produced by ave;new",
 		"data": {
+			"duration": 142.991,
 			"genre": "チュウマイ"
 		},
 		"id": 66,
@@ -743,6 +809,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 168.682,
 			"genre": "チュウマイ"
 		},
 		"id": 67,
@@ -753,6 +820,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 170.895,
 			"genre": "チュウマイ"
 		},
 		"id": 68,
@@ -765,6 +833,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 142.088,
 			"genre": "オンゲキ"
 		},
 		"id": 69,
@@ -775,6 +844,7 @@
 		"altTitles": [],
 		"artist": "曲：kz(livetune)／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.111,
 			"genre": "オンゲキ"
 		},
 		"id": 70,
@@ -785,6 +855,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 156,
 			"genre": "オンゲキ"
 		},
 		"id": 71,
@@ -797,6 +868,7 @@
 		"altTitles": [],
 		"artist": "曲：上松範廉(Elements Garden)／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 149.583,
 			"genre": "オンゲキ"
 		},
 		"id": 72,
@@ -807,6 +879,7 @@
 		"altTitles": [],
 		"artist": "曲：TeddyLoid／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 149.2,
 			"genre": "オンゲキ"
 		},
 		"id": 73,
@@ -817,6 +890,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 142.452,
 			"genre": "オンゲキ"
 		},
 		"id": 74,
@@ -827,6 +901,7 @@
 		"altTitles": [],
 		"artist": "曲：Tom-H@ck／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 157.44,
 			"genre": "オンゲキ"
 		},
 		"id": 75,
@@ -839,6 +914,7 @@
 		"altTitles": [],
 		"artist": "曲：鯨井国家／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 126.167,
 			"genre": "オンゲキ"
 		},
 		"id": 76,
@@ -851,6 +927,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 130.16,
 			"genre": "オンゲキ"
 		},
 		"id": 77,
@@ -861,6 +938,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 133.68,
 			"genre": "オンゲキ"
 		},
 		"id": 78,
@@ -873,6 +951,7 @@
 		"altTitles": [],
 		"artist": "有形ランペイジ",
 		"data": {
+			"duration": 149.813,
 			"genre": "オンゲキ"
 		},
 		"id": 79,
@@ -885,6 +964,7 @@
 		"altTitles": [],
 		"artist": "曲：佐藤純一（fhána）／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 156.045,
 			"genre": "オンゲキ"
 		},
 		"id": 80,
@@ -895,6 +975,7 @@
 		"altTitles": [],
 		"artist": "曲：NAOKI／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 135.57,
 			"genre": "オンゲキ"
 		},
 		"id": 81,
@@ -905,6 +986,7 @@
 		"altTitles": [],
 		"artist": "Cranky,Morrigan feat.Lily",
 		"data": {
+			"duration": 145.667,
 			"genre": "オンゲキ"
 		},
 		"id": 82,
@@ -915,6 +997,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 157.969,
 			"genre": "オンゲキ"
 		},
 		"id": 83,
@@ -925,6 +1008,7 @@
 		"altTitles": [],
 		"artist": "void (Mournfinale)",
 		"data": {
+			"duration": 140.688,
 			"genre": "オンゲキ"
 		},
 		"id": 84,
@@ -935,6 +1019,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 148.125,
 			"genre": "オンゲキ"
 		},
 		"id": 85,
@@ -945,6 +1030,7 @@
 		"altTitles": [],
 		"artist": "曲：ZAQ／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 153.375,
 			"genre": "オンゲキ"
 		},
 		"id": 86,
@@ -955,6 +1041,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 132.273,
 			"genre": "オンゲキ"
 		},
 		"id": 87,
@@ -965,6 +1052,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 141.444,
 			"genre": "オンゲキ"
 		},
 		"id": 88,
@@ -975,6 +1063,7 @@
 		"altTitles": [],
 		"artist": "並木 学「ケツイ ～絆地獄たち～」",
 		"data": {
+			"duration": 111.399,
 			"genre": "LUNATIC"
 		},
 		"id": 89,
@@ -987,6 +1076,7 @@
 		"altTitles": [],
 		"artist": "Machico「この素晴らしい世界に祝福を！2」",
 		"data": {
+			"duration": 132.317,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 90,
@@ -997,6 +1087,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 146.601,
 			"genre": "niconico"
 		},
 		"id": 91,
@@ -1009,6 +1100,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 152.069,
 			"genre": "niconico"
 		},
 		"id": 92,
@@ -1021,6 +1113,7 @@
 		"altTitles": [],
 		"artist": "うたたP",
 		"data": {
+			"duration": 149.155,
 			"genre": "niconico"
 		},
 		"id": 93,
@@ -1033,6 +1126,7 @@
 		"altTitles": [],
 		"artist": "和田たけあき(くらげP)",
 		"data": {
+			"duration": 150.409,
 			"genre": "niconico"
 		},
 		"id": 94,
@@ -1045,6 +1139,7 @@
 		"altTitles": [],
 		"artist": "めぐみん（CV：高橋李依）、ゆんゆん（CV：豊崎愛生）「この素晴らしい世界に祝福を！2」",
 		"data": {
+			"duration": 107.429,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 95,
@@ -1055,6 +1150,7 @@
 		"altTitles": [],
 		"artist": "アクア（CV：雨宮天）「この素晴らしい世界に祝福を！2」",
 		"data": {
+			"duration": 115.304,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 96,
@@ -1067,6 +1163,7 @@
 		"altTitles": [],
 		"artist": "ダクネス（CV：茅野愛衣）「この素晴らしい世界に祝福を！2」",
 		"data": {
+			"duration": 122.663,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 97,
@@ -1079,6 +1176,7 @@
 		"altTitles": [],
 		"artist": "EBIMAYO",
 		"data": {
+			"duration": 121.757,
 			"genre": "VARIETY"
 		},
 		"id": 98,
@@ -1089,6 +1187,7 @@
 		"altTitles": [],
 		"artist": "Shandy kubota",
 		"data": {
+			"duration": 123.429,
 			"genre": "チュウマイ"
 		},
 		"id": 99,
@@ -1099,6 +1198,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト",
 		"data": {
+			"duration": 129.205,
 			"genre": "東方Project"
 		},
 		"id": 100,
@@ -1111,6 +1211,7 @@
 		"altTitles": [],
 		"artist": "Poppin’Party「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 120.743,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 101,
@@ -1121,6 +1222,7 @@
 		"altTitles": [],
 		"artist": "Afterglow「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 110.506,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 102,
@@ -1133,6 +1235,7 @@
 		"altTitles": [],
 		"artist": "Pastel＊Palettes「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 105.093,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 103,
@@ -1145,6 +1248,7 @@
 		"altTitles": [],
 		"artist": "Roselia「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 113.778,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 104,
@@ -1155,6 +1259,7 @@
 		"altTitles": [],
 		"artist": "ハロー、ハッピーワールド！「バンドリ！ ガールズバンドパーティ！」",
 		"data": {
+			"duration": 102.837,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 105,
@@ -1167,6 +1272,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修",
 		"data": {
+			"duration": 150.326,
 			"genre": "チュウマイ"
 		},
 		"id": 106,
@@ -1179,6 +1285,7 @@
 		"altTitles": [],
 		"artist": "穴山大輔",
 		"data": {
+			"duration": 151.75,
 			"genre": "チュウマイ"
 		},
 		"id": 107,
@@ -1192,6 +1299,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 134.057,
 			"genre": "オンゲキ"
 		},
 		"id": 108,
@@ -1202,6 +1310,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 136.981,
 			"genre": "オンゲキ"
 		},
 		"id": 109,
@@ -1212,6 +1321,7 @@
 		"altTitles": [],
 		"artist": "日向 美海(CV：相坂 優歌)「アンジュ・ヴィエルジュ」",
 		"data": {
+			"duration": 145.579,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 110,
@@ -1222,6 +1332,7 @@
 		"altTitles": [],
 		"artist": "本間芽衣子(茅野愛衣)、安城鳴子(戸松遥)、鶴見知利子(早見沙織)「あの日見た花の名前を僕達はまだ知らない。」",
 		"data": {
+			"duration": 146.866,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 111,
@@ -1234,6 +1345,7 @@
 		"altTitles": [],
 		"artist": "涼宮ハルヒ（CV.平野 綾） TVアニメ「涼宮ハルヒの憂鬱」",
 		"data": {
+			"duration": 161.635,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 112,
@@ -1244,6 +1356,7 @@
 		"altTitles": [],
 		"artist": "fourfolium［涼風青葉（CV：高田憂希）／滝本ひふみ（CV：山口 愛）／篠田はじめ（CV：戸田めぐみ）／飯島ゆん（CV：竹尾歩美）］「NEW GAME!!」",
 		"data": {
+			"duration": 155.482,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 113,
@@ -1254,6 +1367,7 @@
 		"altTitles": [],
 		"artist": "相坂 優歌「アンジュ・ヴィエルジュ」",
 		"data": {
+			"duration": 155.625,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 114,
@@ -1264,6 +1378,7 @@
 		"altTitles": [],
 		"artist": "鈴木このみ「アンジュ・ヴィエルジュ」",
 		"data": {
+			"duration": 159.387,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 115,
@@ -1274,6 +1389,7 @@
 		"altTitles": [],
 		"artist": "L.I.N.K.s（相坂優歌／石原 舞／高橋李依／生田善子／山本希望）「アンジュ・ヴィエルジュ」",
 		"data": {
+			"duration": 160.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 116,
@@ -1284,6 +1400,7 @@
 		"altTitles": [],
 		"artist": "ふわりP",
 		"data": {
+			"duration": 178.977,
 			"genre": "チュウマイ"
 		},
 		"id": 117,
@@ -1296,6 +1413,7 @@
 		"altTitles": [],
 		"artist": "lumo",
 		"data": {
+			"duration": 165,
 			"genre": "チュウマイ"
 		},
 		"id": 118,
@@ -1308,6 +1426,7 @@
 		"altTitles": [],
 		"artist": "40mP feat.シャノ",
 		"data": {
+			"duration": 154.08,
 			"genre": "チュウマイ"
 		},
 		"id": 119,
@@ -1320,6 +1439,7 @@
 		"altTitles": [],
 		"artist": "鈴木このみ「Re:ゼロから始める異世界生活」",
 		"data": {
+			"duration": 155.368,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 120,
@@ -1330,6 +1450,7 @@
 		"altTitles": [],
 		"artist": "佐咲紗花",
 		"data": {
+			"duration": 135.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 121,
@@ -1340,6 +1461,7 @@
 		"altTitles": [],
 		"artist": "藍井エイル",
 		"data": {
+			"duration": 117.902,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 122,
@@ -1352,6 +1474,7 @@
 		"altTitles": [],
 		"artist": "fripSide「とある科学の超電磁砲S」",
 		"data": {
+			"duration": 158.958,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 123,
@@ -1362,6 +1485,7 @@
 		"altTitles": [],
 		"artist": "御坂美琴（佐藤利奈）「とある科学の超電磁砲」",
 		"data": {
+			"duration": 138.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 124,
@@ -1374,6 +1498,7 @@
 		"altTitles": [],
 		"artist": "白井黒子（新井里美）「とある科学の超電磁砲」",
 		"data": {
+			"duration": 159.002,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 125,
@@ -1386,6 +1511,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 139.2,
 			"genre": "niconico"
 		},
 		"id": 126,
@@ -1398,6 +1524,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 149.6,
 			"genre": "niconico"
 		},
 		"id": 127,
@@ -1410,6 +1537,7 @@
 		"altTitles": [],
 		"artist": "奏音69×巡音ルカ",
 		"data": {
+			"duration": 158.376,
 			"genre": "niconico"
 		},
 		"id": 128,
@@ -1422,6 +1550,7 @@
 		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
+			"duration": 136.95,
 			"genre": "東方Project"
 		},
 		"id": 129,
@@ -1432,6 +1561,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 145.574,
 			"genre": "オンゲキ"
 		},
 		"id": 130,
@@ -1442,6 +1572,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE",
 		"data": {
+			"duration": 131,
 			"genre": "オンゲキ"
 		},
 		"id": 131,
@@ -1452,6 +1583,7 @@
 		"altTitles": [],
 		"artist": "ガリガリさむし",
 		"data": {
+			"duration": 129.103,
 			"genre": "オンゲキ"
 		},
 		"id": 132,
@@ -1462,6 +1594,7 @@
 		"altTitles": [],
 		"artist": "Junk",
 		"data": {
+			"duration": 153.383,
 			"genre": "オンゲキ"
 		},
 		"id": 133,
@@ -1472,6 +1605,7 @@
 		"altTitles": [],
 		"artist": "fripSide「とある科学の超電磁砲」",
 		"data": {
+			"duration": 146.014,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 134,
@@ -1482,6 +1616,7 @@
 		"altTitles": [],
 		"artist": "初春飾利（豊崎愛生）＆佐天涙子（伊藤かな恵）「とある科学の超電磁砲」",
 		"data": {
+			"duration": 135.857,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 135,
@@ -1494,6 +1629,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 119.561,
 			"genre": "niconico"
 		},
 		"id": 136,
@@ -1506,6 +1642,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 138.971,
 			"genre": "niconico"
 		},
 		"id": 137,
@@ -1516,6 +1653,7 @@
 		"altTitles": [],
 		"artist": "曲：eba／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
+			"duration": 143.505,
 			"genre": "オンゲキ"
 		},
 		"id": 138,
@@ -1528,6 +1666,7 @@
 		"altTitles": [],
 		"artist": "BlackY vs. Yooh",
 		"data": {
+			"duration": 152.165,
 			"genre": "オンゲキ"
 		},
 		"id": 139,
@@ -1538,6 +1677,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 142.25,
 			"genre": "niconico"
 		},
 		"id": 140,
@@ -1550,6 +1690,7 @@
 		"altTitles": [],
 		"artist": "iroha(sasaki)／kuma(alfred)",
 		"data": {
+			"duration": 151.636,
 			"genre": "niconico"
 		},
 		"id": 141,
@@ -1562,6 +1703,7 @@
 		"altTitles": [],
 		"artist": "otetsu",
 		"data": {
+			"duration": 145.375,
 			"genre": "niconico"
 		},
 		"id": 142,
@@ -1574,6 +1716,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 159.4,
 			"genre": "niconico"
 		},
 		"id": 143,
@@ -1584,6 +1727,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 122.1,
 			"genre": "niconico"
 		},
 		"id": 144,
@@ -1596,6 +1740,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 157.353,
 			"genre": "niconico"
 		},
 		"id": 145,
@@ -1608,6 +1753,7 @@
 		"altTitles": [],
 		"artist": "KOTOKO",
 		"data": {
+			"duration": 131.613,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 146,
@@ -1618,6 +1764,7 @@
 		"altTitles": [],
 		"artist": "曲：大畑拓也／歌：bitter flavor [桜井 春菜(CV：近藤 玲奈)、早乙女 彩華(CV：中島 唯)]",
 		"data": {
+			"duration": 149.571,
 			"genre": "オンゲキ"
 		},
 		"id": 147,
@@ -1628,6 +1775,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 126.522,
 			"genre": "オンゲキ"
 		},
 		"id": 148,
@@ -1638,6 +1786,7 @@
 		"altTitles": [],
 		"artist": "まらしぃ",
 		"data": {
+			"duration": 151.65,
 			"genre": "オンゲキ"
 		},
 		"id": 149,
@@ -1648,6 +1797,7 @@
 		"altTitles": [],
 		"artist": "Street",
 		"data": {
+			"duration": 119.143,
 			"genre": "LUNATIC"
 		},
 		"id": 150,
@@ -1658,6 +1808,7 @@
 		"altTitles": [],
 		"artist": "曲：MOSAIC.WAV／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 146.604,
 			"genre": "オンゲキ"
 		},
 		"id": 151,
@@ -1670,6 +1821,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修",
 		"data": {
+			"duration": 92.1,
 			"genre": "LUNATIC"
 		},
 		"id": 152,
@@ -1682,6 +1834,7 @@
 		"altTitles": [],
 		"artist": "ペコリーヌ（M・A・O）、コッコロ（伊藤美来）、キャル（立花理香）「プリンセスコネクト！Re:Dive」",
 		"data": {
+			"duration": 153.2,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 153,
@@ -1692,6 +1845,7 @@
 		"altTitles": [],
 		"artist": "Wake Up, Girls！",
 		"data": {
+			"duration": 144.755,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 154,
@@ -1704,6 +1858,7 @@
 		"altTitles": [],
 		"artist": "TrySail",
 		"data": {
+			"duration": 160,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 155,
@@ -1714,6 +1869,7 @@
 		"altTitles": [],
 		"artist": "茅原実里",
 		"data": {
+			"duration": 145.666,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 156,
@@ -1724,6 +1880,7 @@
 		"altTitles": [],
 		"artist": "池頼広「Shadowverse」",
 		"data": {
+			"duration": 139.116,
 			"genre": "VARIETY"
 		},
 		"id": 157,
@@ -1736,6 +1893,7 @@
 		"altTitles": [],
 		"artist": "ペコリーヌ（M・A・O）、コッコロ（伊藤美来）、キャル（立花理香）「プリンセスコネクト！Re:Dive」",
 		"data": {
+			"duration": 122.967,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 158,
@@ -1746,6 +1904,7 @@
 		"altTitles": [],
 		"artist": "高宮なすの(CV:鳴海杏子)「てーきゅう」",
 		"data": {
+			"duration": 158.182,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 159,
@@ -1758,6 +1917,7 @@
 		"altTitles": [],
 		"artist": "パトリシア・オブ・エンド(CV:高森奈津美)・黒木未知(CV:仙台エリ)・夕莉シャチ(CV:浅川悠)・明日原ユウキ(CV:種﨑敦美)「ノラと皇女と野良猫ハート」",
 		"data": {
+			"duration": 140.44,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 160,
@@ -1770,6 +1930,7 @@
 		"altTitles": [],
 		"artist": "バルーン",
 		"data": {
+			"duration": 138.207,
 			"genre": "niconico"
 		},
 		"id": 161,
@@ -1782,6 +1943,7 @@
 		"altTitles": [],
 		"artist": "少女病",
 		"data": {
+			"duration": 164.198,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 162,
@@ -1794,6 +1956,7 @@
 		"altTitles": [],
 		"artist": "SYNC.ART'S feat.美里",
 		"data": {
+			"duration": 145.742,
 			"genre": "東方Project"
 		},
 		"id": 163,
@@ -1806,6 +1969,7 @@
 		"altTitles": [],
 		"artist": "霜月はるか",
 		"data": {
+			"duration": 142.06,
 			"genre": "チュウマイ"
 		},
 		"id": 164,
@@ -1816,6 +1980,7 @@
 		"altTitles": [],
 		"artist": "曲：前山田健一／歌：7EVENDAYS⇔HOLIDAYS [井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)]",
 		"data": {
+			"duration": 154.615,
 			"genre": "オンゲキ"
 		},
 		"id": 165,
@@ -1828,6 +1993,7 @@
 		"altTitles": [],
 		"artist": "IOSYS TRAX",
 		"data": {
+			"duration": 161.111,
 			"genre": "オンゲキ"
 		},
 		"id": 166,
@@ -1838,6 +2004,7 @@
 		"altTitles": [],
 		"artist": "削除 (Violin : Katali)",
 		"data": {
+			"duration": 149.848,
 			"genre": "オンゲキ"
 		},
 		"id": 167,
@@ -1851,6 +2018,7 @@
 		"altTitles": [],
 		"artist": "sumijun(Halozy) feat. ななひら(Confetto)",
 		"data": {
+			"duration": 127.839,
 			"genre": "東方Project"
 		},
 		"id": 168,
@@ -1863,6 +2031,7 @@
 		"altTitles": [],
 		"artist": "石鹸屋",
 		"data": {
+			"duration": 147.879,
 			"genre": "東方Project"
 		},
 		"id": 169,
@@ -1875,6 +2044,7 @@
 		"altTitles": [],
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
+			"duration": 135.273,
 			"genre": "東方Project"
 		},
 		"id": 170,
@@ -1887,6 +2057,7 @@
 		"altTitles": [],
 		"artist": "片霧烈火＆橋本鏡也",
 		"data": {
+			"duration": 149.25,
 			"genre": "東方Project"
 		},
 		"id": 171,
@@ -1899,6 +2070,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
+			"duration": 139.2,
 			"genre": "東方Project"
 		},
 		"id": 172,
@@ -1909,6 +2081,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE feat.野宮あゆみ",
 		"data": {
+			"duration": 117,
 			"genre": "東方Project"
 		},
 		"id": 173,
@@ -1919,6 +2092,7 @@
 		"altTitles": [],
 		"artist": "IOSYS",
 		"data": {
+			"duration": 140.333,
 			"genre": "東方Project"
 		},
 		"id": 174,
@@ -1931,6 +2105,7 @@
 		"altTitles": [],
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
+			"duration": 152.229,
 			"genre": "東方Project"
 		},
 		"id": 175,
@@ -1941,6 +2116,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 124,
 			"genre": "東方Project"
 		},
 		"id": 176,
@@ -1951,6 +2127,7 @@
 		"altTitles": [],
 		"artist": "siromaru + cranky",
 		"data": {
+			"duration": 151.875,
 			"genre": "VARIETY"
 		},
 		"id": 177,
@@ -1961,6 +2138,7 @@
 		"altTitles": [],
 		"artist": "曲：ゆよゆっぺ／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 140.108,
 			"genre": "オンゲキ"
 		},
 		"id": 178,
@@ -1971,6 +2149,7 @@
 		"altTitles": [],
 		"artist": "曲：八木雄一 feat. Marty Friedman／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 148.571,
 			"genre": "オンゲキ"
 		},
 		"id": 179,
@@ -1981,6 +2160,7 @@
 		"altTitles": [],
 		"artist": "曲：村井大／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 145.263,
 			"genre": "オンゲキ"
 		},
 		"id": 180,
@@ -1993,6 +2173,7 @@
 		"altTitles": [],
 		"artist": "曲：烏屋茶房／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
+			"duration": 151.613,
 			"genre": "オンゲキ"
 		},
 		"id": 181,
@@ -2005,6 +2186,7 @@
 		"altTitles": [],
 		"artist": "Machico「この素晴らしい世界に祝福を！」",
 		"data": {
+			"duration": 149.838,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 182,
@@ -2015,6 +2197,7 @@
 		"altTitles": [],
 		"artist": "ChouCho",
 		"data": {
+			"duration": 149.818,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 183,
@@ -2025,6 +2208,7 @@
 		"altTitles": [],
 		"artist": "LiSA",
 		"data": {
+			"duration": 120.789,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 184,
@@ -2035,6 +2219,7 @@
 		"altTitles": [],
 		"artist": "ユーフィリア(CV：高橋 李依)「アンジュ・ヴィエルジュ」",
 		"data": {
+			"duration": 145.767,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 185,
@@ -2045,6 +2230,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK x DECO*27",
 		"data": {
+			"duration": 119.314,
 			"genre": "niconico"
 		},
 		"id": 186,
@@ -2055,6 +2241,7 @@
 		"altTitles": [],
 		"artist": "supercell",
 		"data": {
+			"duration": 160.941,
 			"genre": "niconico"
 		},
 		"id": 187,
@@ -2067,6 +2254,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 128.438,
 			"genre": "チュウマイ"
 		},
 		"id": 188,
@@ -2077,6 +2265,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 147.15,
 			"genre": "チュウマイ"
 		},
 		"id": 189,
@@ -2087,6 +2276,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：ASTERISM [星咲 あかり(CV：赤尾 ひかる)、藤沢 柚子(CV：久保田 梨沙)、三角 葵(CV：春野 杏)]",
 		"data": {
+			"duration": 144,
 			"genre": "オンゲキ"
 		},
 		"id": 190,
@@ -2097,6 +2287,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 159.633,
 			"genre": "オンゲキ"
 		},
 		"id": 191,
@@ -2107,6 +2298,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
+			"duration": 128.815,
 			"genre": "東方Project"
 		},
 		"id": 192,
@@ -2119,6 +2311,7 @@
 		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
+			"duration": 149.538,
 			"genre": "オンゲキ"
 		},
 		"id": 193,
@@ -2129,6 +2322,7 @@
 		"altTitles": [],
 		"artist": "穴山大輔 VS 光吉猛修 VS Kai",
 		"data": {
+			"duration": 166.158,
 			"genre": "オンゲキ"
 		},
 		"id": 194,
@@ -2144,6 +2338,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 140.238,
 			"genre": "niconico"
 		},
 		"id": 195,
@@ -2156,6 +2351,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 153.15,
 			"genre": "niconico"
 		},
 		"id": 196,
@@ -2168,6 +2364,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 145.99,
 			"genre": "niconico"
 		},
 		"id": 197,
@@ -2180,6 +2377,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 146.842,
 			"genre": "チュウマイ"
 		},
 		"id": 198,
@@ -2192,6 +2390,7 @@
 		"altTitles": [],
 		"artist": "フランシュシュ「ゾンビランドサガ」",
 		"data": {
+			"duration": 159.767,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 199,
@@ -2204,6 +2403,7 @@
 		"altTitles": [],
 		"artist": "LiSA",
 		"data": {
+			"duration": 158.639,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 200,
@@ -2214,6 +2414,7 @@
 		"altTitles": [],
 		"artist": "放課後ティータイム",
 		"data": {
+			"duration": 149.76,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 201,
@@ -2224,6 +2425,7 @@
 		"altTitles": [],
 		"artist": "T.M.Revolution×水樹奈々",
 		"data": {
+			"duration": 143.713,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 202,
@@ -2234,6 +2436,7 @@
 		"altTitles": [],
 		"artist": "EGOIST",
 		"data": {
+			"duration": 156.279,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 203,
@@ -2244,6 +2447,7 @@
 		"altTitles": [],
 		"artist": "DOLLS「プロジェクト東京ドールズ」",
 		"data": {
+			"duration": 160.732,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 204,
@@ -2254,6 +2458,7 @@
 		"altTitles": [],
 		"artist": "スタァライト九九組「少女☆歌劇 レヴュースタァライト」",
 		"data": {
+			"duration": 161.625,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 205,
@@ -2264,6 +2469,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 151.579,
 			"genre": "niconico"
 		},
 		"id": 206,
@@ -2276,6 +2482,7 @@
 		"altTitles": [],
 		"artist": "ギガ",
 		"data": {
+			"duration": 135.158,
 			"genre": "niconico"
 		},
 		"id": 207,
@@ -2288,6 +2495,7 @@
 		"altTitles": [],
 		"artist": "Orangestar feat.初音ミク",
 		"data": {
+			"duration": 153.488,
 			"genre": "niconico"
 		},
 		"id": 208,
@@ -2300,6 +2508,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 147.892,
 			"genre": "niconico"
 		},
 		"id": 209,
@@ -2312,6 +2521,7 @@
 		"altTitles": [],
 		"artist": "和田たけあき",
 		"data": {
+			"duration": 162.829,
 			"genre": "niconico"
 		},
 		"id": 210,
@@ -2324,6 +2534,7 @@
 		"altTitles": [],
 		"artist": "DIVELA",
 		"data": {
+			"duration": 141.882,
 			"genre": "niconico"
 		},
 		"id": 211,
@@ -2334,6 +2545,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 131.55,
 			"genre": "東方Project"
 		},
 		"id": 212,
@@ -2346,6 +2558,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
+			"duration": 133.5,
 			"genre": "東方Project"
 		},
 		"id": 213,
@@ -2358,6 +2571,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 140.165,
 			"genre": "VARIETY"
 		},
 		"id": 214,
@@ -2368,6 +2582,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.769,
 			"genre": "オンゲキ"
 		},
 		"id": 215,
@@ -2380,6 +2595,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 159.783,
 			"genre": "オンゲキ"
 		},
 		"id": 216,
@@ -2392,6 +2608,7 @@
 		"altTitles": [],
 		"artist": "Noah",
 		"data": {
+			"duration": 154.435,
 			"genre": "オンゲキ"
 		},
 		"id": 217,
@@ -2402,6 +2619,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 158.308,
 			"genre": "オンゲキ"
 		},
 		"id": 218,
@@ -2412,6 +2630,7 @@
 		"altTitles": [],
 		"artist": "曲：やしきん／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 145.946,
 			"genre": "オンゲキ"
 		},
 		"id": 219,
@@ -2424,6 +2643,7 @@
 		"altTitles": [],
 		"artist": "sky_delta",
 		"data": {
+			"duration": 145.946,
 			"genre": "オンゲキ"
 		},
 		"id": 220,
@@ -2434,6 +2654,7 @@
 		"altTitles": [],
 		"artist": "曲：DJ Genki／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 142.927,
 			"genre": "オンゲキ"
 		},
 		"id": 221,
@@ -2446,6 +2667,7 @@
 		"altTitles": [],
 		"artist": "ぺのれり",
 		"data": {
+			"duration": 139.186,
 			"genre": "オンゲキ"
 		},
 		"id": 222,
@@ -2456,6 +2678,7 @@
 		"altTitles": [],
 		"artist": "並木 学「怒首領蜂大往生」",
 		"data": {
+			"duration": 101.156,
 			"genre": "LUNATIC"
 		},
 		"id": 223,
@@ -2469,6 +2692,7 @@
 		"altTitles": [],
 		"artist": "DOLLS「プロジェクト東京ドールズ」",
 		"data": {
+			"duration": 115.593,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 224,
@@ -2481,6 +2705,7 @@
 		"altTitles": [],
 		"artist": "スタァライト九九組「少女☆歌劇 レヴュースタァライト」",
 		"data": {
+			"duration": 103.04,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 225,
@@ -2493,6 +2718,7 @@
 		"altTitles": [],
 		"artist": "Kizuna AI",
 		"data": {
+			"duration": 128.625,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 226,
@@ -2503,6 +2729,7 @@
 		"altTitles": [],
 		"artist": "アズマ リム",
 		"data": {
+			"duration": 157.8,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 227,
@@ -2515,6 +2742,7 @@
 		"altTitles": [],
 		"artist": "YuNi",
 		"data": {
+			"duration": 134.571,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 228,
@@ -2527,6 +2755,7 @@
 		"altTitles": [],
 		"artist": "あまね＋ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 110.211,
 			"genre": "東方Project"
 		},
 		"id": 229,
@@ -2539,6 +2768,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 157.777,
 			"genre": "東方Project"
 		},
 		"id": 230,
@@ -2551,6 +2781,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト",
 		"data": {
+			"duration": 150.677,
 			"genre": "東方Project"
 		},
 		"id": 231,
@@ -2563,6 +2794,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 128.033,
 			"genre": "東方Project"
 		},
 		"id": 232,
@@ -2573,6 +2805,7 @@
 		"altTitles": [],
 		"artist": "SYNC.ART'S feat. 3L",
 		"data": {
+			"duration": 129.882,
 			"genre": "東方Project"
 		},
 		"id": 233,
@@ -2585,6 +2818,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 133.75,
 			"genre": "niconico"
 		},
 		"id": 234,
@@ -2597,6 +2831,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：FIREシューターズ",
 		"data": {
+			"duration": 150.216,
 			"genre": "オンゲキ"
 		},
 		"id": 235,
@@ -2609,6 +2844,7 @@
 		"altTitles": [],
 		"artist": "山本真央樹",
 		"data": {
+			"duration": 156,
 			"genre": "オンゲキ"
 		},
 		"id": 236,
@@ -2619,6 +2855,7 @@
 		"altTitles": [],
 		"artist": "草津結衣奈(CV:高田憂希)、尖石内湾(CV:安齋由香里)「温泉むすめ」",
 		"data": {
+			"duration": 164.889,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 237,
@@ -2631,6 +2868,7 @@
 		"altTitles": [],
 		"artist": "SPRiNGS「温泉むすめ」",
 		"data": {
+			"duration": 135.375,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 238,
@@ -2643,6 +2881,7 @@
 		"altTitles": [],
 		"artist": "petit corolla「温泉むすめ」",
 		"data": {
+			"duration": 156.279,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 239,
@@ -2653,6 +2892,7 @@
 		"altTitles": [],
 		"artist": "ゆうゆ / 篠螺悠那",
 		"data": {
+			"duration": 136.025,
 			"genre": "東方Project"
 		},
 		"id": 240,
@@ -2663,6 +2903,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 151,
 			"genre": "niconico"
 		},
 		"id": 241,
@@ -2675,6 +2916,7 @@
 		"altTitles": [],
 		"artist": "バルーン",
 		"data": {
+			"duration": 147,
 			"genre": "niconico"
 		},
 		"id": 242,
@@ -2687,6 +2929,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお × Cranky",
 		"data": {
+			"duration": 144.833,
 			"genre": "東方Project"
 		},
 		"id": 243,
@@ -2699,6 +2942,7 @@
 		"altTitles": [],
 		"artist": "曲：中山真斗／歌：マーチングポケッツ [日向 千夏(CV：岡咲 美保)、柏木 美亜(CV：和氣 あず未)、東雲 つむぎ(CV：和泉 風花)]",
 		"data": {
+			"duration": 152.381,
 			"genre": "オンゲキ"
 		},
 		"id": 244,
@@ -2711,6 +2955,7 @@
 		"altTitles": [],
 		"artist": "はるなば",
 		"data": {
+			"duration": 126,
 			"genre": "オンゲキ"
 		},
 		"id": 245,
@@ -2721,6 +2966,7 @@
 		"altTitles": [],
 		"artist": "こふ",
 		"data": {
+			"duration": 143.368,
 			"genre": "オンゲキ"
 		},
 		"id": 246,
@@ -2731,6 +2977,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 137.643,
 			"genre": "チュウマイ"
 		},
 		"id": 247,
@@ -2741,6 +2988,7 @@
 		"altTitles": [],
 		"artist": "void (Mournfinale)",
 		"data": {
+			"duration": 165.353,
 			"genre": "チュウマイ"
 		},
 		"id": 248,
@@ -2751,6 +2999,7 @@
 		"altTitles": [],
 		"artist": "777☆SISTERS「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 155.25,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 249,
@@ -2763,6 +3012,7 @@
 		"altTitles": [],
 		"artist": "SiSH「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 160.714,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 250,
@@ -2775,6 +3025,7 @@
 		"altTitles": [],
 		"artist": "WITCH NUMBER 4「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 158.769,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 251,
@@ -2787,6 +3038,7 @@
 		"altTitles": [],
 		"artist": "ナナホシ管弦楽団 ",
 		"data": {
+			"duration": 156.158,
 			"genre": "niconico"
 		},
 		"id": 252,
@@ -2799,6 +3051,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：AQUAシューターズ",
 		"data": {
+			"duration": 158.63,
 			"genre": "オンゲキ"
 		},
 		"id": 253,
@@ -2811,6 +3064,7 @@
 		"altTitles": [],
 		"artist": "orangentle",
 		"data": {
+			"duration": 126.667,
 			"genre": "オンゲキ"
 		},
 		"id": 254,
@@ -2821,6 +3075,7 @@
 		"altTitles": [],
 		"artist": "NI+CORA「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 127.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 255,
@@ -2831,6 +3086,7 @@
 		"altTitles": [],
 		"artist": "サンボンリボン「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 161.044,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 256,
@@ -2843,6 +3099,7 @@
 		"altTitles": [],
 		"artist": "ヨルシカ",
 		"data": {
+			"duration": 136.286,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 257,
@@ -2855,6 +3112,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 123.208,
 			"genre": "niconico"
 		},
 		"id": 258,
@@ -2867,6 +3125,7 @@
 		"altTitles": [],
 		"artist": "fripSide「とある科学の超電磁砲」",
 		"data": {
+			"duration": 146.237,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 259,
@@ -2877,6 +3136,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 144,
 			"genre": "niconico"
 		},
 		"id": 260,
@@ -2889,6 +3149,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 149.647,
 			"genre": "niconico"
 		},
 		"id": 261,
@@ -2901,6 +3162,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 116.143,
 			"genre": "niconico"
 		},
 		"id": 262,
@@ -2913,6 +3175,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 137.344,
 			"genre": "niconico"
 		},
 		"id": 263,
@@ -2923,6 +3186,7 @@
 		"altTitles": [],
 		"artist": "のぼる↑",
 		"data": {
+			"duration": 133.5,
 			"genre": "niconico"
 		},
 		"id": 264,
@@ -2935,6 +3199,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
+			"duration": 165,
 			"genre": "オンゲキ"
 		},
 		"id": 265,
@@ -2945,6 +3210,7 @@
 		"altTitles": [],
 		"artist": "[H.]",
 		"data": {
+			"duration": 111.678,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 266,
@@ -2957,6 +3223,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ",
 		"data": {
+			"duration": 170.016,
 			"genre": "チュウマイ"
 		},
 		"id": 267,
@@ -2967,6 +3234,7 @@
 		"altTitles": [],
 		"artist": "明坂 芹菜(CV:新田 恵海)＆小仏 凪(CV:佐倉 薫)",
 		"data": {
+			"duration": 143.103,
 			"genre": "チュウマイ"
 		},
 		"id": 268,
@@ -2979,6 +3247,7 @@
 		"altTitles": [],
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
+			"duration": 144.656,
 			"genre": "チュウマイ"
 		},
 		"id": 269,
@@ -2991,6 +3260,7 @@
 		"altTitles": [],
 		"artist": "曲：睦月周平／歌：LEAFシューターズ",
 		"data": {
+			"duration": 143.704,
 			"genre": "オンゲキ"
 		},
 		"id": 270,
@@ -3001,6 +3271,7 @@
 		"altTitles": [],
 		"artist": "Freezer",
 		"data": {
+			"duration": 138.514,
 			"genre": "オンゲキ"
 		},
 		"id": 271,
@@ -3011,6 +3282,7 @@
 		"altTitles": [],
 		"artist": "Lia「Angel Beats!」",
 		"data": {
+			"duration": 161.586,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 272,
@@ -3021,6 +3293,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 151.533,
 			"genre": "niconico"
 		},
 		"id": 273,
@@ -3033,6 +3306,7 @@
 		"altTitles": [],
 		"artist": "Last Note.",
 		"data": {
+			"duration": 150.939,
 			"genre": "niconico"
 		},
 		"id": 274,
@@ -3045,6 +3319,7 @@
 		"altTitles": [],
 		"artist": "CIRCRUSH",
 		"data": {
+			"duration": 145.929,
 			"genre": "niconico"
 		},
 		"id": 275,
@@ -3055,6 +3330,7 @@
 		"altTitles": [],
 		"artist": "Black Raison d'être",
 		"data": {
+			"duration": 154.839,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 276,
@@ -3065,6 +3341,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P ver.Ø",
 		"data": {
+			"duration": 148.421,
 			"genre": "オンゲキ"
 		},
 		"id": 277,
@@ -3077,6 +3354,7 @@
 		"altTitles": [],
 		"artist": "Yooh",
 		"data": {
+			"duration": 126.487,
 			"genre": "オンゲキ"
 		},
 		"id": 278,
@@ -3087,6 +3365,7 @@
 		"altTitles": [],
 		"artist": "多田葵「Angel Beats!」",
 		"data": {
+			"duration": 110.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 279,
@@ -3097,6 +3376,7 @@
 		"altTitles": [],
 		"artist": "Girls Dead Monster (marina)「Angel Beats!」",
 		"data": {
+			"duration": 147.586,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 280,
@@ -3107,6 +3387,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 156.504,
 			"genre": "niconico"
 		},
 		"id": 281,
@@ -3119,6 +3400,7 @@
 		"altTitles": [],
 		"artist": "ぬるはち",
 		"data": {
+			"duration": 144.522,
 			"genre": "東方Project"
 		},
 		"id": 282,
@@ -3129,6 +3411,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 138.857,
 			"genre": "東方Project"
 		},
 		"id": 283,
@@ -3141,6 +3424,7 @@
 		"altTitles": [],
 		"artist": "Cranky vs t+pazolite",
 		"data": {
+			"duration": 148.8,
 			"genre": "VARIETY"
 		},
 		"id": 284,
@@ -3151,6 +3435,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 142.65,
 			"genre": "チュウマイ"
 		},
 		"id": 285,
@@ -3161,6 +3446,7 @@
 		"altTitles": [],
 		"artist": "Nhato",
 		"data": {
+			"duration": 146.323,
 			"genre": "オンゲキ"
 		},
 		"id": 286,
@@ -3171,6 +3457,7 @@
 		"altTitles": [],
 		"artist": "向日葵",
 		"data": {
+			"duration": 122.769,
 			"genre": "niconico"
 		},
 		"id": 287,
@@ -3181,6 +3468,7 @@
 		"altTitles": [],
 		"artist": "ナナホシ管弦楽団 feat. 松下",
 		"data": {
+			"duration": 155,
 			"genre": "niconico"
 		},
 		"id": 288,
@@ -3193,6 +3481,7 @@
 		"altTitles": [],
 		"artist": "じーざすP feat.kradness",
 		"data": {
+			"duration": 150.479,
 			"genre": "チュウマイ"
 		},
 		"id": 289,
@@ -3203,6 +3492,7 @@
 		"altTitles": [],
 		"artist": "やなぎなぎ「やはり俺の青春ラブコメはまちがっている。続」",
 		"data": {
+			"duration": 122.759,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 290,
@@ -3215,6 +3505,7 @@
 		"altTitles": [],
 		"artist": "LOVE☆MAXガールズ「ゴシックは魔法乙女」",
 		"data": {
+			"duration": 158.211,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 291,
@@ -3227,6 +3518,7 @@
 		"altTitles": [],
 		"artist": "米津玄師",
 		"data": {
+			"duration": 92.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 292,
@@ -3239,6 +3531,7 @@
 		"altTitles": [],
 		"artist": "LiSA",
 		"data": {
+			"duration": 123.789,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 293,
@@ -3249,6 +3542,7 @@
 		"altTitles": [],
 		"artist": "ヒャダイン「日常」",
 		"data": {
+			"duration": 135,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 294,
@@ -3261,6 +3555,7 @@
 		"altTitles": [],
 		"artist": "紗倉ひびき（CV:ファイルーズあい）＆街雄鳴造（CV:石川界人）「ダンベル何キロ持てる？」",
 		"data": {
+			"duration": 155.455,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 295,
@@ -3273,6 +3568,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 157.164,
 			"genre": "niconico"
 		},
 		"id": 296,
@@ -3285,6 +3581,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 130.067,
 			"genre": "niconico"
 		},
 		"id": 297,
@@ -3297,6 +3594,7 @@
 		"altTitles": [],
 		"artist": "はるまきごはん feat.初音ミク",
 		"data": {
+			"duration": 146.124,
 			"genre": "niconico"
 		},
 		"id": 298,
@@ -3309,6 +3607,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 132.923,
 			"genre": "東方Project"
 		},
 		"id": 299,
@@ -3321,6 +3620,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.484,
 			"genre": "オンゲキ"
 		},
 		"id": 300,
@@ -3331,6 +3631,7 @@
 		"altTitles": [],
 		"artist": "Maozon",
 		"data": {
+			"duration": 148.75,
 			"genre": "オンゲキ"
 		},
 		"id": 301,
@@ -3341,6 +3642,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 147.2,
 			"genre": "オンゲキ"
 		},
 		"id": 302,
@@ -3351,6 +3653,7 @@
 		"altTitles": [],
 		"artist": "Sound Artz",
 		"data": {
+			"duration": 151.409,
 			"genre": "オンゲキ"
 		},
 		"id": 303,
@@ -3361,6 +3664,7 @@
 		"altTitles": [],
 		"artist": "Lite Show Magic",
 		"data": {
+			"duration": 128.182,
 			"genre": "オンゲキ"
 		},
 		"id": 304,
@@ -3371,6 +3675,7 @@
 		"altTitles": [],
 		"artist": "内藤那津子「怒首領蜂大復活」",
 		"data": {
+			"duration": 137.619,
 			"genre": "LUNATIC"
 		},
 		"id": 305,
@@ -3385,6 +3690,7 @@
 		"altTitles": [],
 		"artist": "DOLLS「プロジェクト東京ドールズ」",
 		"data": {
+			"duration": 158.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 306,
@@ -3395,6 +3701,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 126.667,
 			"genre": "niconico"
 		},
 		"id": 307,
@@ -3407,6 +3714,7 @@
 		"altTitles": [],
 		"artist": "雪ノ下雪乃(CV：早見沙織)＆由比ヶ浜結衣(CV：東山奈央) 「やはり俺の青春ラブコメはまちがっている。続」",
 		"data": {
+			"duration": 113.766,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 308,
@@ -3419,6 +3727,7 @@
 		"altTitles": [],
 		"artist": "Mastermind(xi+nora2r)",
 		"data": {
+			"duration": 140.938,
 			"genre": "VARIETY"
 		},
 		"id": 309,
@@ -3429,6 +3738,7 @@
 		"altTitles": [],
 		"artist": "神樹ヶ峰女学園星守クラス「バトルガール ハイスクール」",
 		"data": {
+			"duration": 163.82,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 310,
@@ -3441,6 +3751,7 @@
 		"altTitles": [],
 		"artist": "ゆうゆ feat. ケムリクサ",
 		"data": {
+			"duration": 154.286,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 311,
@@ -3451,6 +3762,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 148.755,
 			"genre": "niconico"
 		},
 		"id": 312,
@@ -3463,6 +3775,7 @@
 		"altTitles": [],
 		"artist": "和田たけあき(くらげP)",
 		"data": {
+			"duration": 128.615,
 			"genre": "niconico"
 		},
 		"id": 313,
@@ -3475,6 +3788,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock & 佐藤厚仁／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
+			"duration": 155.466,
 			"genre": "オンゲキ"
 		},
 		"id": 314,
@@ -3487,6 +3801,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 138.511,
 			"genre": "オンゲキ"
 		},
 		"id": 315,
@@ -3497,6 +3812,7 @@
 		"altTitles": [],
 		"artist": "f*f（CV：本渡楓・下地紫野）「バトルガール ハイスクール」",
 		"data": {
+			"duration": 151.011,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 316,
@@ -3507,6 +3823,7 @@
 		"altTitles": [],
 		"artist": "川田まみ「蒼の彼方のフォーリズム」",
 		"data": {
+			"duration": 160,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 317,
@@ -3519,6 +3836,7 @@
 		"altTitles": [],
 		"artist": "Halozy feat. ななひら",
 		"data": {
+			"duration": 129.144,
 			"genre": "東方Project"
 		},
 		"id": 318,
@@ -3531,6 +3849,7 @@
 		"altTitles": [],
 		"artist": "NAOKI underground",
 		"data": {
+			"duration": 137.554,
 			"genre": "チュウマイ"
 		},
 		"id": 319,
@@ -3541,6 +3860,7 @@
 		"altTitles": [],
 		"artist": "曲：齋藤大／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 166.612,
 			"genre": "オンゲキ"
 		},
 		"id": 320,
@@ -3553,6 +3873,7 @@
 		"altTitles": [],
 		"artist": "DJ Noriken",
 		"data": {
+			"duration": 147.6,
 			"genre": "オンゲキ"
 		},
 		"id": 321,
@@ -3563,6 +3884,7 @@
 		"altTitles": [],
 		"artist": "a_hisa",
 		"data": {
+			"duration": 149.333,
 			"genre": "オンゲキ"
 		},
 		"id": 322,
@@ -3575,6 +3897,7 @@
 		"altTitles": [],
 		"artist": "Hiro",
 		"data": {
+			"duration": 109.459,
 			"genre": "LUNATIC"
 		},
 		"id": 323,
@@ -3587,6 +3910,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：マーチングポケッツ [日向 千夏(CV：岡咲 美保)、柏木 美亜(CV：和氣 あず未)、東雲 つむぎ(CV：和泉 風花)]",
 		"data": {
+			"duration": 142.125,
 			"genre": "オンゲキ"
 		},
 		"id": 324,
@@ -3599,6 +3923,7 @@
 		"altTitles": [],
 		"artist": "ああああ",
 		"data": {
+			"duration": 145.962,
 			"genre": "オンゲキ"
 		},
 		"id": 325,
@@ -3609,6 +3934,7 @@
 		"altTitles": [],
 		"artist": "Soleily",
 		"data": {
+			"duration": 145.263,
 			"genre": "オンゲキ"
 		},
 		"id": 326,
@@ -3619,6 +3945,7 @@
 		"altTitles": [],
 		"artist": "KiRaRe「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 120,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 327,
@@ -3631,6 +3958,7 @@
 		"altTitles": [],
 		"artist": "オルタンシア「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 163.125,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 328,
@@ -3641,6 +3969,7 @@
 		"altTitles": [],
 		"artist": "ステラマリス「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 130.462,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 329,
@@ -3651,6 +3980,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 144.314,
 			"genre": "niconico"
 		},
 		"id": 330,
@@ -3661,6 +3991,7 @@
 		"altTitles": [],
 		"artist": "星月みき(CV：洲崎綾)「バトルガール ハイスクール」",
 		"data": {
+			"duration": 139,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 331,
@@ -3671,6 +4002,7 @@
 		"altTitles": [],
 		"artist": "寺島拓篤「転生したらスライムだった件」",
 		"data": {
+			"duration": 142.769,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 332,
@@ -3681,6 +4013,7 @@
 		"altTitles": [],
 		"artist": "田所あずさ「転生したらスライムだった件」",
 		"data": {
+			"duration": 159.167,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 333,
@@ -3693,6 +4026,7 @@
 		"altTitles": [],
 		"artist": "やしきん feat.でらっくま(CV:三森すずこ)",
 		"data": {
+			"duration": 153.034,
 			"genre": "チュウマイ"
 		},
 		"id": 334,
@@ -3706,6 +4040,7 @@
 		"altTitles": [],
 		"artist": "TORIENA",
 		"data": {
+			"duration": 140.229,
 			"genre": "チュウマイ"
 		},
 		"id": 335,
@@ -3716,6 +4051,7 @@
 		"altTitles": [],
 		"artist": "曲：穴山大輔, 水野健治／歌：藤沢 柚子(CV：久保田 梨沙)、早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 178.729,
 			"genre": "オンゲキ"
 		},
 		"id": 336,
@@ -3728,6 +4064,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 131.25,
 			"genre": "niconico"
 		},
 		"id": 337,
@@ -3738,6 +4075,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 136.926,
 			"genre": "niconico"
 		},
 		"id": 338,
@@ -3750,6 +4088,7 @@
 		"altTitles": [],
 		"artist": "ろん×Junky",
 		"data": {
+			"duration": 143.151,
 			"genre": "niconico"
 		},
 		"id": 339,
@@ -3762,6 +4101,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 142.934,
 			"genre": "チュウマイ"
 		},
 		"id": 340,
@@ -3774,6 +4114,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：ASTERISM [星咲 あかり(CV：赤尾 ひかる)、藤沢 柚子(CV：久保田 梨沙)、三角 葵(CV：春野 杏)]",
 		"data": {
+			"duration": 165.472,
 			"genre": "オンゲキ"
 		},
 		"id": 341,
@@ -3786,6 +4127,7 @@
 		"altTitles": [],
 		"artist": "MisoilePunch♪",
 		"data": {
+			"duration": 150.856,
 			"genre": "オンゲキ"
 		},
 		"id": 342,
@@ -3796,6 +4138,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 165.542,
 			"genre": "niconico"
 		},
 		"id": 343,
@@ -3808,6 +4151,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 152.863,
 			"genre": "VARIETY"
 		},
 		"id": 344,
@@ -3818,6 +4162,7 @@
 		"altTitles": [],
 		"artist": "削除 feat. Nikki Simmons",
 		"data": {
+			"duration": 162,
 			"genre": "VARIETY"
 		},
 		"id": 345,
@@ -3828,6 +4173,7 @@
 		"altTitles": [],
 		"artist": "777☆SISTERS「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 147.188,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 346,
@@ -3840,6 +4186,7 @@
 		"altTitles": [],
 		"artist": "777☆SISTERS「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 158.222,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 347,
@@ -3850,6 +4197,7 @@
 		"altTitles": [],
 		"artist": "Innocent Key",
 		"data": {
+			"duration": 148,
 			"genre": "東方Project"
 		},
 		"id": 348,
@@ -3862,6 +4210,7 @@
 		"altTitles": [],
 		"artist": "Sound piercer feat.DAZBEE",
 		"data": {
+			"duration": 172.941,
 			"genre": "VARIETY"
 		},
 		"id": 349,
@@ -3874,6 +4223,7 @@
 		"altTitles": [],
 		"artist": "かめりあ feat. ななひら",
 		"data": {
+			"duration": 149.531,
 			"genre": "VARIETY"
 		},
 		"id": 350,
@@ -3886,6 +4236,7 @@
 		"altTitles": [],
 		"artist": "Cres.",
 		"data": {
+			"duration": 134,
 			"genre": "VARIETY"
 		},
 		"id": 351,
@@ -3896,6 +4247,7 @@
 		"altTitles": [],
 		"artist": "Morrigan feat.Lily",
 		"data": {
+			"duration": 126.4,
 			"genre": "チュウマイ"
 		},
 		"id": 352,
@@ -3906,6 +4258,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 150.643,
 			"genre": "チュウマイ"
 		},
 		"id": 353,
@@ -3916,6 +4269,7 @@
 		"altTitles": [],
 		"artist": "曲：Powerless／歌：柏木 咲姫(CV：石見 舞菜香)、柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 150.529,
 			"genre": "オンゲキ"
 		},
 		"id": 354,
@@ -3926,6 +4280,7 @@
 		"altTitles": [],
 		"artist": "cubesato",
 		"data": {
+			"duration": 143.158,
 			"genre": "LUNATIC"
 		},
 		"id": 355,
@@ -3936,6 +4291,7 @@
 		"altTitles": [],
 		"artist": "WASi303",
 		"data": {
+			"duration": 134.625,
 			"genre": "LUNATIC"
 		},
 		"id": 356,
@@ -3946,6 +4302,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 144.935,
 			"genre": "niconico"
 		},
 		"id": 357,
@@ -3958,6 +4315,7 @@
 		"altTitles": [],
 		"artist": "曲：Funta7／歌：星咲 あかり(CV：赤尾 ひかる)、日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 171.75,
 			"genre": "オンゲキ"
 		},
 		"id": 358,
@@ -3970,6 +4328,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり♪♪」",
 		"data": {
+			"duration": 91.366,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 359,
@@ -3982,6 +4341,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり♪♪」",
 		"data": {
+			"duration": 158.857,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 360,
@@ -3994,6 +4354,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA「バーチャルさんはみている」",
 		"data": {
+			"duration": 157.2,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 361,
@@ -4006,6 +4367,7 @@
 		"altTitles": [],
 		"artist": "technoplanet",
 		"data": {
+			"duration": 147.6,
 			"genre": "オンゲキ"
 		},
 		"id": 362,
@@ -4016,6 +4378,7 @@
 		"altTitles": [],
 		"artist": "黒沢ダイスケ VS 穴山大輔",
 		"data": {
+			"duration": 173.793,
 			"genre": "オンゲキ"
 		},
 		"id": 363,
@@ -4029,6 +4392,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり、」",
 		"data": {
+			"duration": 160.419,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 364,
@@ -4041,6 +4405,7 @@
 		"altTitles": [],
 		"artist": "ツキカゲ（安齋由香里，沼倉愛美，藤田茜，洲崎綾，のぐちゆり，内田彩）「RELEASE THE SPYCE」",
 		"data": {
+			"duration": 149.25,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 365,
@@ -4053,6 +4418,7 @@
 		"altTitles": [],
 		"artist": "onoken",
 		"data": {
+			"duration": 171.667,
 			"genre": "VARIETY"
 		},
 		"id": 366,
@@ -4063,6 +4429,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree feat.yu＊tree",
 		"data": {
+			"duration": 155.51,
 			"genre": "オンゲキ"
 		},
 		"id": 367,
@@ -4073,6 +4440,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree Remixed by sasakure.UK",
 		"data": {
+			"duration": 158.019,
 			"genre": "オンゲキ"
 		},
 		"id": 368,
@@ -4083,6 +4451,7 @@
 		"altTitles": [],
 		"artist": "ClariS　「劇場版 魔法少女まどか☆マギカ[新編]叛逆の物語」",
 		"data": {
+			"duration": 124.382,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 369,
@@ -4095,6 +4464,7 @@
 		"altTitles": [],
 		"artist": "AiRBLUE「CUE!」",
 		"data": {
+			"duration": 151.705,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 370,
@@ -4105,6 +4475,7 @@
 		"altTitles": [],
 		"artist": "LiSA",
 		"data": {
+			"duration": 156.457,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 371,
@@ -4117,6 +4488,7 @@
 		"altTitles": [],
 		"artist": "UNISON SQUARE GARDEN",
 		"data": {
+			"duration": 148.8,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 372,
@@ -4127,6 +4499,7 @@
 		"altTitles": [],
 		"artist": "桜高軽音部",
 		"data": {
+			"duration": 165,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 373,
@@ -4139,6 +4512,7 @@
 		"altTitles": [],
 		"artist": "ULTRA-PRISM with イカ娘（金元寿子）「侵略！イカ娘」",
 		"data": {
+			"duration": 152.432,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 374,
@@ -4151,6 +4525,7 @@
 		"altTitles": [],
 		"artist": "中野家の五つ子（花澤香菜、竹達彩奈、伊藤美来、佐倉綾音、水瀬いのり）「五等分の花嫁」",
 		"data": {
+			"duration": 139.198,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 375,
@@ -4163,6 +4538,7 @@
 		"altTitles": [],
 		"artist": "ユリイ・カノン feat.GUMI",
 		"data": {
+			"duration": 137.379,
 			"genre": "niconico"
 		},
 		"id": 376,
@@ -4175,6 +4551,7 @@
 		"altTitles": [],
 		"artist": "Omoi feat. 初音ミク",
 		"data": {
+			"duration": 163.459,
 			"genre": "niconico"
 		},
 		"id": 377,
@@ -4187,6 +4564,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア feat.flower",
 		"data": {
+			"duration": 142.105,
 			"genre": "niconico"
 		},
 		"id": 378,
@@ -4199,6 +4577,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 147.958,
 			"genre": "東方Project"
 		},
 		"id": 379,
@@ -4211,6 +4590,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 141.474,
 			"genre": "VARIETY"
 		},
 		"id": 380,
@@ -4221,6 +4601,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 135.5,
 			"genre": "チュウマイ"
 		},
 		"id": 381,
@@ -4233,6 +4614,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 157.397,
 			"genre": "オンゲキ"
 		},
 		"id": 382,
@@ -4243,6 +4625,7 @@
 		"altTitles": [],
 		"artist": "曲：睦月周平／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 148.696,
 			"genre": "オンゲキ"
 		},
 		"id": 383,
@@ -4253,6 +4636,7 @@
 		"altTitles": [],
 		"artist": "曲：設楽哲也／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 146.277,
 			"genre": "オンゲキ"
 		},
 		"id": 384,
@@ -4265,6 +4649,7 @@
 		"altTitles": [],
 		"artist": "曲：DJ Genki／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 132.649,
 			"genre": "オンゲキ"
 		},
 		"id": 385,
@@ -4275,6 +4660,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE",
 		"data": {
+			"duration": 147.692,
 			"genre": "オンゲキ"
 		},
 		"id": 386,
@@ -4285,6 +4671,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 140.784,
 			"genre": "オンゲキ"
 		},
 		"id": 387,
@@ -4295,6 +4682,7 @@
 		"altTitles": [],
 		"artist": "s-don",
 		"data": {
+			"duration": 143.226,
 			"genre": "オンゲキ"
 		},
 		"id": 388,
@@ -4305,6 +4693,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 137.5,
 			"genre": "オンゲキ"
 		},
 		"id": 389,
@@ -4315,6 +4704,7 @@
 		"altTitles": [],
 		"artist": "曲：kz(livetune)／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 159.111,
 			"genre": "ボーナストラック"
 		},
 		"id": 390,
@@ -4327,6 +4717,7 @@
 		"altTitles": [],
 		"artist": "曲：kz(livetune)／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 159.111,
 			"genre": "ボーナストラック"
 		},
 		"id": 391,
@@ -4339,6 +4730,7 @@
 		"altTitles": [],
 		"artist": "曲：kz(livetune)／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 159.111,
 			"genre": "ボーナストラック"
 		},
 		"id": 392,
@@ -4351,6 +4743,7 @@
 		"altTitles": [],
 		"artist": "並木 学「怒首領蜂大往生」",
 		"data": {
+			"duration": 179.673,
 			"genre": "LUNATIC"
 		},
 		"id": 393,
@@ -4364,6 +4757,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 140.21,
 			"genre": "チュウマイ"
 		},
 		"id": 394,
@@ -4374,6 +4768,7 @@
 		"altTitles": [],
 		"artist": "ClariS　「魔法少女まどか☆マギカ」",
 		"data": {
+			"duration": 112.136,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 395,
@@ -4386,6 +4781,7 @@
 		"altTitles": [],
 		"artist": "AiRBLUE「CUE!」",
 		"data": {
+			"duration": 145.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 396,
@@ -4396,6 +4792,7 @@
 		"altTitles": [],
 		"artist": "hololive IDOL PROJECT",
 		"data": {
+			"duration": 157.857,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 397,
@@ -4406,6 +4803,7 @@
 		"altTitles": [],
 		"artist": "コーロまちカド(シャミ子･桃･リリス･ミカン)/CV:小原好美･鬼頭明里･高橋未奈美･高柳知葉「まちカドまぞく」",
 		"data": {
+			"duration": 153.684,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 398,
@@ -4418,6 +4816,7 @@
 		"altTitles": [],
 		"artist": "ガヴリール（富田美憂），ヴィーネ（大西沙織），サターニャ（大空直美），ラフィエル（花澤香菜）「ガヴリールドロップアウト」",
 		"data": {
+			"duration": 140.536,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 399,
@@ -4430,6 +4829,7 @@
 		"altTitles": [],
 		"artist": "有形ランペイジ",
 		"data": {
+			"duration": 158.13,
 			"genre": "VARIETY"
 		},
 		"id": 400,
@@ -4440,6 +4840,7 @@
 		"altTitles": [],
 		"artist": "ユリイ・カノン feat.nameless",
 		"data": {
+			"duration": 143.721,
 			"genre": "チュウマイ"
 		},
 		"id": 401,
@@ -4452,6 +4853,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ & 脇眞富（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)、高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 158.382,
 			"genre": "オンゲキ"
 		},
 		"id": 402,
@@ -4464,6 +4866,7 @@
 		"altTitles": [],
 		"artist": "衛藤可奈美（CV：本渡 楓）、十条姫和（CV：大西沙織）、柳瀬舞衣（CV：和氣あず未）、糸見沙耶香（CV：木野日菜）、益子 薫（CV：松田利冴）、古波蔵エレン（CV：鈴木絵理）「刀使ノ巫女」",
 		"data": {
+			"duration": 154.499,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 403,
@@ -4476,6 +4879,7 @@
 		"altTitles": [],
 		"artist": "衛藤可奈美（CV：本渡 楓）＆安桜美炎（CV：茜屋日海夏）「みにとじ」",
 		"data": {
+			"duration": 142.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 404,
@@ -4488,6 +4892,7 @@
 		"altTitles": [],
 		"artist": "Cranky feat.おもしろ三国志",
 		"data": {
+			"duration": 171.244,
 			"genre": "チュウマイ"
 		},
 		"id": 405,
@@ -4500,6 +4905,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 178.5,
 			"genre": "niconico"
 		},
 		"id": 406,
@@ -4512,6 +4918,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 152.4,
 			"genre": "niconico"
 		},
 		"id": 407,
@@ -4524,6 +4931,7 @@
 		"altTitles": [],
 		"artist": "てにをは",
 		"data": {
+			"duration": 136,
 			"genre": "niconico"
 		},
 		"id": 408,
@@ -4536,6 +4944,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：結城 莉玖(CV：朝日奈 丸佳)、東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 145,
 			"genre": "オンゲキ"
 		},
 		"id": 409,
@@ -4548,6 +4957,7 @@
 		"altTitles": [],
 		"artist": "MAYA AKAI",
 		"data": {
+			"duration": 137.956,
 			"genre": "オンゲキ"
 		},
 		"id": 410,
@@ -4558,6 +4968,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 154.468,
 			"genre": "東方Project"
 		},
 		"id": 411,
@@ -4570,6 +4981,7 @@
 		"altTitles": [],
 		"artist": "ソニック カラーズ",
 		"data": {
+			"duration": 112.315,
 			"genre": "VARIETY"
 		},
 		"id": 412,
@@ -4580,6 +4992,7 @@
 		"altTitles": [],
 		"artist": "MARETU",
 		"data": {
+			"duration": 153.462,
 			"genre": "チュウマイ"
 		},
 		"id": 413,
@@ -4592,6 +5005,7 @@
 		"altTitles": [],
 		"artist": "内田彩「五等分の花嫁」",
 		"data": {
+			"duration": 150.707,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 414,
@@ -4602,6 +5016,7 @@
 		"altTitles": [],
 		"artist": "曲：R・O・N／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 147.429,
 			"genre": "オンゲキ"
 		},
 		"id": 415,
@@ -4612,6 +5027,7 @@
 		"altTitles": [],
 		"artist": "Kobaryo",
 		"data": {
+			"duration": 149.048,
 			"genre": "オンゲキ"
 		},
 		"id": 416,
@@ -4622,6 +5038,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 165.294,
 			"genre": "ボーナストラック"
 		},
 		"id": 417,
@@ -4634,6 +5051,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 165.294,
 			"genre": "ボーナストラック"
 		},
 		"id": 418,
@@ -4646,6 +5064,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 165.294,
 			"genre": "ボーナストラック"
 		},
 		"id": 419,
@@ -4658,6 +5077,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 140.893,
 			"genre": "東方Project"
 		},
 		"id": 420,
@@ -4670,6 +5090,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 153.14,
 			"genre": "東方Project"
 		},
 		"id": 421,
@@ -4680,6 +5101,7 @@
 		"altTitles": [],
 		"artist": "くっちー (DARKSIDE APPROACH)",
 		"data": {
+			"duration": 152.67,
 			"genre": "東方Project"
 		},
 		"id": 422,
@@ -4692,6 +5114,7 @@
 		"altTitles": [],
 		"artist": "DiGiTAL WiNG feat. 花たん",
 		"data": {
+			"duration": 139.8,
 			"genre": "東方Project"
 		},
 		"id": 423,
@@ -4702,6 +5125,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 153.2,
 			"genre": "niconico"
 		},
 		"id": 424,
@@ -4714,6 +5138,7 @@
 		"altTitles": [],
 		"artist": "ETIA.「Arcaea」",
 		"data": {
+			"duration": 127.2,
 			"genre": "VARIETY"
 		},
 		"id": 425,
@@ -4724,6 +5149,7 @@
 		"altTitles": [],
 		"artist": "Team Grimoire vs Laur「Arcaea」",
 		"data": {
+			"duration": 143.011,
 			"genre": "VARIETY"
 		},
 		"id": 426,
@@ -4734,6 +5160,7 @@
 		"altTitles": [],
 		"artist": "からとPαnchii少年 feat.はるの「Arcaea」",
 		"data": {
+			"duration": 135.273,
 			"genre": "VARIETY"
 		},
 		"id": 427,
@@ -4748,6 +5175,7 @@
 		"altTitles": [],
 		"artist": "水野健治 VS Kai「Wonderland Wars」",
 		"data": {
+			"duration": 146,
 			"genre": "VARIETY"
 		},
 		"id": 428,
@@ -4758,6 +5186,7 @@
 		"altTitles": [],
 		"artist": "fn(ArcaeaSoundTeam)「Arcaea」",
 		"data": {
+			"duration": 151.5,
 			"genre": "LUNATIC"
 		},
 		"id": 429,
@@ -4771,6 +5200,7 @@
 		"altTitles": [],
 		"artist": "syudou",
 		"data": {
+			"duration": 140,
 			"genre": "niconico"
 		},
 		"id": 430,
@@ -4783,6 +5213,7 @@
 		"altTitles": [],
 		"artist": "n-buna",
 		"data": {
+			"duration": 137.321,
 			"genre": "niconico"
 		},
 		"id": 431,
@@ -4795,6 +5226,7 @@
 		"altTitles": [],
 		"artist": "曲：高木龍一(Dream Monster)／歌：三角 葵(CV：春野 杏)、桜井 春菜(CV：近藤 玲奈)、珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 141.997,
 			"genre": "オンゲキ"
 		},
 		"id": 432,
@@ -4807,6 +5239,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 154.5,
 			"genre": "オンゲキ"
 		},
 		"id": 433,
@@ -4817,6 +5250,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 161.018,
 			"genre": "オンゲキ"
 		},
 		"id": 434,
@@ -4830,6 +5264,7 @@
 		"altTitles": [],
 		"artist": "1640mP（164×40mP） / 初音ミク / Leo/need「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 125.238,
 			"genre": "niconico"
 		},
 		"id": 435,
@@ -4842,6 +5277,7 @@
 		"altTitles": [],
 		"artist": "とあ / 初音ミク / MORE MORE JUMP!「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 123.453,
 			"genre": "niconico"
 		},
 		"id": 436,
@@ -4854,6 +5290,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 156.632,
 			"genre": "チュウマイ"
 		},
 		"id": 437,
@@ -4864,6 +5301,7 @@
 		"altTitles": [],
 		"artist": "トロワアンジュ「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 151.915,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 438,
@@ -4874,6 +5312,7 @@
 		"altTitles": [],
 		"artist": "テトラルキア「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 148.356,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 439,
@@ -4886,6 +5325,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 147.2,
 			"genre": "niconico"
 		},
 		"id": 440,
@@ -4898,6 +5338,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 139.5,
 			"genre": "東方Project"
 		},
 		"id": 441,
@@ -4910,6 +5351,7 @@
 		"altTitles": [],
 		"artist": "岸田教団＆THE明星ロケッツ",
 		"data": {
+			"duration": 149.816,
 			"genre": "東方Project"
 		},
 		"id": 442,
@@ -4922,6 +5364,7 @@
 		"altTitles": [],
 		"artist": "穴山大輔",
 		"data": {
+			"duration": 158.471,
 			"genre": "オンゲキ"
 		},
 		"id": 443,
@@ -4932,6 +5375,7 @@
 		"altTitles": [],
 		"artist": "曲：大畑拓也／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 149.571,
 			"genre": "ボーナストラック"
 		},
 		"id": 444,
@@ -4944,6 +5388,7 @@
 		"altTitles": [],
 		"artist": "曲：大畑拓也／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 149.571,
 			"genre": "ボーナストラック"
 		},
 		"id": 445,
@@ -4956,6 +5401,7 @@
 		"altTitles": [],
 		"artist": "パトリシア・オブ・エンド, ルーシア・オブ・エンド・サクラメント, ユウラシア・オブ・エンド「ノラと皇女と野良猫ハート2」",
 		"data": {
+			"duration": 109.213,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 446,
@@ -4968,6 +5414,7 @@
 		"altTitles": [],
 		"artist": "亜沙",
 		"data": {
+			"duration": 140.178,
 			"genre": "niconico"
 		},
 		"id": 447,
@@ -4980,6 +5427,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 150.4,
 			"genre": "niconico"
 		},
 		"id": 448,
@@ -4992,6 +5440,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
+			"duration": 136.917,
 			"genre": "オンゲキ"
 		},
 		"id": 449,
@@ -5002,6 +5451,7 @@
 		"altTitles": [],
 		"artist": "yaseta",
 		"data": {
+			"duration": 144.857,
 			"genre": "オンゲキ"
 		},
 		"id": 450,
@@ -5012,6 +5462,7 @@
 		"altTitles": [],
 		"artist": "ヨルシカ",
 		"data": {
+			"duration": 151.2,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 451,
@@ -5024,6 +5475,7 @@
 		"altTitles": [],
 		"artist": "カンザキイオリ",
 		"data": {
+			"duration": 158.4,
 			"genre": "niconico"
 		},
 		"id": 452,
@@ -5036,6 +5488,7 @@
 		"altTitles": [],
 		"artist": "fourfolium［涼風青葉（CV：高田憂希）／滝本ひふみ（CV：山口 愛）／篠田はじめ（CV：戸田めぐみ）／飯島ゆん（CV：竹尾歩美）］「NEW GAME!」",
 		"data": {
+			"duration": 150.909,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 453,
@@ -5048,6 +5501,7 @@
 		"altTitles": [],
 		"artist": "fourfolium［涼風青葉（CV：高田憂希）／滝本ひふみ（CV：山口 愛）／篠田はじめ（CV：戸田めぐみ）／飯島ゆん（CV：竹尾歩美）］「NEW GAME!!」",
 		"data": {
+			"duration": 129.643,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 454,
@@ -5058,6 +5512,7 @@
 		"altTitles": [],
 		"artist": "滝本ひふみ（CV：山口 愛）「NEW GAME!」",
 		"data": {
+			"duration": 160.552,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 455,
@@ -5070,6 +5525,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 144.348,
 			"genre": "東方Project"
 		},
 		"id": 456,
@@ -5082,6 +5538,7 @@
 		"altTitles": [],
 		"artist": "anubasu-anubasu",
 		"data": {
+			"duration": 139.2,
 			"genre": "オンゲキ"
 		},
 		"id": 457,
@@ -5092,6 +5549,7 @@
 		"altTitles": [],
 		"artist": "かゆき",
 		"data": {
+			"duration": 147.5,
 			"genre": "オンゲキ"
 		},
 		"id": 458,
@@ -5104,6 +5562,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 158.182,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 459,
@@ -5116,6 +5575,7 @@
 		"altTitles": [],
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
+			"duration": 156.183,
 			"genre": "VARIETY"
 		},
 		"id": 460,
@@ -5128,6 +5588,7 @@
 		"altTitles": [],
 		"artist": "ガリガリさむし",
 		"data": {
+			"duration": 147.921,
 			"genre": "チュウマイ"
 		},
 		"id": 461,
@@ -5138,6 +5599,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 159.368,
 			"genre": "オンゲキ"
 		},
 		"id": 462,
@@ -5148,6 +5610,7 @@
 		"altTitles": [],
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？BLOOM」",
 		"data": {
+			"duration": 154.317,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 463,
@@ -5160,6 +5623,7 @@
 		"altTitles": [],
 		"artist": "Two for all「モンソニ！」",
 		"data": {
+			"duration": 166.656,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 464,
@@ -5170,6 +5634,7 @@
 		"altTitles": [],
 		"artist": "白雪姫リボン「モンソニ！」",
 		"data": {
+			"duration": 159.621,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 465,
@@ -5182,6 +5647,7 @@
 		"altTitles": [],
 		"artist": "鈴木このみ",
 		"data": {
+			"duration": 167.023,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 466,
@@ -5192,6 +5658,7 @@
 		"altTitles": [],
 		"artist": "川田まみ",
 		"data": {
+			"duration": 157.421,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 467,
@@ -5202,6 +5669,7 @@
 		"altTitles": [],
 		"artist": "ずっと真夜中でいいのに。",
 		"data": {
+			"duration": 158.796,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 468,
@@ -5214,6 +5682,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 147.789,
 			"genre": "niconico"
 		},
 		"id": 469,
@@ -5226,6 +5695,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 147.693,
 			"genre": "niconico"
 		},
 		"id": 470,
@@ -5238,6 +5708,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 150.8,
 			"genre": "niconico"
 		},
 		"id": 471,
@@ -5248,6 +5719,7 @@
 		"altTitles": [],
 		"artist": "東方LostWord feat.いとうかなこ",
 		"data": {
+			"duration": 155.638,
 			"genre": "東方Project"
 		},
 		"id": 472,
@@ -5260,6 +5732,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 154.613,
 			"genre": "VARIETY"
 		},
 		"id": 473,
@@ -5270,6 +5743,7 @@
 		"altTitles": [],
 		"artist": "onoken feat. 佐々木正明",
 		"data": {
+			"duration": 147.421,
 			"genre": "VARIETY"
 		},
 		"id": 474,
@@ -5280,6 +5754,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 140.355,
 			"genre": "チュウマイ"
 		},
 		"id": 475,
@@ -5290,6 +5765,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 147.082,
 			"genre": "オンゲキ"
 		},
 		"id": 476,
@@ -5300,6 +5776,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：7EVENDAYS⇔HOLIDAYS [井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)]",
 		"data": {
+			"duration": 157.284,
 			"genre": "オンゲキ"
 		},
 		"id": 477,
@@ -5312,6 +5789,7 @@
 		"altTitles": [],
 		"artist": "aran",
 		"data": {
+			"duration": 149.754,
 			"genre": "オンゲキ"
 		},
 		"id": 478,
@@ -5322,6 +5800,7 @@
 		"altTitles": [],
 		"artist": "kamome sano",
 		"data": {
+			"duration": 151.368,
 			"genre": "オンゲキ"
 		},
 		"id": 479,
@@ -5332,6 +5811,7 @@
 		"altTitles": [],
 		"artist": "Artifact",
 		"data": {
+			"duration": 145.718,
 			"genre": "オンゲキ"
 		},
 		"id": 480,
@@ -5342,6 +5822,7 @@
 		"altTitles": [],
 		"artist": "siromaru",
 		"data": {
+			"duration": 145.171,
 			"genre": "オンゲキ"
 		},
 		"id": 481,
@@ -5352,6 +5833,7 @@
 		"altTitles": [],
 		"artist": "曲：中山真斗／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 152.802,
 			"genre": "ボーナストラック"
 		},
 		"id": 483,
@@ -5364,6 +5846,7 @@
 		"altTitles": [],
 		"artist": "曲：中山真斗／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 152.802,
 			"genre": "ボーナストラック"
 		},
 		"id": 484,
@@ -5376,6 +5859,7 @@
 		"altTitles": [],
 		"artist": "曲：中山真斗／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 152.802,
 			"genre": "ボーナストラック"
 		},
 		"id": 485,
@@ -5388,6 +5872,7 @@
 		"altTitles": [],
 		"artist": "原曲：並木 学「バトルガレッガ(AC)」",
 		"data": {
+			"duration": 151.714,
 			"genre": "LUNATIC"
 		},
 		"id": 486,
@@ -5400,6 +5885,7 @@
 		"altTitles": [],
 		"artist": "SEGA SOUND STAFF「セガNET麻雀 MJ」",
 		"data": {
+			"duration": 141.834,
 			"genre": "VARIETY"
 		},
 		"id": 487,
@@ -5410,6 +5896,7 @@
 		"altTitles": [],
 		"artist": "SEGA SOUND STAFF「セガNET麻雀 MJ」",
 		"data": {
+			"duration": 171.896,
 			"genre": "LUNATIC"
 		},
 		"id": 488,
@@ -5422,6 +5909,7 @@
 		"altTitles": [],
 		"artist": "TANO*C Sound Team",
 		"data": {
+			"duration": 132.414,
 			"genre": "VARIETY"
 		},
 		"id": 489,
@@ -5432,6 +5920,7 @@
 		"altTitles": [],
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？」",
 		"data": {
+			"duration": 154.021,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 490,
@@ -5442,6 +5931,7 @@
 		"altTitles": [],
 		"artist": "にじさんじ",
 		"data": {
+			"duration": 131.19,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 491,
@@ -5452,6 +5942,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 158.057,
 			"genre": "チュウマイ"
 		},
 		"id": 492,
@@ -5464,6 +5955,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 155.697,
 			"genre": "niconico"
 		},
 		"id": 493,
@@ -5476,6 +5968,7 @@
 		"altTitles": [],
 		"artist": "柊キライ",
 		"data": {
+			"duration": 147.244,
 			"genre": "niconico"
 		},
 		"id": 494,
@@ -5488,6 +5981,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 135.921,
 			"genre": "niconico"
 		},
 		"id": 495,
@@ -5500,6 +5994,7 @@
 		"altTitles": [],
 		"artist": "ああああ",
 		"data": {
+			"duration": 141.373,
 			"genre": "VARIETY"
 		},
 		"id": 496,
@@ -5512,6 +6007,7 @@
 		"altTitles": [],
 		"artist": "cubesato",
 		"data": {
+			"duration": 129.535,
 			"genre": "チュウマイ"
 		},
 		"id": 497,
@@ -5524,6 +6020,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：三角 葵(CV：春野 杏)、九條 楓(CV：佳村 はるか)、日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 161.009,
 			"genre": "オンゲキ"
 		},
 		"id": 498,
@@ -5536,6 +6033,7 @@
 		"altTitles": [],
 		"artist": "zts",
 		"data": {
+			"duration": 162.087,
 			"genre": "オンゲキ"
 		},
 		"id": 499,
@@ -5546,6 +6044,7 @@
 		"altTitles": [],
 		"artist": "宝鐘マリン（ホロライブ）",
 		"data": {
+			"duration": 159.597,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 500,
@@ -5558,6 +6057,7 @@
 		"altTitles": [],
 		"artist": "Prizmmy☆",
 		"data": {
+			"duration": 132.504,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 501,
@@ -5568,6 +6068,7 @@
 		"altTitles": [],
 		"artist": "COOL&CREATE × 兎田ぺこら、さくらみこ、宝鐘マリン",
 		"data": {
+			"duration": 148.706,
 			"genre": "東方Project"
 		},
 		"id": 502,
@@ -5580,6 +6081,7 @@
 		"altTitles": [],
 		"artist": "曲：前山田健一／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 155.036,
 			"genre": "ボーナストラック"
 		},
 		"id": 503,
@@ -5592,6 +6094,7 @@
 		"altTitles": [],
 		"artist": "曲：前山田健一／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 155.036,
 			"genre": "ボーナストラック"
 		},
 		"id": 504,
@@ -5604,6 +6107,7 @@
 		"altTitles": [],
 		"artist": "azusa",
 		"data": {
+			"duration": 152.538,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 505,
@@ -5614,6 +6118,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 140.036,
 			"genre": "niconico"
 		},
 		"id": 506,
@@ -5626,6 +6131,7 @@
 		"altTitles": [],
 		"artist": "Ayase",
 		"data": {
+			"duration": 127.195,
 			"genre": "niconico"
 		},
 		"id": 507,
@@ -5638,6 +6144,7 @@
 		"altTitles": [],
 		"artist": "i☆Ris",
 		"data": {
+			"duration": 165.072,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 508,
@@ -5648,6 +6155,7 @@
 		"altTitles": [],
 		"artist": "Aoi",
 		"data": {
+			"duration": 124.56,
 			"genre": "VARIETY"
 		},
 		"id": 509,
@@ -5658,6 +6166,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修の兄",
 		"data": {
+			"duration": 166.475,
 			"genre": "VARIETY"
 		},
 		"id": 510,
@@ -5668,6 +6177,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：bitter flavor [桜井 春菜(CV：近藤 玲奈)、早乙女 彩華(CV：中島 唯)]",
 		"data": {
+			"duration": 129.041,
 			"genre": "オンゲキ"
 		},
 		"id": 511,
@@ -5678,6 +6188,7 @@
 		"altTitles": [],
 		"artist": "pan",
 		"data": {
+			"duration": 150.308,
 			"genre": "オンゲキ"
 		},
 		"id": 512,
@@ -5688,6 +6199,7 @@
 		"altTitles": [],
 		"artist": "LV.4",
 		"data": {
+			"duration": 143.735,
 			"genre": "オンゲキ"
 		},
 		"id": 513,
@@ -5698,6 +6210,7 @@
 		"altTitles": [],
 		"artist": "Run Girls, Run!",
 		"data": {
+			"duration": 110.538,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 514,
@@ -5710,6 +6223,7 @@
 		"altTitles": [],
 		"artist": "バルーン",
 		"data": {
+			"duration": 140.728,
 			"genre": "niconico"
 		},
 		"id": 515,
@@ -5722,6 +6236,7 @@
 		"altTitles": [],
 		"artist": "島爺×蜂屋ななし",
 		"data": {
+			"duration": 132.089,
 			"genre": "チュウマイ"
 		},
 		"id": 516,
@@ -5732,6 +6247,7 @@
 		"altTitles": [],
 		"artist": "八王子P「#コンパス」",
 		"data": {
+			"duration": 144.91,
 			"genre": "niconico"
 		},
 		"id": 517,
@@ -5744,6 +6260,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア「#コンパス」",
 		"data": {
+			"duration": 144.345,
 			"genre": "niconico"
 		},
 		"id": 518,
@@ -5756,6 +6273,7 @@
 		"altTitles": [],
 		"artist": "ポリスピカデリー「#コンパス」",
 		"data": {
+			"duration": 145.48,
 			"genre": "niconico"
 		},
 		"id": 519,
@@ -5768,6 +6286,7 @@
 		"altTitles": [],
 		"artist": "Drop & 葉月ゆら「#コンパス」",
 		"data": {
+			"duration": 154.451,
 			"genre": "niconico"
 		},
 		"id": 520,
@@ -5780,6 +6299,7 @@
 		"altTitles": [],
 		"artist": "Junk feat.nananao",
 		"data": {
+			"duration": 112.751,
 			"genre": "VARIETY"
 		},
 		"id": 521,
@@ -5790,6 +6310,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：藍原 椿(CV：橋本 ちなみ)、早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 159.651,
 			"genre": "オンゲキ"
 		},
 		"id": 522,
@@ -5802,6 +6323,7 @@
 		"altTitles": [],
 		"artist": "ガリガリさむし",
 		"data": {
+			"duration": 129.421,
 			"genre": "オンゲキ"
 		},
 		"id": 523,
@@ -5814,6 +6336,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 129.421,
 			"genre": "niconico"
 		},
 		"id": 524,
@@ -5826,6 +6349,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 153.555,
 			"genre": "niconico"
 		},
 		"id": 525,
@@ -5838,6 +6362,7 @@
 		"altTitles": [],
 		"artist": "halca / TVアニメ「彼女、お借りします」EDテーマ",
 		"data": {
+			"duration": 135.988,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 526,
@@ -5850,6 +6375,7 @@
 		"altTitles": [],
 		"artist": "Eight / FantasticYouth",
 		"data": {
+			"duration": 160.444,
 			"genre": "niconico"
 		},
 		"id": 527,
@@ -5862,6 +6388,7 @@
 		"altTitles": [],
 		"artist": "BACO",
 		"data": {
+			"duration": 139.321,
 			"genre": "VARIETY"
 		},
 		"id": 528,
@@ -5872,6 +6399,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 136.421,
 			"genre": "オンゲキ"
 		},
 		"id": 529,
@@ -5882,6 +6410,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 137.338,
 			"genre": "ボーナストラック"
 		},
 		"id": 530,
@@ -5894,6 +6423,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 137.338,
 			"genre": "ボーナストラック"
 		},
 		"id": 531,
@@ -5906,6 +6436,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 137.338,
 			"genre": "ボーナストラック"
 		},
 		"id": 532,
@@ -5919,6 +6450,7 @@
 		"altTitles": [],
 		"artist": "Angely Diva「モンソニ！」",
 		"data": {
+			"duration": 122.198,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 533,
@@ -5931,6 +6463,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 157.038,
 			"genre": "niconico"
 		},
 		"id": 534,
@@ -5943,6 +6476,7 @@
 		"altTitles": [],
 		"artist": "なきゃむりゃ",
 		"data": {
+			"duration": 163.907,
 			"genre": "niconico"
 		},
 		"id": 535,
@@ -5955,6 +6489,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 155.671,
 			"genre": "東方Project"
 		},
 		"id": 536,
@@ -5965,6 +6500,7 @@
 		"altTitles": [],
 		"artist": "Nankumo",
 		"data": {
+			"duration": 91.621,
 			"genre": "VARIETY"
 		},
 		"id": 537,
@@ -5975,6 +6511,7 @@
 		"altTitles": [],
 		"artist": "SEXY-SYNTHESIZER",
 		"data": {
+			"duration": 161.009,
 			"genre": "チュウマイ"
 		},
 		"id": 538,
@@ -5985,6 +6522,7 @@
 		"altTitles": [],
 		"artist": "Crusher-P",
 		"data": {
+			"duration": 160.921,
 			"genre": "チュウマイ"
 		},
 		"id": 539,
@@ -5995,6 +6533,7 @@
 		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
+			"duration": 139.991,
 			"genre": "チュウマイ"
 		},
 		"id": 540,
@@ -6005,6 +6544,7 @@
 		"altTitles": [],
 		"artist": "Massive New Krew",
 		"data": {
+			"duration": 123.13,
 			"genre": "チュウマイ"
 		},
 		"id": 541,
@@ -6015,6 +6555,7 @@
 		"altTitles": [],
 		"artist": "曲：かいりきベア／歌：高瀬 梨緒(CV：久保 ユリカ)、藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 152.336,
 			"genre": "オンゲキ"
 		},
 		"id": 542,
@@ -6027,6 +6568,7 @@
 		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
+			"duration": 166.779,
 			"genre": "LUNATIC"
 		},
 		"id": 543,
@@ -6037,6 +6579,7 @@
 		"altTitles": [],
 		"artist": "MK&Kanae Asaba",
 		"data": {
+			"duration": 142.575,
 			"genre": "チュウマイ"
 		},
 		"id": 544,
@@ -6047,6 +6590,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 150.415,
 			"genre": "オンゲキ"
 		},
 		"id": 545,
@@ -6059,6 +6603,7 @@
 		"altTitles": [],
 		"artist": "Yu-dachi",
 		"data": {
+			"duration": 145.832,
 			"genre": "オンゲキ"
 		},
 		"id": 546,
@@ -6069,6 +6614,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 159.905,
 			"genre": "ボーナストラック"
 		},
 		"id": 547,
@@ -6081,6 +6627,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 159.905,
 			"genre": "ボーナストラック"
 		},
 		"id": 548,
@@ -6093,6 +6640,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 159.905,
 			"genre": "ボーナストラック"
 		},
 		"id": 549,
@@ -6105,6 +6653,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 159.905,
 			"genre": "ボーナストラック"
 		},
 		"id": 550,
@@ -6117,6 +6666,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 159.905,
 			"genre": "ボーナストラック"
 		},
 		"id": 551,
@@ -6129,6 +6679,7 @@
 		"altTitles": [],
 		"artist": "さつき が てんこもり feat. 初音ミク",
 		"data": {
+			"duration": 141.163,
 			"genre": "niconico"
 		},
 		"id": 552,
@@ -6141,6 +6692,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK x DECO*27",
 		"data": {
+			"duration": 174.124,
 			"genre": "niconico"
 		},
 		"id": 553,
@@ -6151,6 +6703,7 @@
 		"altTitles": [],
 		"artist": "Team Grimoire",
 		"data": {
+			"duration": 152.546,
 			"genre": "チュウマイ"
 		},
 		"id": 554,
@@ -6163,6 +6716,7 @@
 		"altTitles": [],
 		"artist": "激戦の人",
 		"data": {
+			"duration": 158.372,
 			"genre": "東方Project"
 		},
 		"id": 555,
@@ -6173,6 +6727,7 @@
 		"altTitles": [],
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
+			"duration": 122.956,
 			"genre": "東方Project"
 		},
 		"id": 556,
@@ -6183,6 +6738,7 @@
 		"altTitles": [],
 		"artist": "XL Project",
 		"data": {
+			"duration": 161.051,
 			"genre": "東方Project"
 		},
 		"id": 557,
@@ -6193,6 +6749,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 120.421,
 			"genre": "東方Project"
 		},
 		"id": 558,
@@ -6205,6 +6762,7 @@
 		"altTitles": [],
 		"artist": "MYTH & ROID「Re:ゼロから始める異世界生活」",
 		"data": {
+			"duration": 172.958,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 559,
@@ -6215,6 +6773,7 @@
 		"altTitles": [],
 		"artist": "ルゼ",
 		"data": {
+			"duration": 157.517,
 			"genre": "オンゲキ"
 		},
 		"id": 560,
@@ -6228,6 +6787,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 139.344,
 			"genre": "オンゲキ"
 		},
 		"id": 561,
@@ -6238,6 +6798,7 @@
 		"altTitles": [],
 		"artist": "まふまふ",
 		"data": {
+			"duration": 147.053,
 			"genre": "niconico"
 		},
 		"id": 562,
@@ -6250,6 +6811,7 @@
 		"altTitles": [],
 		"artist": "n-buna feat.ヤギヌマカナ",
 		"data": {
+			"duration": 160.512,
 			"genre": "チュウマイ"
 		},
 		"id": 563,
@@ -6262,6 +6824,7 @@
 		"altTitles": [],
 		"artist": "MYTH & ROID「Re:ゼロから始める異世界生活」",
 		"data": {
+			"duration": 161.884,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 564,
@@ -6272,6 +6835,7 @@
 		"altTitles": [],
 		"artist": "uma vs. モリモリあつし",
 		"data": {
+			"duration": 144.477,
 			"genre": "VARIETY"
 		},
 		"id": 565,
@@ -6285,6 +6849,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 144.421,
 			"genre": "ボーナストラック"
 		},
 		"id": 566,
@@ -6297,6 +6862,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 144.421,
 			"genre": "ボーナストラック"
 		},
 		"id": 567,
@@ -6309,6 +6875,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 144.421,
 			"genre": "ボーナストラック"
 		},
 		"id": 568,
@@ -6321,6 +6888,7 @@
 		"altTitles": [],
 		"artist": "ハチロク「まいてつ」",
 		"data": {
+			"duration": 160.733,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 569,
@@ -6333,6 +6901,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 165.335,
 			"genre": "niconico"
 		},
 		"id": 570,
@@ -6345,6 +6914,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 138.227,
 			"genre": "VARIETY"
 		},
 		"id": 571,
@@ -6355,6 +6925,7 @@
 		"altTitles": [],
 		"artist": "曲：椿山日南子／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 163.044,
 			"genre": "オンゲキ"
 		},
 		"id": 572,
@@ -6365,6 +6936,7 @@
 		"altTitles": [],
 		"artist": "BlackY",
 		"data": {
+			"duration": 148.159,
 			"genre": "オンゲキ"
 		},
 		"id": 573,
@@ -6375,6 +6947,7 @@
 		"altTitles": [],
 		"artist": "TJ.hangneil",
 		"data": {
+			"duration": 158.078,
 			"genre": "オンゲキ"
 		},
 		"id": 574,
@@ -6385,6 +6958,7 @@
 		"altTitles": [],
 		"artist": "SPicA「温泉むすめ」",
 		"data": {
+			"duration": 132.007,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 575,
@@ -6397,6 +6971,7 @@
 		"altTitles": [],
 		"artist": "温泉むすめ 有馬楓花（CV:桑原由気）「温泉むすめ」",
 		"data": {
+			"duration": 162.774,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 576,
@@ -6409,6 +6984,7 @@
 		"altTitles": [],
 		"artist": "テヅカ x Qayo",
 		"data": {
+			"duration": 142.49,
 			"genre": "VARIETY"
 		},
 		"id": 577,
@@ -6421,6 +6997,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 144.613,
 			"genre": "東方Project"
 		},
 		"id": 578,
@@ -6433,6 +7010,7 @@
 		"altTitles": [],
 		"artist": "Unlucky Morpheus",
 		"data": {
+			"duration": 149.647,
 			"genre": "東方Project"
 		},
 		"id": 579,
@@ -6445,6 +7023,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 125.581,
 			"genre": "東方Project"
 		},
 		"id": 580,
@@ -6457,6 +7036,7 @@
 		"altTitles": [],
 		"artist": "舞風-Maikaze",
 		"data": {
+			"duration": 153.754,
 			"genre": "東方Project"
 		},
 		"id": 581,
@@ -6469,6 +7049,7 @@
 		"altTitles": [],
 		"artist": "Tanchiky",
 		"data": {
+			"duration": 126.42,
 			"genre": "VARIETY"
 		},
 		"id": 582,
@@ -6479,6 +7060,7 @@
 		"altTitles": [],
 		"artist": "Ino(chronoize) feat. 柳瀬マサキ",
 		"data": {
+			"duration": 150.068,
 			"genre": "VARIETY"
 		},
 		"id": 583,
@@ -6491,6 +7073,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修「バーニングレンジャー」",
 		"data": {
+			"duration": 157.792,
 			"genre": "VARIETY"
 		},
 		"id": 584,
@@ -6503,6 +7086,7 @@
 		"altTitles": [],
 		"artist": "THE IDOLM@STER FIVE STARS!!!!!「アイドルマスター」シリーズ",
 		"data": {
+			"duration": 134.71,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 585,
@@ -6515,6 +7099,7 @@
 		"altTitles": [],
 		"artist": "ストレイライト「アイドルマスター シャイニーカラーズ」",
 		"data": {
+			"duration": 133.125,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 586,
@@ -6525,6 +7110,7 @@
 		"altTitles": [],
 		"artist": "魔女っ娘ミラクるん（CV：竹達彩奈）「ゆるゆり♪♪」",
 		"data": {
+			"duration": 146,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 587,
@@ -6537,6 +7123,7 @@
 		"altTitles": [],
 		"artist": "星街すいせい(ホロライブ)",
 		"data": {
+			"duration": 155.455,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 588,
@@ -6547,6 +7134,7 @@
 		"altTitles": [],
 		"artist": "チーム“ハナヤマタ”「ハナヤマタ」",
 		"data": {
+			"duration": 160.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 589,
@@ -6559,6 +7147,7 @@
 		"altTitles": [],
 		"artist": "Ado",
 		"data": {
+			"duration": 136.18,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 590,
@@ -6571,6 +7160,7 @@
 		"altTitles": [],
 		"artist": "yama",
 		"data": {
+			"duration": 134,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 591,
@@ -6583,6 +7173,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 137.349,
 			"genre": "niconico"
 		},
 		"id": 592,
@@ -6593,6 +7184,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 143.137,
 			"genre": "niconico"
 		},
 		"id": 593,
@@ -6605,6 +7197,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 152.015,
 			"genre": "niconico"
 		},
 		"id": 594,
@@ -6617,6 +7210,7 @@
 		"altTitles": [],
 		"artist": "すりぃ feat.鏡音レン",
 		"data": {
+			"duration": 156,
 			"genre": "niconico"
 		},
 		"id": 595,
@@ -6629,6 +7223,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト",
 		"data": {
+			"duration": 128.698,
 			"genre": "東方Project"
 		},
 		"id": 596,
@@ -6641,6 +7236,7 @@
 		"altTitles": [],
 		"artist": "Cosmograph",
 		"data": {
+			"duration": 130.286,
 			"genre": "VARIETY"
 		},
 		"id": 598,
@@ -6653,6 +7249,7 @@
 		"altTitles": [],
 		"artist": "Laur vs CK",
 		"data": {
+			"duration": 156.05,
 			"genre": "チュウマイ"
 		},
 		"id": 599,
@@ -6663,6 +7260,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 144,
 			"genre": "チュウマイ"
 		},
 		"id": 600,
@@ -6673,6 +7271,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.75,
 			"genre": "オンゲキ"
 		},
 		"id": 601,
@@ -6683,6 +7282,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 139.535,
 			"genre": "オンゲキ"
 		},
 		"id": 602,
@@ -6693,6 +7293,7 @@
 		"altTitles": [],
 		"artist": "曲：ラムシーニ／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 156.076,
 			"genre": "オンゲキ"
 		},
 		"id": 603,
@@ -6705,6 +7306,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 158.625,
 			"genre": "オンゲキ"
 		},
 		"id": 604,
@@ -6717,6 +7319,7 @@
 		"altTitles": [],
 		"artist": "polysha",
 		"data": {
+			"duration": 145.455,
 			"genre": "オンゲキ"
 		},
 		"id": 605,
@@ -6727,6 +7330,7 @@
 		"altTitles": [],
 		"artist": "Sound piercer “Espitz”",
 		"data": {
+			"duration": 156.835,
 			"genre": "オンゲキ"
 		},
 		"id": 606,
@@ -6739,6 +7343,7 @@
 		"altTitles": [],
 		"artist": "AJURIKA",
 		"data": {
+			"duration": 153.6,
 			"genre": "オンゲキ"
 		},
 		"id": 607,
@@ -6749,6 +7354,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 157.397,
 			"genre": "ボーナストラック"
 		},
 		"id": 608,
@@ -6761,6 +7367,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 157.397,
 			"genre": "ボーナストラック"
 		},
 		"id": 609,
@@ -6773,6 +7380,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 157.397,
 			"genre": "ボーナストラック"
 		},
 		"id": 610,
@@ -6785,6 +7393,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 157.397,
 			"genre": "ボーナストラック"
 		},
 		"id": 611,
@@ -6797,6 +7406,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 157.397,
 			"genre": "ボーナストラック"
 		},
 		"id": 612,
@@ -6809,6 +7419,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 114.815,
 			"genre": "LUNATIC"
 		},
 		"id": 613,
@@ -6821,6 +7432,7 @@
 		"altTitles": [],
 		"artist": "立秋 feat. ちょこ",
 		"data": {
+			"duration": 143.683,
 			"genre": "VARIETY"
 		},
 		"id": 614,
@@ -6834,6 +7446,7 @@
 		"altTitles": [],
 		"artist": "EmoCosine",
 		"data": {
+			"duration": 142.125,
 			"genre": "VARIETY"
 		},
 		"id": 615,
@@ -6844,6 +7457,7 @@
 		"altTitles": [],
 		"artist": "qfeileadh&レゾナンスもえこ",
 		"data": {
+			"duration": 153.615,
 			"genre": "VARIETY"
 		},
 		"id": 616,
@@ -6856,6 +7470,7 @@
 		"altTitles": [],
 		"artist": "名取さな",
 		"data": {
+			"duration": 164.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 617,
@@ -6868,6 +7483,7 @@
 		"altTitles": [],
 		"artist": "名取さな",
 		"data": {
+			"duration": 146.207,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 618,
@@ -6880,6 +7496,7 @@
 		"altTitles": [],
 		"artist": "リゼ・ヘルエスタ",
 		"data": {
+			"duration": 156.117,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 619,
@@ -6892,6 +7509,7 @@
 		"altTitles": [],
 		"artist": "周防パトラ",
 		"data": {
+			"duration": 147.2,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 620,
@@ -6905,6 +7523,7 @@
 		"altTitles": [],
 		"artist": "曲：烏屋茶房／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 151.613,
 			"genre": "ボーナストラック"
 		},
 		"id": 621,
@@ -6917,6 +7536,7 @@
 		"altTitles": [],
 		"artist": "曲：烏屋茶房／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 151.613,
 			"genre": "ボーナストラック"
 		},
 		"id": 622,
@@ -6929,6 +7549,7 @@
 		"altTitles": [],
 		"artist": "曲：烏屋茶房／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 151.613,
 			"genre": "ボーナストラック"
 		},
 		"id": 623,
@@ -6942,6 +7563,7 @@
 		"altTitles": [],
 		"artist": "曲：TAKU INOUE／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 167.077,
 			"genre": "オンゲキ"
 		},
 		"id": 624,
@@ -6952,6 +7574,7 @@
 		"altTitles": [],
 		"artist": "梅干茶漬け",
 		"data": {
+			"duration": 135.378,
 			"genre": "オンゲキ"
 		},
 		"id": 625,
@@ -6962,6 +7585,7 @@
 		"altTitles": [],
 		"artist": "Street",
 		"data": {
+			"duration": 149.368,
 			"genre": "オンゲキ"
 		},
 		"id": 626,
@@ -6974,6 +7598,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 163.25,
 			"genre": "niconico"
 		},
 		"id": 627,
@@ -6986,6 +7611,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 138.462,
 			"genre": "niconico"
 		},
 		"id": 628,
@@ -6998,6 +7624,7 @@
 		"altTitles": [],
 		"artist": "温泉むすめ 道後泉海（CV:篠田みなみ）「温泉むすめ」",
 		"data": {
+			"duration": 154.348,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 629,
@@ -7010,6 +7637,7 @@
 		"altTitles": [],
 		"artist": "笑う角を曲がる",
 		"data": {
+			"duration": 140.914,
 			"genre": "チュウマイ"
 		},
 		"id": 630,
@@ -7022,6 +7650,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 145.185,
 			"genre": "チュウマイ"
 		},
 		"id": 631,
@@ -7034,6 +7663,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)、逢坂 茜(CV：大空 直美)、日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 173.6,
 			"genre": "オンゲキ"
 		},
 		"id": 632,
@@ -7046,6 +7676,7 @@
 		"altTitles": [],
 		"artist": "こふ",
 		"data": {
+			"duration": 146.483,
 			"genre": "オンゲキ"
 		},
 		"id": 633,
@@ -7056,6 +7687,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 152.381,
 			"genre": "niconico"
 		},
 		"id": 634,
@@ -7068,6 +7700,7 @@
 		"altTitles": [],
 		"artist": "デスおはぎ",
 		"data": {
+			"duration": 120.5,
 			"genre": "niconico"
 		},
 		"id": 635,
@@ -7080,6 +7713,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 133.867,
 			"genre": "niconico"
 		},
 		"id": 636,
@@ -7092,6 +7726,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 160.588,
 			"genre": "ボーナストラック"
 		},
 		"id": 637,
@@ -7104,6 +7739,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 160.588,
 			"genre": "ボーナストラック"
 		},
 		"id": 638,
@@ -7116,6 +7752,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 160.588,
 			"genre": "ボーナストラック"
 		},
 		"id": 639,
@@ -7128,6 +7765,7 @@
 		"altTitles": [],
 		"artist": "LiGHTs「ラピスリライツ」",
 		"data": {
+			"duration": 166.087,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 640,
@@ -7140,6 +7778,7 @@
 		"altTitles": [],
 		"artist": "シュガーポケッツ「ラピスリライツ」",
 		"data": {
+			"duration": 140.611,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 641,
@@ -7152,6 +7791,7 @@
 		"altTitles": [],
 		"artist": "ABE_YUTA",
 		"data": {
+			"duration": 124.038,
 			"genre": "VARIETY"
 		},
 		"id": 642,
@@ -7162,6 +7802,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat. 藤枝あかね",
 		"data": {
+			"duration": 155.657,
 			"genre": "東方Project"
 		},
 		"id": 643,
@@ -7174,6 +7815,7 @@
 		"altTitles": [],
 		"artist": "UNDEAD CORPORATION",
 		"data": {
+			"duration": 142,
 			"genre": "東方Project"
 		},
 		"id": 644,
@@ -7184,6 +7826,7 @@
 		"altTitles": [],
 		"artist": "Aliesrite* (Ym1024 feat. lamie*)",
 		"data": {
+			"duration": 161.194,
 			"genre": "VARIETY"
 		},
 		"id": 645,
@@ -7194,6 +7837,7 @@
 		"altTitles": [],
 		"artist": "mommy",
 		"data": {
+			"duration": 112.041,
 			"genre": "VARIETY"
 		},
 		"id": 646,
@@ -7204,6 +7848,7 @@
 		"altTitles": [],
 		"artist": "sky_delta",
 		"data": {
+			"duration": 135.75,
 			"genre": "オンゲキ"
 		},
 		"id": 647,
@@ -7214,6 +7859,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 104.91,
 			"genre": "VARIETY"
 		},
 		"id": 648,
@@ -7224,6 +7870,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：桜井 春菜(CV：近藤 玲奈)、柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 132.152,
 			"genre": "オンゲキ"
 		},
 		"id": 649,
@@ -7234,6 +7881,7 @@
 		"altTitles": [],
 		"artist": "onoken feat. 土屋雄作",
 		"data": {
+			"duration": 155.593,
 			"genre": "オンゲキ"
 		},
 		"id": 650,
@@ -7246,6 +7894,7 @@
 		"altTitles": [],
 		"artist": "芹沢文乃（伊藤かな恵）＆梅ノ森千世（井口裕香）＆霧谷希（竹達彩奈）",
 		"data": {
+			"duration": 160.702,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 651,
@@ -7258,6 +7907,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー / 初音ミク / ワンダーランズ×ショウタイム「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 153.043,
 			"genre": "niconico"
 		},
 		"id": 652,
@@ -7270,6 +7920,7 @@
 		"altTitles": [],
 		"artist": "まふまふ / 初音ミク / 25時、ナイトコードで。「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 154.021,
 			"genre": "niconico"
 		},
 		"id": 653,
@@ -7282,6 +7933,7 @@
 		"altTitles": [],
 		"artist": "Giga / 初音ミク / Vivid BAD SQUAD「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 143.478,
 			"genre": "niconico"
 		},
 		"id": 654,
@@ -7292,6 +7944,7 @@
 		"altTitles": [],
 		"artist": "Ninja Action Team",
 		"data": {
+			"duration": 150.316,
 			"genre": "VARIETY"
 		},
 		"id": 655,
@@ -7302,6 +7955,7 @@
 		"altTitles": [],
 		"artist": "曲：睦月周平／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 143.704,
 			"genre": "ボーナストラック"
 		},
 		"id": 656,
@@ -7314,6 +7968,7 @@
 		"altTitles": [],
 		"artist": "曲：睦月周平／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 143.704,
 			"genre": "ボーナストラック"
 		},
 		"id": 657,
@@ -7326,6 +7981,7 @@
 		"altTitles": [],
 		"artist": "曲：睦月周平／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 143.704,
 			"genre": "ボーナストラック"
 		},
 		"id": 658,
@@ -7338,6 +7994,7 @@
 		"altTitles": [],
 		"artist": "曲：大熊淳生（Arte Refact）／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 145.5,
 			"genre": "オンゲキ"
 		},
 		"id": 659,
@@ -7348,6 +8005,7 @@
 		"altTitles": [],
 		"artist": "曲：Kensuke／歌：逢坂 茜(CV：大空 直美)、藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 166.091,
 			"genre": "オンゲキ"
 		},
 		"id": 660,
@@ -7360,6 +8018,7 @@
 		"altTitles": [],
 		"artist": "Getty",
 		"data": {
+			"duration": 135.771,
 			"genre": "オンゲキ"
 		},
 		"id": 661,
@@ -7370,6 +8029,7 @@
 		"altTitles": [],
 		"artist": "Masahiro “Godspeed” Aoki",
 		"data": {
+			"duration": 152.925,
 			"genre": "オンゲキ"
 		},
 		"id": 662,
@@ -7380,6 +8040,7 @@
 		"altTitles": [],
 		"artist": "DECO*27 × 堀江晶太(kemu) / 初音ミク、星乃一歌、天馬司、宵崎奏「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 162.406,
 			"genre": "niconico"
 		},
 		"id": 663,
@@ -7392,6 +8053,7 @@
 		"altTitles": [],
 		"artist": "Giga & Mitchie M / 初音ミク、花里みのり、小豆沢こはね「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 159.75,
 			"genre": "niconico"
 		},
 		"id": 664,
@@ -7404,6 +8066,7 @@
 		"altTitles": [],
 		"artist": "セイネ (CV: 河上英里子) 「グルーヴコースター」",
 		"data": {
+			"duration": 147.978,
 			"genre": "VARIETY"
 		},
 		"id": 665,
@@ -7416,6 +8079,7 @@
 		"altTitles": [],
 		"artist": "Tatsh feat.彩音「グルーヴコースター」",
 		"data": {
+			"duration": 132,
 			"genre": "VARIETY"
 		},
 		"id": 666,
@@ -7426,6 +8090,7 @@
 		"altTitles": [],
 		"artist": "253215「グルーヴコースター」",
 		"data": {
+			"duration": 131.182,
 			"genre": "VARIETY"
 		},
 		"id": 667,
@@ -7436,6 +8101,7 @@
 		"altTitles": [],
 		"artist": "xi vs MASAKI「グルーヴコースター」",
 		"data": {
+			"duration": 127.333,
 			"genre": "VARIETY"
 		},
 		"id": 668,
@@ -7446,6 +8112,7 @@
 		"altTitles": [],
 		"artist": "土屋昇平(ZUNTATA)「ダライアスバースト」",
 		"data": {
+			"duration": 142.286,
 			"genre": "LUNATIC"
 		},
 		"id": 669,
@@ -7456,6 +8123,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 149.423,
 			"genre": "niconico"
 		},
 		"id": 670,
@@ -7468,6 +8136,7 @@
 		"altTitles": [],
 		"artist": "YUC'e",
 		"data": {
+			"duration": 131.684,
 			"genre": "チュウマイ"
 		},
 		"id": 671,
@@ -7478,6 +8147,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：珠洲島 有栖(CV：長縄 まりあ)、皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 148.727,
 			"genre": "オンゲキ"
 		},
 		"id": 672,
@@ -7488,6 +8158,7 @@
 		"altTitles": [],
 		"artist": "とろまる",
 		"data": {
+			"duration": 145.833,
 			"genre": "オンゲキ"
 		},
 		"id": 673,
@@ -7498,6 +8169,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 145,
 			"genre": "ボーナストラック"
 		},
 		"id": 674,
@@ -7510,6 +8182,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 145,
 			"genre": "ボーナストラック"
 		},
 		"id": 675,
@@ -7522,6 +8195,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 128.621,
 			"genre": "ボーナストラック"
 		},
 		"id": 676,
@@ -7534,6 +8208,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 128.621,
 			"genre": "ボーナストラック"
 		},
 		"id": 677,
@@ -7546,6 +8221,7 @@
 		"altTitles": [],
 		"artist": "為栗メロ（CV:会沢紗弥）新阪ルナ（CV:香里有佐）恋浜みろく（CV:柳原かなこ）「駅メモ！ - ステーションメモリーズ！-」",
 		"data": {
+			"duration": 168.158,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 678,
@@ -7558,6 +8234,7 @@
 		"altTitles": [],
 		"artist": "igel",
 		"data": {
+			"duration": 143.5,
 			"genre": "オンゲキ"
 		},
 		"id": 679,
@@ -7570,6 +8247,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 136.138,
 			"genre": "オンゲキ"
 		},
 		"id": 680,
@@ -7580,6 +8258,7 @@
 		"altTitles": [],
 		"artist": "Re:STAGE! ALL IDOL「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 124.968,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 681,
@@ -7592,6 +8271,7 @@
 		"altTitles": [],
 		"artist": "ステラマリス「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 120.557,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 682,
@@ -7602,6 +8282,7 @@
 		"altTitles": [],
 		"artist": "本城香澄（CV：岩橋由佳）「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 164.842,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 683,
@@ -7614,6 +8295,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 173.836,
 			"genre": "VARIETY"
 		},
 		"id": 684,
@@ -7626,6 +8308,7 @@
 		"altTitles": [],
 		"artist": "naotyu-",
 		"data": {
+			"duration": 128.129,
 			"genre": "VARIETY"
 		},
 		"id": 685,
@@ -7636,6 +8319,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 126.316,
 			"genre": "VARIETY"
 		},
 		"id": 686,
@@ -7646,6 +8330,7 @@
 		"altTitles": [],
 		"artist": "上田麗奈「魔女の旅々」",
 		"data": {
+			"duration": 157.119,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 687,
@@ -7658,6 +8343,7 @@
 		"altTitles": [],
 		"artist": "レイナ（CV.久保ユリカ），ヒヨ（CV.鈴木絵理），ナナミ（CV.佐倉綾音）「プロジェクト東京ドールズ」",
 		"data": {
+			"duration": 150.978,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 688,
@@ -7670,6 +8356,7 @@
 		"altTitles": [],
 		"artist": "スペシャルウィーク （CV.和氣あず未）、サイレンススズカ （CV.高野麻里佳）、トウカイテイオー （CV.Machico）",
 		"data": {
+			"duration": 136.575,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 689,
@@ -7682,6 +8369,7 @@
 		"altTitles": [],
 		"artist": "AXiS「Tokyo 7th シスターズ」",
 		"data": {
+			"duration": 161.2,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 690,
@@ -7692,6 +8380,7 @@
 		"altTitles": [],
 		"artist": "PSYQUI",
 		"data": {
+			"duration": 130,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 691,
@@ -7704,6 +8393,7 @@
 		"altTitles": [],
 		"artist": "くじら",
 		"data": {
+			"duration": 140.488,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 692,
@@ -7716,6 +8406,7 @@
 		"altTitles": [],
 		"artist": "電音部、鳳凰火凛 (CV: 健屋花那)、瀬戸海月 (CV: シスター・クレア)、大賀ルキア (CV: 星川サラ)",
 		"data": {
+			"duration": 141.916,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 693,
@@ -7726,6 +8417,7 @@
 		"altTitles": [],
 		"artist": "Ayase",
 		"data": {
+			"duration": 151.452,
 			"genre": "niconico"
 		},
 		"id": 694,
@@ -7738,6 +8430,7 @@
 		"altTitles": [],
 		"artist": "Unlucky Morpheus",
 		"data": {
+			"duration": 148.645,
 			"genre": "東方Project"
 		},
 		"id": 695,
@@ -7750,6 +8443,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 160.843,
 			"genre": "東方Project"
 		},
 		"id": 696,
@@ -7762,6 +8456,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE「太鼓の達人」",
 		"data": {
+			"duration": 136.853,
 			"genre": "VARIETY"
 		},
 		"id": 697,
@@ -7774,6 +8469,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 146.881,
 			"genre": "VARIETY"
 		},
 		"id": 698,
@@ -7784,6 +8480,7 @@
 		"altTitles": [],
 		"artist": "BlackY fused with WAiKURO",
 		"data": {
+			"duration": 136.5,
 			"genre": "チュウマイ"
 		},
 		"id": 699,
@@ -7794,6 +8491,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：3年生シューターズ",
 		"data": {
+			"duration": 162.745,
 			"genre": "オンゲキ"
 		},
 		"id": 700,
@@ -7804,6 +8502,7 @@
 		"altTitles": [],
 		"artist": "Palme",
 		"data": {
+			"duration": 158.507,
 			"genre": "オンゲキ"
 		},
 		"id": 701,
@@ -7814,6 +8513,7 @@
 		"altTitles": [],
 		"artist": "Srav3R",
 		"data": {
+			"duration": 146.211,
 			"genre": "オンゲキ"
 		},
 		"id": 702,
@@ -7824,6 +8524,7 @@
 		"altTitles": [],
 		"artist": "Massive New Krew",
 		"data": {
+			"duration": 135.871,
 			"genre": "オンゲキ"
 		},
 		"id": 703,
@@ -7834,6 +8535,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 146.333,
 			"genre": "オンゲキ"
 		},
 		"id": 704,
@@ -7844,6 +8546,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 145.574,
 			"genre": "ボーナストラック"
 		},
 		"id": 705,
@@ -7856,6 +8559,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 145.574,
 			"genre": "ボーナストラック"
 		},
 		"id": 706,
@@ -7868,6 +8572,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 145.574,
 			"genre": "ボーナストラック"
 		},
 		"id": 707,
@@ -7880,6 +8585,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 145.574,
 			"genre": "ボーナストラック"
 		},
 		"id": 708,
@@ -7892,6 +8598,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 145.574,
 			"genre": "ボーナストラック"
 		},
 		"id": 709,
@@ -7904,6 +8611,7 @@
 		"altTitles": [],
 		"artist": "安井洋介「まもるクンは呪われてしまった！」",
 		"data": {
+			"duration": 173.571,
 			"genre": "VARIETY"
 		},
 		"id": 710,
@@ -7914,6 +8622,7 @@
 		"altTitles": [],
 		"artist": "Taku Takahashi(m-flo, block.fm), Mitsunori Ikeda(Tachytelic Inc.)「プロジェクト東京ドールズ」",
 		"data": {
+			"duration": 129,
 			"genre": "LUNATIC"
 		},
 		"id": 711,
@@ -7926,6 +8635,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 149.077,
 			"genre": "オンゲキ"
 		},
 		"id": 712,
@@ -7936,6 +8646,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 156.964,
 			"genre": "オンゲキ"
 		},
 		"id": 713,
@@ -7948,6 +8659,7 @@
 		"altTitles": [],
 		"artist": "曲：Tomggg／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 153.6,
 			"genre": "オンゲキ"
 		},
 		"id": 714,
@@ -7958,6 +8670,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite / LeaF",
 		"data": {
+			"duration": 147,
 			"genre": "オンゲキ"
 		},
 		"id": 715,
@@ -7968,6 +8681,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：桜井 春菜(CV：近藤 玲奈)、早乙女 彩華(CV：中島 唯)、井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 150.6,
 			"genre": "オンゲキ"
 		},
 		"id": 716,
@@ -7978,6 +8692,7 @@
 		"altTitles": [],
 		"artist": "pan",
 		"data": {
+			"duration": 156.667,
 			"genre": "オンゲキ"
 		},
 		"id": 717,
@@ -7988,6 +8703,7 @@
 		"altTitles": [],
 		"artist": "やどりぎ",
 		"data": {
+			"duration": 143.544,
 			"genre": "オンゲキ"
 		},
 		"id": 718,
@@ -8000,6 +8716,7 @@
 		"altTitles": [],
 		"artist": "庭師",
 		"data": {
+			"duration": 162.623,
 			"genre": "オンゲキ"
 		},
 		"id": 719,
@@ -8012,6 +8729,7 @@
 		"altTitles": [],
 		"artist": "xi vs かねこちはる",
 		"data": {
+			"duration": 152.264,
 			"genre": "オンゲキ"
 		},
 		"id": 720,
@@ -8022,6 +8740,7 @@
 		"altTitles": [],
 		"artist": "古墳P",
 		"data": {
+			"duration": 146.522,
 			"genre": "niconico"
 		},
 		"id": 721,
@@ -8032,6 +8751,7 @@
 		"altTitles": [],
 		"artist": "小林オニキス",
 		"data": {
+			"duration": 150.411,
 			"genre": "niconico"
 		},
 		"id": 722,
@@ -8044,6 +8764,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 146.116,
 			"genre": "niconico"
 		},
 		"id": 723,
@@ -8056,6 +8777,7 @@
 		"altTitles": [],
 		"artist": "オワタP",
 		"data": {
+			"duration": 174.773,
 			"genre": "niconico"
 		},
 		"id": 724,
@@ -8068,6 +8790,7 @@
 		"altTitles": [],
 		"artist": "Peaky P-key「D4DJ」",
 		"data": {
+			"duration": 138,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 725,
@@ -8080,6 +8803,7 @@
 		"altTitles": [],
 		"artist": "燐舞曲「D4DJ」",
 		"data": {
+			"duration": 135.892,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 726,
@@ -8092,6 +8816,7 @@
 		"altTitles": [],
 		"artist": "大橋彩香「政宗くんのリベンジ」",
 		"data": {
+			"duration": 164.42,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 727,
@@ -8104,6 +8829,7 @@
 		"altTitles": [],
 		"artist": "Hiro「Crackin'DJ」",
 		"data": {
+			"duration": 106.275,
 			"genre": "VARIETY"
 		},
 		"id": 728,
@@ -8114,6 +8840,7 @@
 		"altTitles": [],
 		"artist": "キノシタ feat.音街ウナ・鏡音リン",
 		"data": {
+			"duration": 150.286,
 			"genre": "niconico"
 		},
 		"id": 729,
@@ -8126,6 +8853,7 @@
 		"altTitles": [],
 		"artist": "キノシタ feat. そらみこ",
 		"data": {
+			"duration": 139.016,
 			"genre": "チュウマイ"
 		},
 		"id": 730,
@@ -8138,6 +8866,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 135.554,
 			"genre": "チュウマイ"
 		},
 		"id": 731,
@@ -8148,6 +8877,7 @@
 		"altTitles": [],
 		"artist": "ソフマップ 店内BGM　歌：光吉猛修 コーラス：音撃譜面部",
 		"data": {
+			"duration": 132.048,
 			"genre": "VARIETY"
 		},
 		"id": 732,
@@ -8158,6 +8888,7 @@
 		"altTitles": [],
 		"artist": "Tatsh x NAOKI",
 		"data": {
+			"duration": 122.278,
 			"genre": "VARIETY"
 		},
 		"id": 733,
@@ -8168,6 +8899,7 @@
 		"altTitles": [],
 		"artist": "編曲：SEGA SOUND STAFF",
 		"data": {
+			"duration": 96.6,
 			"genre": "LUNATIC"
 		},
 		"id": 734,
@@ -8180,6 +8912,7 @@
 		"altTitles": [],
 		"artist": "成海遥香（CV：雨宮天）、煌上花音（CV：本渡楓）、楠明日葉（CV：田村睦心）、南ひなた（CV：五十嵐裕美）、サドネ（CV：悠木碧）、朝比奈心美（CV：原田ひとみ）「バトルガール ハイスクール」",
 		"data": {
+			"duration": 161.912,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 735,
@@ -8192,6 +8925,7 @@
 		"altTitles": [],
 		"artist": "f*f（CV：本渡楓・下地紫野）「バトルガール ハイスクール」",
 		"data": {
+			"duration": 161.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 736,
@@ -8202,6 +8936,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 159.769,
 			"genre": "ボーナストラック"
 		},
 		"id": 737,
@@ -8214,6 +8949,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 159.769,
 			"genre": "ボーナストラック"
 		},
 		"id": 738,
@@ -8226,6 +8962,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 159.769,
 			"genre": "ボーナストラック"
 		},
 		"id": 739,
@@ -8238,6 +8975,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 159.769,
 			"genre": "ボーナストラック"
 		},
 		"id": 740,
@@ -8250,6 +8988,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 159.769,
 			"genre": "ボーナストラック"
 		},
 		"id": 741,
@@ -8262,6 +9001,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 168,
 			"genre": "オンゲキ"
 		},
 		"id": 742,
@@ -8274,6 +9014,7 @@
 		"altTitles": [],
 		"artist": "曲：Nika Lenz（Arte Refact）／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 141.429,
 			"genre": "オンゲキ"
 		},
 		"id": 743,
@@ -8286,6 +9027,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 156,
 			"genre": "オンゲキ"
 		},
 		"id": 744,
@@ -8296,6 +9038,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree Remixed by Sampling Masters MEGA",
 		"data": {
+			"duration": 162.418,
 			"genre": "オンゲキ"
 		},
 		"id": 745,
@@ -8306,6 +9049,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 154.513,
 			"genre": "オンゲキ"
 		},
 		"id": 746,
@@ -8318,6 +9062,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 143.077,
 			"genre": "オンゲキ"
 		},
 		"id": 747,
@@ -8330,6 +9075,7 @@
 		"altTitles": [],
 		"artist": "MisoilePunch♪",
 		"data": {
+			"duration": 158.612,
 			"genre": "オンゲキ"
 		},
 		"id": 748,
@@ -8340,6 +9086,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 152.788,
 			"genre": "niconico"
 		},
 		"id": 749,
@@ -8352,6 +9099,7 @@
 		"altTitles": [],
 		"artist": "s-don vs. 翡乃イスカ",
 		"data": {
+			"duration": 149.032,
 			"genre": "チュウマイ"
 		},
 		"id": 750,
@@ -8364,6 +9112,7 @@
 		"altTitles": [],
 		"artist": "はるまきごはん feat.めらみぽっぷ",
 		"data": {
+			"duration": 139.2,
 			"genre": "チュウマイ"
 		},
 		"id": 751,
@@ -8376,6 +9125,7 @@
 		"altTitles": [],
 		"artist": "nmk feat.橘花音",
 		"data": {
+			"duration": 121.011,
 			"genre": "VARIETY"
 		},
 		"id": 752,
@@ -8386,6 +9136,7 @@
 		"altTitles": [],
 		"artist": "wa. vs ETIA.",
 		"data": {
+			"duration": 115.625,
 			"genre": "VARIETY"
 		},
 		"id": 753,
@@ -8396,6 +9147,7 @@
 		"altTitles": [],
 		"artist": "達見 恵 featured by 佐野 宏晃",
 		"data": {
+			"duration": 157.377,
 			"genre": "チュウマイ"
 		},
 		"id": 754,
@@ -8406,6 +9158,7 @@
 		"altTitles": [],
 		"artist": "DIVELA",
 		"data": {
+			"duration": 141.569,
 			"genre": "niconico"
 		},
 		"id": 755,
@@ -8418,6 +9171,7 @@
 		"altTitles": [],
 		"artist": "シンP",
 		"data": {
+			"duration": 145.415,
 			"genre": "niconico"
 		},
 		"id": 756,
@@ -8430,6 +9184,7 @@
 		"altTitles": [],
 		"artist": "ゴリライザー制作委員会",
 		"data": {
+			"duration": 107.391,
 			"genre": "VARIETY"
 		},
 		"id": 757,
@@ -8442,6 +9197,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock(Dream Monster)／歌：藤沢 柚子(CV：久保田 梨沙)、井之原 小星(CV：ももの はるな)、逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 174.242,
 			"genre": "オンゲキ"
 		},
 		"id": 758,
@@ -8454,6 +9210,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 147.082,
 			"genre": "ボーナストラック"
 		},
 		"id": 759,
@@ -8466,6 +9223,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 147.082,
 			"genre": "ボーナストラック"
 		},
 		"id": 760,
@@ -8478,6 +9236,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 147.082,
 			"genre": "ボーナストラック"
 		},
 		"id": 761,
@@ -8490,6 +9249,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 147.082,
 			"genre": "ボーナストラック"
 		},
 		"id": 762,
@@ -8503,6 +9263,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 147.082,
 			"genre": "ボーナストラック"
 		},
 		"id": 763,
@@ -8515,6 +9276,7 @@
 		"altTitles": [],
 		"artist": "並木 学「東方幻想麻雀」",
 		"data": {
+			"duration": 152.129,
 			"genre": "東方Project"
 		},
 		"id": 764,
@@ -8528,6 +9290,7 @@
 		"altTitles": [],
 		"artist": "来兎「東方幻想麻雀」",
 		"data": {
+			"duration": 147.882,
 			"genre": "東方Project"
 		},
 		"id": 765,
@@ -8538,6 +9301,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修「東方幻想麻雀」",
 		"data": {
+			"duration": 139.935,
 			"genre": "東方Project"
 		},
 		"id": 766,
@@ -8550,6 +9314,7 @@
 		"altTitles": [],
 		"artist": "FELT",
 		"data": {
+			"duration": 155.077,
 			"genre": "東方Project"
 		},
 		"id": 767,
@@ -8560,6 +9325,7 @@
 		"altTitles": [],
 		"artist": "demetori",
 		"data": {
+			"duration": 143.032,
 			"genre": "東方Project"
 		},
 		"id": 768,
@@ -8572,6 +9338,7 @@
 		"altTitles": [],
 		"artist": "セブンスヘブンMAXION",
 		"data": {
+			"duration": 143.5,
 			"genre": "東方Project"
 		},
 		"id": 769,
@@ -8584,6 +9351,7 @@
 		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
+			"duration": 149.714,
 			"genre": "東方Project"
 		},
 		"id": 770,
@@ -8594,6 +9362,7 @@
 		"altTitles": [],
 		"artist": "COOL&CREATE × 宝鐘マリン feat.不知火フレア",
 		"data": {
+			"duration": 141.739,
 			"genre": "東方Project"
 		},
 		"id": 771,
@@ -8604,6 +9373,7 @@
 		"altTitles": [],
 		"artist": "曲：ANCHOR／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 157.895,
 			"genre": "オンゲキ"
 		},
 		"id": 773,
@@ -8614,6 +9384,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 121.92,
 			"genre": "オンゲキ"
 		},
 		"id": 774,
@@ -8626,6 +9397,7 @@
 		"altTitles": [],
 		"artist": "C-Show & Maozon",
 		"data": {
+			"duration": 155.381,
 			"genre": "オンゲキ"
 		},
 		"id": 775,
@@ -8636,6 +9408,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
+			"duration": 151.343,
 			"genre": "オンゲキ"
 		},
 		"id": 776,
@@ -8648,6 +9421,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 135.079,
 			"genre": "オンゲキ"
 		},
 		"id": 777,
@@ -8658,6 +9432,7 @@
 		"altTitles": [],
 		"artist": "ke-ji(CERTIA)",
 		"data": {
+			"duration": 148.247,
 			"genre": "オンゲキ"
 		},
 		"id": 778,
@@ -8671,6 +9446,7 @@
 		"altTitles": [],
 		"artist": "kanone vs. BlackY",
 		"data": {
+			"duration": 164.634,
 			"genre": "オンゲキ"
 		},
 		"id": 779,
@@ -8681,6 +9457,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 136.048,
 			"genre": "niconico"
 		},
 		"id": 780,
@@ -8693,6 +9470,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 146.6,
 			"genre": "niconico"
 		},
 		"id": 781,
@@ -8705,6 +9483,7 @@
 		"altTitles": [],
 		"artist": "柊キライ",
 		"data": {
+			"duration": 159.416,
 			"genre": "niconico"
 		},
 		"id": 782,
@@ -8717,6 +9496,7 @@
 		"altTitles": [],
 		"artist": "まふまふ「#コンパス」",
 		"data": {
+			"duration": 156.25,
 			"genre": "niconico"
 		},
 		"id": 783,
@@ -8729,6 +9509,7 @@
 		"altTitles": [],
 		"artist": "USAO「Arcaea」",
 		"data": {
+			"duration": 141.6,
 			"genre": "VARIETY"
 		},
 		"id": 784,
@@ -8739,6 +9520,7 @@
 		"altTitles": [],
 		"artist": "s-don「Arcaea」",
 		"data": {
+			"duration": 139.355,
 			"genre": "VARIETY"
 		},
 		"id": 785,
@@ -8751,6 +9533,7 @@
 		"altTitles": [],
 		"artist": "Endorfin.「Arcaea」",
 		"data": {
+			"duration": 154.269,
 			"genre": "VARIETY"
 		},
 		"id": 786,
@@ -8761,6 +9544,7 @@
 		"altTitles": [],
 		"artist": "BlackY feat. Risa Yuzuki「Arcaea」",
 		"data": {
+			"duration": 141.878,
 			"genre": "VARIETY"
 		},
 		"id": 787,
@@ -8773,6 +9557,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite「Arcaea」",
 		"data": {
+			"duration": 140.26,
 			"genre": "VARIETY"
 		},
 		"id": 788,
@@ -8783,6 +9568,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 159.75,
 			"genre": "ボーナストラック"
 		},
 		"id": 789,
@@ -8795,6 +9581,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 159.75,
 			"genre": "ボーナストラック"
 		},
 		"id": 790,
@@ -8807,6 +9594,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 159.75,
 			"genre": "ボーナストラック"
 		},
 		"id": 791,
@@ -8819,6 +9607,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 159.75,
 			"genre": "ボーナストラック"
 		},
 		"id": 792,
@@ -8831,6 +9620,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 159.75,
 			"genre": "ボーナストラック"
 		},
 		"id": 793,
@@ -8843,6 +9633,7 @@
 		"altTitles": [],
 		"artist": "niki feat.noire",
 		"data": {
+			"duration": 142.994,
 			"genre": "チュウマイ"
 		},
 		"id": 794,
@@ -8853,6 +9644,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 131.208,
 			"genre": "チュウマイ"
 		},
 		"id": 795,
@@ -8863,6 +9655,7 @@
 		"altTitles": [],
 		"artist": "曲：脇眞富（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)、日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 150,
 			"genre": "オンゲキ"
 		},
 		"id": 796,
@@ -8875,6 +9668,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 137.974,
 			"genre": "オンゲキ"
 		},
 		"id": 797,
@@ -8885,6 +9679,7 @@
 		"altTitles": [],
 		"artist": "曲：白戸佑輔(Dream Monster)／歌：ASTERISM [星咲 あかり(CV：赤尾 ひかる)、藤沢 柚子(CV：久保田 梨沙)、三角 葵(CV：春野 杏)]",
 		"data": {
+			"duration": 171.786,
 			"genre": "オンゲキ"
 		},
 		"id": 798,
@@ -8895,6 +9690,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 146.233,
 			"genre": "オンゲキ"
 		},
 		"id": 799,
@@ -8907,6 +9703,7 @@
 		"altTitles": [],
 		"artist": "曲：央海加亥／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 178.626,
 			"genre": "オンゲキ"
 		},
 		"id": 800,
@@ -8919,6 +9716,7 @@
 		"altTitles": [],
 		"artist": "igel",
 		"data": {
+			"duration": 165.525,
 			"genre": "オンゲキ"
 		},
 		"id": 801,
@@ -8929,6 +9727,7 @@
 		"altTitles": [],
 		"artist": "Junk",
 		"data": {
+			"duration": 168.982,
 			"genre": "オンゲキ"
 		},
 		"id": 802,
@@ -8941,6 +9740,7 @@
 		"altTitles": [],
 		"artist": "大国奏音",
 		"data": {
+			"duration": 156.818,
 			"genre": "オンゲキ"
 		},
 		"id": 803,
@@ -8953,6 +9753,7 @@
 		"altTitles": [],
 		"artist": "細江慎治",
 		"data": {
+			"duration": 138.546,
 			"genre": "LUNATIC"
 		},
 		"id": 804,
@@ -8967,6 +9768,7 @@
 		"altTitles": [],
 		"artist": "水野健治 VS 穴山大輔",
 		"data": {
+			"duration": 172.5,
 			"genre": "オンゲキ"
 		},
 		"id": 805,
@@ -8983,6 +9785,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 220.779,
 			"genre": "オンゲキ"
 		},
 		"id": 806,
@@ -8993,6 +9796,7 @@
 		"altTitles": [],
 		"artist": "細江慎治",
 		"data": {
+			"duration": 138.546,
 			"genre": "LUNATIC"
 		},
 		"id": 807,
@@ -9009,6 +9813,7 @@
 		"altTitles": [],
 		"artist": "ああああ vs ぺのれり",
 		"data": {
+			"duration": 173.295,
 			"genre": "オンゲキ"
 		},
 		"id": 808,
@@ -9019,6 +9824,7 @@
 		"altTitles": [],
 		"artist": "SEGA SOUND STAFF arranged by Kanon Oguni",
 		"data": {
+			"duration": 173.647,
 			"genre": "オンゲキ"
 		},
 		"id": 809,
@@ -9029,6 +9835,7 @@
 		"altTitles": [],
 		"artist": "40mP feat.シャノ",
 		"data": {
+			"duration": 160.172,
 			"genre": "チュウマイ"
 		},
 		"id": 810,
@@ -9041,6 +9848,7 @@
 		"altTitles": [],
 		"artist": "ああああ",
 		"data": {
+			"duration": 131.538,
 			"genre": "チュウマイ"
 		},
 		"id": 811,
@@ -9053,6 +9861,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 165.472,
 			"genre": "ボーナストラック"
 		},
 		"id": 812,
@@ -9065,6 +9874,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 165.472,
 			"genre": "ボーナストラック"
 		},
 		"id": 813,
@@ -9077,6 +9887,7 @@
 		"altTitles": [],
 		"artist": "曲：原田篤（Arte Refact）／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 165.472,
 			"genre": "ボーナストラック"
 		},
 		"id": 814,
@@ -9089,6 +9900,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite feat. しゃま(CV:種﨑 敦美) & みるく(CV:伊藤 あすか)",
 		"data": {
+			"duration": 160,
 			"genre": "チュウマイ"
 		},
 		"id": 815,
@@ -9101,6 +9913,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 143.256,
 			"genre": "チュウマイ"
 		},
 		"id": 816,
@@ -9113,6 +9926,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 142.088,
 			"genre": "オンゲキ"
 		},
 		"id": 817,
@@ -9123,6 +9937,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 149,
 			"genre": "チュウマイ"
 		},
 		"id": 818,
@@ -9133,6 +9948,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 136.774,
 			"genre": "チュウマイ"
 		},
 		"id": 819,
@@ -9145,6 +9961,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite (HARDCORE TANO*C) feat.TANO*C ALL STARS",
 		"data": {
+			"duration": 155.351,
 			"genre": "チュウマイ"
 		},
 		"id": 820,
@@ -9157,6 +9974,7 @@
 		"altTitles": [],
 		"artist": "R Sound Design feat.向日葵",
 		"data": {
+			"duration": 150.909,
 			"genre": "チュウマイ"
 		},
 		"id": 821,
@@ -9167,6 +9985,7 @@
 		"altTitles": [],
 		"artist": "霜月はるか",
 		"data": {
+			"duration": 117.3,
 			"genre": "チュウマイ"
 		},
 		"id": 822,
@@ -9177,6 +9996,7 @@
 		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
+			"duration": 146.943,
 			"genre": "チュウマイ"
 		},
 		"id": 823,
@@ -9189,6 +10009,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock & 佐藤厚仁／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 155.466,
 			"genre": "ボーナストラック"
 		},
 		"id": 824,
@@ -9201,6 +10022,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock & 佐藤厚仁／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 155.466,
 			"genre": "ボーナストラック"
 		},
 		"id": 825,
@@ -9213,6 +10035,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock & 佐藤厚仁／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 155.466,
 			"genre": "ボーナストラック"
 		},
 		"id": 826,
@@ -9225,6 +10048,7 @@
 		"altTitles": [],
 		"artist": "くるぶっこちゃん",
 		"data": {
+			"duration": 156,
 			"genre": "チュウマイ"
 		},
 		"id": 827,
@@ -9237,6 +10061,7 @@
 		"altTitles": [],
 		"artist": "RD-Sounds feat.中恵光城",
 		"data": {
+			"duration": 149.412,
 			"genre": "チュウマイ"
 		},
 		"id": 828,
@@ -9249,6 +10074,7 @@
 		"altTitles": [],
 		"artist": "suzu",
 		"data": {
+			"duration": 140.952,
 			"genre": "チュウマイ"
 		},
 		"id": 829,
@@ -9261,6 +10087,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 150.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 830,
@@ -9273,6 +10100,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 150.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 831,
@@ -9285,6 +10113,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 150.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 832,
@@ -9297,6 +10126,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 150.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 833,
@@ -9309,6 +10139,7 @@
 		"altTitles": [],
 		"artist": "PSYQUI feat.Such",
 		"data": {
+			"duration": 145.059,
 			"genre": "チュウマイ"
 		},
 		"id": 834,
@@ -9319,6 +10150,7 @@
 		"altTitles": [],
 		"artist": "Yunomi feat.nicamoq",
 		"data": {
+			"duration": 135.938,
 			"genre": "チュウマイ"
 		},
 		"id": 835,
@@ -9331,6 +10163,7 @@
 		"altTitles": [],
 		"artist": "香椎モイミ",
 		"data": {
+			"duration": 117.423,
 			"genre": "niconico"
 		},
 		"id": 836,
@@ -9343,6 +10176,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 159.107,
 			"genre": "チュウマイ"
 		},
 		"id": 837,
@@ -9353,6 +10187,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 129,
 			"genre": "チュウマイ"
 		},
 		"id": 838,
@@ -9363,6 +10198,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.SUIMI",
 		"data": {
+			"duration": 128.769,
 			"genre": "チュウマイ"
 		},
 		"id": 839,
@@ -9373,6 +10209,7 @@
 		"altTitles": [],
 		"artist": "山本真央樹",
 		"data": {
+			"duration": 154.79,
 			"genre": "チュウマイ"
 		},
 		"id": 840,
@@ -9385,6 +10222,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 841,
@@ -9397,6 +10235,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 842,
@@ -9409,6 +10248,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 843,
@@ -9421,6 +10261,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 844,
@@ -9433,6 +10274,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 845,
@@ -9445,6 +10287,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 846,
@@ -9457,6 +10300,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 847,
@@ -9469,6 +10313,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 848,
@@ -9481,6 +10326,7 @@
 		"altTitles": [],
 		"artist": "曲：田中秀和／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 220.779,
 			"genre": "ボーナストラック"
 		},
 		"id": 849,
@@ -9493,6 +10339,7 @@
 		"altTitles": [],
 		"artist": "曲：脇眞富（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 150,
 			"genre": "ボーナストラック"
 		},
 		"id": 850,
@@ -9505,6 +10352,7 @@
 		"altTitles": [],
 		"artist": "曲：脇眞富（Arte Refact）／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 150,
 			"genre": "ボーナストラック"
 		},
 		"id": 851,
@@ -9517,6 +10365,7 @@
 		"altTitles": [],
 		"artist": "Chinozo",
 		"data": {
+			"duration": 127.059,
 			"genre": "niconico"
 		},
 		"id": 852,
@@ -9529,6 +10378,7 @@
 		"altTitles": [],
 		"artist": "烏屋茶房 feat.利香",
 		"data": {
+			"duration": 158.873,
 			"genre": "チュウマイ"
 		},
 		"id": 853,
@@ -9541,6 +10391,7 @@
 		"altTitles": [],
 		"artist": "PRASTIK DANCEFLOOR",
 		"data": {
+			"duration": 138.806,
 			"genre": "チュウマイ"
 		},
 		"id": 854,
@@ -9551,6 +10402,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite feat.ななひら",
 		"data": {
+			"duration": 163.317,
 			"genre": "チュウマイ"
 		},
 		"id": 855,
@@ -9563,6 +10415,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 133.171,
 			"genre": "niconico"
 		},
 		"id": 856,
@@ -9575,6 +10428,7 @@
 		"altTitles": [],
 		"artist": "BlackY feat. Risa Yuzuki",
 		"data": {
+			"duration": 153.559,
 			"genre": "チュウマイ"
 		},
 		"id": 857,
@@ -9585,6 +10439,7 @@
 		"altTitles": [],
 		"artist": "きくお×cosMo＠暴走P feat.影縫英",
 		"data": {
+			"duration": 143.5,
 			"genre": "チュウマイ"
 		},
 		"id": 858,
@@ -9597,6 +10452,7 @@
 		"altTitles": [],
 		"artist": "NAOKI feat.小坂りゆ",
 		"data": {
+			"duration": 135.366,
 			"genre": "チュウマイ"
 		},
 		"id": 859,
@@ -9609,6 +10465,7 @@
 		"altTitles": [],
 		"artist": "KOTOKO",
 		"data": {
+			"duration": 152.5,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 860,
@@ -9621,6 +10478,7 @@
 		"altTitles": [],
 		"artist": "P丸様。",
 		"data": {
+			"duration": 128.182,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 861,
@@ -9633,6 +10491,7 @@
 		"altTitles": [],
 		"artist": "kanone feat. せんざい",
 		"data": {
+			"duration": 139.083,
 			"genre": "チュウマイ"
 		},
 		"id": 862,
@@ -9645,6 +10504,7 @@
 		"altTitles": [],
 		"artist": "曲：高木龍一(Dream Monster)／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 141.997,
 			"genre": "ボーナストラック"
 		},
 		"id": 863,
@@ -9657,6 +10517,7 @@
 		"altTitles": [],
 		"artist": "曲：高木龍一(Dream Monster)／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 141.997,
 			"genre": "ボーナストラック"
 		},
 		"id": 864,
@@ -9669,6 +10530,7 @@
 		"altTitles": [],
 		"artist": "曲：高木龍一(Dream Monster)／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 141.997,
 			"genre": "ボーナストラック"
 		},
 		"id": 865,
@@ -9682,6 +10544,7 @@
 		"altTitles": [],
 		"artist": "ツミキ",
 		"data": {
+			"duration": 138.706,
 			"genre": "niconico"
 		},
 		"id": 866,
@@ -9694,6 +10557,7 @@
 		"altTitles": [],
 		"artist": "ETIA.",
 		"data": {
+			"duration": 149.486,
 			"genre": "チュウマイ"
 		},
 		"id": 867,
@@ -9704,6 +10568,7 @@
 		"altTitles": [],
 		"artist": "TAG",
 		"data": {
+			"duration": 138.875,
 			"genre": "チュウマイ"
 		},
 		"id": 868,
@@ -9714,6 +10579,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA vs Cranky",
 		"data": {
+			"duration": 149.818,
 			"genre": "チュウマイ"
 		},
 		"id": 869,
@@ -9724,6 +10590,7 @@
 		"altTitles": [],
 		"artist": "山本真央樹 vs Masahiro \"Godspeed\" Aoki (feat. Dylan Reavey)",
 		"data": {
+			"duration": 170.958,
 			"genre": "オンゲキ"
 		},
 		"id": 870,
@@ -9734,6 +10601,7 @@
 		"altTitles": [],
 		"artist": "ステラマリス「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 168.679,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 871,
@@ -9744,6 +10612,7 @@
 		"altTitles": [],
 		"artist": "オルタンシア「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 155.667,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 872,
@@ -9756,6 +10625,7 @@
 		"altTitles": [],
 		"artist": "KiRaRe「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 164.901,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 873,
@@ -9768,6 +10638,7 @@
 		"altTitles": [],
 		"artist": "Ino(chronoize)",
 		"data": {
+			"duration": 120.414,
 			"genre": "チュウマイ"
 		},
 		"id": 874,
@@ -9778,6 +10649,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：いちげきしゅーたーず！",
 		"data": {
+			"duration": 154.629,
 			"genre": "オンゲキ"
 		},
 		"id": 875,
@@ -9790,6 +10662,7 @@
 		"altTitles": [],
 		"artist": "P*Light「WACCA」",
 		"data": {
+			"duration": 127.667,
 			"genre": "VARIETY"
 		},
 		"id": 876,
@@ -9800,6 +10673,7 @@
 		"altTitles": [],
 		"artist": "DJ Noriken「WACCA」",
 		"data": {
+			"duration": 125.647,
 			"genre": "VARIETY"
 		},
 		"id": 877,
@@ -9810,6 +10684,7 @@
 		"altTitles": [],
 		"artist": "HARDCORE TANO*C & エリザベス（CV:大西沙織）「WACCA」",
 		"data": {
+			"duration": 122.595,
 			"genre": "VARIETY"
 		},
 		"id": 878,
@@ -9820,6 +10695,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 162.745,
 			"genre": "ボーナストラック"
 		},
 		"id": 879,
@@ -9832,6 +10708,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 162.745,
 			"genre": "ボーナストラック"
 		},
 		"id": 880,
@@ -9844,6 +10721,7 @@
 		"altTitles": [],
 		"artist": "曲：馬渕直純／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 162.745,
 			"genre": "ボーナストラック"
 		},
 		"id": 881,
@@ -9856,6 +10734,7 @@
 		"altTitles": [],
 		"artist": "TAKU1175 ft.駄々子",
 		"data": {
+			"duration": 150.857,
 			"genre": "チュウマイ"
 		},
 		"id": 882,
@@ -9868,6 +10747,7 @@
 		"altTitles": [],
 		"artist": "カタオカツグミ",
 		"data": {
+			"duration": 163.927,
 			"genre": "オンゲキ"
 		},
 		"id": 883,
@@ -9878,6 +10758,7 @@
 		"altTitles": [],
 		"artist": "テトラルキア「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 149.73,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 884,
@@ -9888,6 +10769,7 @@
 		"altTitles": [],
 		"artist": "トロワアンジュ「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 108.611,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 885,
@@ -9900,6 +10782,7 @@
 		"altTitles": [],
 		"artist": "お月さま交響曲",
 		"data": {
+			"duration": 135,
 			"genre": "チュウマイ"
 		},
 		"id": 886,
@@ -9910,6 +10793,7 @@
 		"altTitles": [],
 		"artist": "月ノ美兎",
 		"data": {
+			"duration": 166.517,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 887,
@@ -9922,6 +10806,7 @@
 		"altTitles": [],
 		"artist": "名取さな",
 		"data": {
+			"duration": 145.833,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 888,
@@ -9934,6 +10819,7 @@
 		"altTitles": [],
 		"artist": "てにをは",
 		"data": {
+			"duration": 132.353,
 			"genre": "niconico"
 		},
 		"id": 889,
@@ -9946,6 +10832,7 @@
 		"altTitles": [],
 		"artist": "稲葉曇",
 		"data": {
+			"duration": 153.469,
 			"genre": "niconico"
 		},
 		"id": 890,
@@ -9958,6 +10845,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ",
 		"data": {
+			"duration": 171.951,
 			"genre": "チュウマイ"
 		},
 		"id": 891,
@@ -9968,6 +10856,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 159.651,
 			"genre": "ボーナストラック"
 		},
 		"id": 892,
@@ -9980,6 +10869,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 159.651,
 			"genre": "ボーナストラック"
 		},
 		"id": 893,
@@ -9992,6 +10882,7 @@
 		"altTitles": [],
 		"artist": "naotyu- feat. 佐々木恵梨",
 		"data": {
+			"duration": 127.731,
 			"genre": "チュウマイ"
 		},
 		"id": 894,
@@ -10002,6 +10893,7 @@
 		"altTitles": [],
 		"artist": "litmus*",
 		"data": {
+			"duration": 143.437,
 			"genre": "オンゲキ"
 		},
 		"id": 895,
@@ -10012,6 +10904,7 @@
 		"altTitles": [],
 		"artist": "いるかアイス feat.ちょこ",
 		"data": {
+			"duration": 128.4,
 			"genre": "チュウマイ"
 		},
 		"id": 896,
@@ -10022,6 +10915,7 @@
 		"altTitles": [],
 		"artist": "Kobaryo「WACCA」",
 		"data": {
+			"duration": 137.878,
 			"genre": "VARIETY"
 		},
 		"id": 897,
@@ -10032,6 +10926,7 @@
 		"altTitles": [],
 		"artist": "USAO「WACCA」",
 		"data": {
+			"duration": 132.3,
 			"genre": "VARIETY"
 		},
 		"id": 898,
@@ -10042,6 +10937,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite & Massive New Krew feat. リリィ(CV:青木志貴)「WACCA」",
 		"data": {
+			"duration": 143.226,
 			"genre": "VARIETY"
 		},
 		"id": 899,
@@ -10052,6 +10948,7 @@
 		"altTitles": [],
 		"artist": "曲：塩野 海／歌：星咲 あかり(CV：赤尾 ひかる)、式宮 舞菜(CV：牧野 天音)",
 		"data": {
+			"duration": 167.294,
 			"genre": "オンゲキ"
 		},
 		"id": 900,
@@ -10064,6 +10961,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 152.771,
 			"genre": "オンゲキ"
 		},
 		"id": 901,
@@ -10076,6 +10974,7 @@
 		"altTitles": [],
 		"artist": "wotaku feat. SHIKI",
 		"data": {
+			"duration": 155.2,
 			"genre": "niconico"
 		},
 		"id": 902,
@@ -10086,6 +10985,7 @@
 		"altTitles": [],
 		"artist": "hanzo",
 		"data": {
+			"duration": 157.5,
 			"genre": "チュウマイ"
 		},
 		"id": 903,
@@ -10098,6 +10998,7 @@
 		"altTitles": [],
 		"artist": "Masahiro “Godspeed” Aoki",
 		"data": {
+			"duration": 158.769,
 			"genre": "チュウマイ"
 		},
 		"id": 904,
@@ -10108,6 +11009,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 125.81,
 			"genre": "チュウマイ"
 		},
 		"id": 905,
@@ -10118,6 +11020,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 152.771,
 			"genre": "ボーナストラック"
 		},
 		"id": 906,
@@ -10130,6 +11033,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 152.771,
 			"genre": "ボーナストラック"
 		},
 		"id": 907,
@@ -10142,6 +11046,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 152.771,
 			"genre": "ボーナストラック"
 		},
 		"id": 908,
@@ -10154,6 +11059,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 152.771,
 			"genre": "ボーナストラック"
 		},
 		"id": 909,
@@ -10166,6 +11072,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 152.771,
 			"genre": "ボーナストラック"
 		},
 		"id": 910,
@@ -10178,6 +11085,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 154.629,
 			"genre": "ボーナストラック"
 		},
 		"id": 911,
@@ -10190,6 +11098,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 154.629,
 			"genre": "ボーナストラック"
 		},
 		"id": 912,
@@ -10202,6 +11111,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 154.629,
 			"genre": "ボーナストラック"
 		},
 		"id": 913,
@@ -10215,6 +11125,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 154.629,
 			"genre": "ボーナストラック"
 		},
 		"id": 914,
@@ -10227,6 +11138,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous feat.藍月なくる",
 		"data": {
+			"duration": 135,
 			"genre": "チュウマイ"
 		},
 		"id": 915,
@@ -10239,6 +11151,7 @@
 		"altTitles": [],
 		"artist": "あず♪",
 		"data": {
+			"duration": 157.636,
 			"genre": "オンゲキ"
 		},
 		"id": 916,
@@ -10249,6 +11162,7 @@
 		"altTitles": [],
 		"artist": "ムラサメ (CV：佐藤 みかん) 「千恋＊万花」",
 		"data": {
+			"duration": 155.357,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 917,
@@ -10261,6 +11175,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 149.143,
 			"genre": "東方Project"
 		},
 		"id": 918,
@@ -10273,6 +11188,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 136.277,
 			"genre": "チュウマイ"
 		},
 		"id": 919,
@@ -10283,6 +11199,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 173.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 920,
@@ -10295,6 +11212,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 173.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 921,
@@ -10307,6 +11225,7 @@
 		"altTitles": [],
 		"artist": "曲：橘亮祐、篠崎あやと／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 173.6,
 			"genre": "ボーナストラック"
 		},
 		"id": 922,
@@ -10319,6 +11238,7 @@
 		"altTitles": [],
 		"artist": "loos feat. Meramipop",
 		"data": {
+			"duration": 85.313,
 			"genre": "チュウマイ"
 		},
 		"id": 923,
@@ -10329,6 +11249,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 83.396,
 			"genre": "チュウマイ"
 		},
 		"id": 924,
@@ -10339,6 +11260,7 @@
 		"altTitles": [],
 		"artist": "Tsukasa(Arte Refact)",
 		"data": {
+			"duration": 83.333,
 			"genre": "チュウマイ"
 		},
 		"id": 925,
@@ -10349,6 +11271,7 @@
 		"altTitles": [],
 		"artist": "Aiobahn feat. KOTOKO",
 		"data": {
+			"duration": 172.541,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 926,
@@ -10359,6 +11282,7 @@
 		"altTitles": [],
 		"artist": "She is Legend「ヘブンバーンズレッド」",
 		"data": {
+			"duration": 135.771,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 927,
@@ -10369,6 +11293,7 @@
 		"altTitles": [],
 		"artist": "onoken",
 		"data": {
+			"duration": 155.593,
 			"genre": "オンゲキ"
 		},
 		"id": 928,
@@ -10381,6 +11306,7 @@
 		"altTitles": [],
 		"artist": "わかどり",
 		"data": {
+			"duration": 130.986,
 			"genre": "オンゲキ"
 		},
 		"id": 929,
@@ -10391,6 +11317,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato(Dream Monster)／歌：逢坂 茜(CV：大空 直美)、高瀬 梨緒(CV：久保 ユリカ)、柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 148.937,
 			"genre": "オンゲキ"
 		},
 		"id": 930,
@@ -10401,6 +11328,7 @@
 		"altTitles": [],
 		"artist": "夏代孝明",
 		"data": {
+			"duration": 147.541,
 			"genre": "チュウマイ"
 		},
 		"id": 931,
@@ -10411,6 +11339,7 @@
 		"altTitles": [],
 		"artist": "EmoCosine + Synthion",
 		"data": {
+			"duration": 139.68,
 			"genre": "オンゲキ"
 		},
 		"id": 932,
@@ -10421,6 +11350,7 @@
 		"altTitles": [],
 		"artist": "Cranky VS MASAKI「グルーヴコースター」",
 		"data": {
+			"duration": 149.754,
 			"genre": "VARIETY"
 		},
 		"id": 933,
@@ -10431,6 +11361,7 @@
 		"altTitles": [],
 		"artist": "世阿弥「グルーヴコースター」",
 		"data": {
+			"duration": 134.201,
 			"genre": "VARIETY"
 		},
 		"id": 934,
@@ -10443,6 +11374,7 @@
 		"altTitles": [],
 		"artist": "Yamajet「グルーヴコースター」",
 		"data": {
+			"duration": 131.591,
 			"genre": "VARIETY"
 		},
 		"id": 935,
@@ -10455,6 +11387,7 @@
 		"altTitles": [],
 		"artist": "C-Show",
 		"data": {
+			"duration": 120,
 			"genre": "チュウマイ"
 		},
 		"id": 936,
@@ -10467,6 +11400,7 @@
 		"altTitles": [],
 		"artist": "Zekk",
 		"data": {
+			"duration": 136.216,
 			"genre": "チュウマイ"
 		},
 		"id": 937,
@@ -10479,6 +11413,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock(Dream Monster)／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 174.242,
 			"genre": "ボーナストラック"
 		},
 		"id": 938,
@@ -10491,6 +11426,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock(Dream Monster)／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 174.242,
 			"genre": "ボーナストラック"
 		},
 		"id": 939,
@@ -10503,6 +11439,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock(Dream Monster)／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 174.242,
 			"genre": "ボーナストラック"
 		},
 		"id": 940,
@@ -10515,6 +11452,7 @@
 		"altTitles": [],
 		"artist": "onoken",
 		"data": {
+			"duration": 159.153,
 			"genre": "オンゲキ"
 		},
 		"id": 941,
@@ -10525,6 +11463,7 @@
 		"altTitles": [],
 		"artist": "曲：下野 隼／歌：皇城 セツナ(CV：八巻 アンナ)、式宮 碧音(CV：髙橋 ミナミ)",
 		"data": {
+			"duration": 166.568,
 			"genre": "オンゲキ"
 		},
 		"id": 942,
@@ -10535,6 +11474,7 @@
 		"altTitles": [],
 		"artist": "温泉むすめ 日中早百合（CV:春野 杏）「温泉むすめ」",
 		"data": {
+			"duration": 163.358,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 943,
@@ -10547,6 +11487,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 151.448,
 			"genre": "チュウマイ"
 		},
 		"id": 944,
@@ -10557,6 +11498,7 @@
 		"altTitles": [],
 		"artist": "南ノ南",
 		"data": {
+			"duration": 154.909,
 			"genre": "niconico"
 		},
 		"id": 945,
@@ -10569,6 +11511,7 @@
 		"altTitles": [],
 		"artist": "ナナホシ管弦楽団/巡音ルカ/MORE MORE JUMP！「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 92.386,
 			"genre": "niconico"
 		},
 		"id": 946,
@@ -10581,6 +11524,7 @@
 		"altTitles": [],
 		"artist": "じん/初音ミク/Leo/need「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 134.315,
 			"genre": "niconico"
 		},
 		"id": 947,
@@ -10593,6 +11537,7 @@
 		"altTitles": [],
 		"artist": "Yooh",
 		"data": {
+			"duration": 148.712,
 			"genre": "チュウマイ"
 		},
 		"id": 948,
@@ -10603,6 +11548,7 @@
 		"altTitles": [],
 		"artist": "Neko Hacker feat.うごくちゃん",
 		"data": {
+			"duration": 141.75,
 			"genre": "チュウマイ"
 		},
 		"id": 949,
@@ -10615,6 +11561,7 @@
 		"altTitles": [],
 		"artist": "uma vs. ガリガリさむし",
 		"data": {
+			"duration": 132.482,
 			"genre": "オンゲキ"
 		},
 		"id": 950,
@@ -10627,6 +11574,7 @@
 		"altTitles": [],
 		"artist": "Reku Mochizuki",
 		"data": {
+			"duration": 120.811,
 			"genre": "オンゲキ"
 		},
 		"id": 951,
@@ -10637,6 +11585,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 184.966,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 952,
@@ -10652,6 +11601,7 @@
 		"altTitles": [],
 		"artist": "なきそ",
 		"data": {
+			"duration": 122.087,
 			"genre": "niconico"
 		},
 		"id": 953,
@@ -10664,6 +11614,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ & 脇眞富（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 158.382,
 			"genre": "ボーナストラック"
 		},
 		"id": 954,
@@ -10676,6 +11627,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ & 脇眞富（Arte Refact）／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 158.382,
 			"genre": "ボーナストラック"
 		},
 		"id": 955,
@@ -10688,6 +11640,7 @@
 		"altTitles": [],
 		"artist": "鳳 ここな(CV.石見舞菜香)、静香(CV.長谷川育美)、カトリナ・グリーベル(CV.天城サリー)、新妻八恵(CV.長縄まりあ)、柳場ぱんだ(CV.大空直美)、流石知冴(CV.佐々木李子)",
 		"data": {
+			"duration": 116.035,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 956,
@@ -10700,6 +11653,7 @@
 		"altTitles": [],
 		"artist": "Aiobahn feat. KOTOKO",
 		"data": {
+			"duration": 163.502,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 957,
@@ -10710,6 +11664,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 145.636,
 			"genre": "niconico"
 		},
 		"id": 958,
@@ -10722,6 +11677,7 @@
 		"altTitles": [],
 		"artist": "Toby Fox「UNDERTALE」",
 		"data": {
+			"duration": 165.75,
 			"genre": "VARIETY"
 		},
 		"id": 959,
@@ -10732,6 +11688,7 @@
 		"altTitles": [],
 		"artist": "Getty vs. DJ DiA",
 		"data": {
+			"duration": 116.211,
 			"genre": "VARIETY"
 		},
 		"id": 960,
@@ -10742,6 +11699,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 171.689,
 			"genre": "オンゲキ"
 		},
 		"id": 961,
@@ -10754,6 +11712,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：星咲 あかり(CV：赤尾 ひかる)、珠洲島 有栖(CV：長縄 まりあ)、日向 千夏(CV：岡咲 美保)、皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 149.511,
 			"genre": "オンゲキ"
 		},
 		"id": 962,
@@ -10764,6 +11723,7 @@
 		"altTitles": [],
 		"artist": "曲：竹内サティフォ／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 147.36,
 			"genre": "オンゲキ"
 		},
 		"id": 963,
@@ -10774,6 +11734,7 @@
 		"altTitles": [],
 		"artist": "曲：森羅万象／歌：藤沢 柚子(CV：久保田 梨沙)",
 		"data": {
+			"duration": 144.118,
 			"genre": "オンゲキ"
 		},
 		"id": 964,
@@ -10786,6 +11747,7 @@
 		"altTitles": [],
 		"artist": "曲：5u5h1／歌：三角 葵(CV：春野 杏)",
 		"data": {
+			"duration": 160.889,
 			"genre": "オンゲキ"
 		},
 		"id": 965,
@@ -10796,6 +11758,7 @@
 		"altTitles": [],
 		"artist": "Yuta Imai",
 		"data": {
+			"duration": 170.609,
 			"genre": "オンゲキ"
 		},
 		"id": 966,
@@ -10806,6 +11769,7 @@
 		"altTitles": [],
 		"artist": "曲：塩野 海／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 167.294,
 			"genre": "ボーナストラック"
 		},
 		"id": 967,
@@ -10818,6 +11782,7 @@
 		"altTitles": [],
 		"artist": "曲：塩野 海／歌：式宮 舞菜(CV：牧野 天音)",
 		"data": {
+			"duration": 167.294,
 			"genre": "ボーナストラック"
 		},
 		"id": 968,
@@ -10830,6 +11795,7 @@
 		"altTitles": [],
 		"artist": "曲：下野 隼／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 166.568,
 			"genre": "ボーナストラック"
 		},
 		"id": 969,
@@ -10842,6 +11808,7 @@
 		"altTitles": [],
 		"artist": "曲：下野 隼／歌：式宮 碧音(CV：髙橋 ミナミ)",
 		"data": {
+			"duration": 166.568,
 			"genre": "ボーナストラック"
 		},
 		"id": 970,
@@ -10854,6 +11821,7 @@
 		"altTitles": [],
 		"artist": "千寿 暦(CV.鳥部万里子)、ラモーナ・ウォルフ(CV.田中美海)、王 雪(CV.花井美春)、リリヤ・クルトベイ(CV.安齋由香里)、与那国緋花里(CV.下地紫野)",
 		"data": {
+			"duration": 95.647,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 971,
@@ -10866,6 +11834,7 @@
 		"altTitles": [],
 		"artist": "七条レタスグループ",
 		"data": {
+			"duration": 120.016,
 			"genre": "東方Project"
 		},
 		"id": 972,
@@ -10878,6 +11847,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 149.511,
 			"genre": "ボーナストラック"
 		},
 		"id": 973,
@@ -10890,6 +11860,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 149.511,
 			"genre": "ボーナストラック"
 		},
 		"id": 974,
@@ -10903,6 +11874,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 149.511,
 			"genre": "ボーナストラック"
 		},
 		"id": 975,
@@ -10915,6 +11887,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 149.511,
 			"genre": "ボーナストラック"
 		},
 		"id": 976,
@@ -10927,6 +11900,7 @@
 		"altTitles": [],
 		"artist": "あべにゅうぷろじぇくと feat.エンジェルオールスターズ(めぐる・すみれ・遥・葵・クルミ・テスラ・ナイン)",
 		"data": {
+			"duration": 157.371,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 977,
@@ -10939,6 +11913,7 @@
 		"altTitles": [],
 		"artist": "周防パトラ",
 		"data": {
+			"duration": 149.538,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 978,
@@ -10951,6 +11926,7 @@
 		"altTitles": [],
 		"artist": "周防パトラ",
 		"data": {
+			"duration": 164.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 979,
@@ -10963,6 +11939,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 151.343,
 			"genre": "ボーナストラック"
 		},
 		"id": 980,
@@ -10975,6 +11952,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 151.343,
 			"genre": "ボーナストラック"
 		},
 		"id": 981,
@@ -10987,6 +11965,7 @@
 		"altTitles": [],
 		"artist": "曲：中土智博／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 151.343,
 			"genre": "ボーナストラック"
 		},
 		"id": 982,
@@ -10999,6 +11978,7 @@
 		"altTitles": [],
 		"artist": "a_hisa",
 		"data": {
+			"duration": 146.667,
 			"genre": "オンゲキ"
 		},
 		"id": 983,
@@ -11009,6 +11989,7 @@
 		"altTitles": [],
 		"artist": "佐藤 優樹",
 		"data": {
+			"duration": 131.12,
 			"genre": "オンゲキ"
 		},
 		"id": 984,
@@ -11019,6 +12000,7 @@
 		"altTitles": [],
 		"artist": "doriko",
 		"data": {
+			"duration": 153,
 			"genre": "niconico"
 		},
 		"id": 985,
@@ -11032,6 +12014,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 157.333,
 			"genre": "niconico"
 		},
 		"id": 986,
@@ -11044,6 +12027,7 @@
 		"altTitles": [],
 		"artist": "なみぐる feat.ずんだもん",
 		"data": {
+			"duration": 155.459,
 			"genre": "niconico"
 		},
 		"id": 987,
@@ -11056,6 +12040,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 149.063,
 			"genre": "チュウマイ"
 		},
 		"id": 988,
@@ -11068,6 +12053,7 @@
 		"altTitles": [],
 		"artist": "ぺのれり",
 		"data": {
+			"duration": 144.118,
 			"genre": "チュウマイ"
 		},
 		"id": 989,
@@ -11078,6 +12064,7 @@
 		"altTitles": [],
 		"artist": "Lite Show Magic「グルーヴコースター」",
 		"data": {
+			"duration": 130.595,
 			"genre": "VARIETY"
 		},
 		"id": 990,
@@ -11090,6 +12077,7 @@
 		"altTitles": [],
 		"artist": "xi「グルーヴコースター」",
 		"data": {
+			"duration": 152.256,
 			"genre": "VARIETY"
 		},
 		"id": 991,
@@ -11100,6 +12088,7 @@
 		"altTitles": [],
 		"artist": "sky_delta「グルーヴコースター」",
 		"data": {
+			"duration": 116.505,
 			"genre": "VARIETY"
 		},
 		"id": 992,
@@ -11110,6 +12099,7 @@
 		"altTitles": [],
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
+			"duration": 146.62,
 			"genre": "VARIETY"
 		},
 		"id": 993,
@@ -11122,6 +12112,7 @@
 		"altTitles": [],
 		"artist": "tn-shi",
 		"data": {
+			"duration": 163.333,
 			"genre": "VARIETY"
 		},
 		"id": 994,
@@ -11132,6 +12123,7 @@
 		"altTitles": [],
 		"artist": "打打だいず vs. siromaru vs. Tanchiky",
 		"data": {
+			"duration": 148.429,
 			"genre": "オンゲキ"
 		},
 		"id": 995,
@@ -11144,6 +12136,7 @@
 		"altTitles": [],
 		"artist": "PRASTIK DANCEFLOOR",
 		"data": {
+			"duration": 144.205,
 			"genre": "オンゲキ"
 		},
 		"id": 996,
@@ -11156,6 +12149,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 147.606,
 			"genre": "チュウマイ"
 		},
 		"id": 997,
@@ -11168,6 +12162,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 155.571,
 			"genre": "niconico"
 		},
 		"id": 998,
@@ -11180,6 +12175,7 @@
 		"altTitles": [],
 		"artist": "アスタレーヴ「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 159.863,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 999,
@@ -11190,6 +12186,7 @@
 		"altTitles": [],
 		"artist": "曲：卯乃／歌：珠洲島 有栖(CV：長縄 まりあ)、西館 ハク(CV：佐藤 実季)",
 		"data": {
+			"duration": 108.857,
 			"genre": "オンゲキ"
 		},
 		"id": 1000,
@@ -11202,6 +12199,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：珠洲島 有栖(CV：長縄 まりあ)、皇城 セツナ(CV：八巻 アンナ)、柏木 咲姫(CV：石見 舞菜香)、日向 千夏(CV：岡咲 美保)、井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 152.79,
 			"genre": "オンゲキ"
 		},
 		"id": 1001,
@@ -11212,6 +12210,7 @@
 		"altTitles": [],
 		"artist": "トライアムトーン「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 162.476,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1002,
@@ -11224,6 +12223,7 @@
 		"altTitles": [],
 		"artist": "アルシュシュ「Re:ステージ！プリズムステップ」",
 		"data": {
+			"duration": 103.597,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1003,
@@ -11236,6 +12236,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato(Dream Monster)／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 148.937,
 			"genre": "ボーナストラック"
 		},
 		"id": 1004,
@@ -11248,6 +12249,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato(Dream Monster)／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 148.937,
 			"genre": "ボーナストラック"
 		},
 		"id": 1005,
@@ -11260,6 +12262,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato(Dream Monster)／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 148.937,
 			"genre": "ボーナストラック"
 		},
 		"id": 1006,
@@ -11272,6 +12275,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1007,
@@ -11284,6 +12288,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1008,
@@ -11296,6 +12301,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1009,
@@ -11309,6 +12315,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1010,
@@ -11321,6 +12328,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1011,
@@ -11333,6 +12341,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 149.916,
 			"genre": "チュウマイ"
 		},
 		"id": 1012,
@@ -11343,6 +12352,7 @@
 		"altTitles": [],
 		"artist": "しーけー feat.ricono",
 		"data": {
+			"duration": 151.563,
 			"genre": "チュウマイ"
 		},
 		"id": 1013,
@@ -11355,6 +12365,7 @@
 		"altTitles": [],
 		"artist": "RouteHeart（七海ロナ・藤宮コトハ）",
 		"data": {
+			"duration": 155.625,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1014,
@@ -11367,6 +12378,7 @@
 		"altTitles": [],
 		"artist": "Sputrip（暁月クララ・香鳴ハノン・常磐カナメ）",
 		"data": {
+			"duration": 153.443,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1015,
@@ -11379,6 +12391,7 @@
 		"altTitles": [],
 		"artist": "REGALILIA（江波キョウカ・鬼多見アユム）",
 		"data": {
+			"duration": 136.389,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1016,
@@ -11391,6 +12404,7 @@
 		"altTitles": [],
 		"artist": "Endorfin.",
 		"data": {
+			"duration": 139.784,
 			"genre": "チュウマイ"
 		},
 		"id": 1017,
@@ -11403,6 +12417,7 @@
 		"altTitles": [],
 		"artist": "USAO & DJ Genki feat. ルーン(CV:河瀬茉希)「WACCA」",
 		"data": {
+			"duration": 141.6,
 			"genre": "VARIETY"
 		},
 		"id": 1018,
@@ -11413,6 +12428,7 @@
 		"altTitles": [],
 		"artist": "\"漆黒\"の堕天使《Gram》†Versus† \"聖刻\"の熾天使《Gram》「WACCA」",
 		"data": {
+			"duration": 145.366,
 			"genre": "VARIETY"
 		},
 		"id": 1019,
@@ -11423,6 +12439,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE「WACCA」",
 		"data": {
+			"duration": 145.826,
 			"genre": "VARIETY"
 		},
 		"id": 1020,
@@ -11435,6 +12452,7 @@
 		"altTitles": [],
 		"artist": "paraoka",
 		"data": {
+			"duration": 123.614,
 			"genre": "VARIETY"
 		},
 		"id": 1021,
@@ -11445,6 +12463,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 157.612,
 			"genre": "niconico"
 		},
 		"id": 1022,
@@ -11457,6 +12476,7 @@
 		"altTitles": [],
 		"artist": "Kai",
 		"data": {
+			"duration": 129.846,
 			"genre": "niconico"
 		},
 		"id": 1023,
@@ -11469,6 +12489,7 @@
 		"altTitles": [],
 		"artist": "千寿 いろは(CV.岡咲 美保)、白丸 美兎(CV.近藤 玲奈)、阿岐留 カミラ(CV.若井 友希)、猫足 蕾(CV.芹澤 優)、本巣 叶羽(CV.赤尾 ひかる)",
 		"data": {
+			"duration": 92.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1024,
@@ -11482,6 +12503,7 @@
 		"altTitles": [],
 		"artist": "連尺野 初魅(CV.葵井 歌菜)、烏森 大黒(CV.Lynn)、舎人 仁花子(CV.斉藤 朱夏)、萬 容(CV.山村 響)、筆島 しぐれ(CV.吉岡 麻耶)",
 		"data": {
+			"duration": 102,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1025,
@@ -11492,6 +12514,7 @@
 		"altTitles": [],
 		"artist": "静香(CV.長谷川育美)",
 		"data": {
+			"duration": 153.9,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1026,
@@ -11502,6 +12525,7 @@
 		"altTitles": [],
 		"artist": "Mr.Asyu",
 		"data": {
+			"duration": 153.281,
 			"genre": "VARIETY"
 		},
 		"id": 1027,
@@ -11512,6 +12536,7 @@
 		"altTitles": [],
 		"artist": "q/stol",
 		"data": {
+			"duration": 152.393,
 			"genre": "オンゲキ"
 		},
 		"id": 1028,
@@ -11522,6 +12547,7 @@
 		"altTitles": [],
 		"artist": "DÉ DÉ MOUSE",
 		"data": {
+			"duration": 152.111,
 			"genre": "オンゲキ"
 		},
 		"id": 1029,
@@ -11532,6 +12558,7 @@
 		"altTitles": [],
 		"artist": "Acotto",
 		"data": {
+			"duration": 136.235,
 			"genre": "オンゲキ"
 		},
 		"id": 1030,
@@ -11542,6 +12569,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE vs DJ Myosuke feat. DELUTAYA「Arcaea」",
 		"data": {
+			"duration": 161.854,
 			"genre": "VARIETY"
 		},
 		"id": 1031,
@@ -11554,6 +12582,7 @@
 		"altTitles": [],
 		"artist": "ぺのれり「Arcaea」",
 		"data": {
+			"duration": 141.758,
 			"genre": "VARIETY"
 		},
 		"id": 1032,
@@ -11564,6 +12593,7 @@
 		"altTitles": [],
 		"artist": "テヅカ × Aoi feat.桃雛なの「Arcaea」",
 		"data": {
+			"duration": 135.273,
 			"genre": "VARIETY"
 		},
 		"id": 1033,
@@ -11576,6 +12606,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE vs USAO「Arcaea」",
 		"data": {
+			"duration": 145.171,
 			"genre": "VARIETY"
 		},
 		"id": 1034,
@@ -11589,6 +12620,7 @@
 		"altTitles": [],
 		"artist": "La prière(棗いつき、藍月なくる、nayuta)",
 		"data": {
+			"duration": 137.294,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1035,
@@ -11601,6 +12633,7 @@
 		"altTitles": [],
 		"artist": "La prière(棗いつき、藍月なくる、nayuta)",
 		"data": {
+			"duration": 104.889,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1036,
@@ -11613,6 +12646,7 @@
 		"altTitles": [],
 		"artist": "蓮ノ空女学院スクールアイドルクラブ",
 		"data": {
+			"duration": 161.623,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1037,
@@ -11623,6 +12657,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 147.914,
 			"genre": "チュウマイ"
 		},
 		"id": 1038,
@@ -11633,6 +12668,7 @@
 		"altTitles": [],
 		"artist": "DJ Raisei",
 		"data": {
+			"duration": 128.471,
 			"genre": "チュウマイ"
 		},
 		"id": 1039,
@@ -11648,6 +12684,7 @@
 		"altTitles": [],
 		"artist": "光収容",
 		"data": {
+			"duration": 125,
 			"genre": "niconico"
 		},
 		"id": 1040,
@@ -11660,6 +12697,7 @@
 		"altTitles": [],
 		"artist": "TOKOTOKO（西沢さんP）",
 		"data": {
+			"duration": 159.324,
 			"genre": "niconico"
 		},
 		"id": 1041,
@@ -11672,6 +12710,7 @@
 		"altTitles": [],
 		"artist": "月紫アリア",
 		"data": {
+			"duration": 179.348,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1042,
@@ -11684,6 +12723,7 @@
 		"altTitles": [],
 		"artist": "Re:AcT",
 		"data": {
+			"duration": 160.952,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1043,
@@ -11694,6 +12734,7 @@
 		"altTitles": [],
 		"artist": "稀羽すう",
 		"data": {
+			"duration": 127.232,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1044,
@@ -11704,6 +12745,7 @@
 		"altTitles": [],
 		"artist": "テヅカ feat. 獅子神レオナ",
 		"data": {
+			"duration": 153.786,
 			"genre": "チュウマイ"
 		},
 		"id": 1045,
@@ -11716,6 +12758,7 @@
 		"altTitles": [],
 		"artist": "曲：大国奏音／歌：東雲 つむぎ(CV：和泉 風花)、井之原 小星(CV：ももの はるな)、星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 161.053,
 			"genre": "オンゲキ"
 		},
 		"id": 1046,
@@ -11728,6 +12771,7 @@
 		"altTitles": [],
 		"artist": "MYUKKE.",
 		"data": {
+			"duration": 135.2,
 			"genre": "オンゲキ"
 		},
 		"id": 1047,
@@ -11738,6 +12782,7 @@
 		"altTitles": [],
 		"artist": "Shade feat.片霧烈火",
 		"data": {
+			"duration": 157.119,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1048,
@@ -11748,6 +12793,7 @@
 		"altTitles": [],
 		"artist": "橋本みゆき",
 		"data": {
+			"duration": 149,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1049,
@@ -11760,6 +12806,7 @@
 		"altTitles": [],
 		"artist": "TAK x Sobrem",
 		"data": {
+			"duration": 155.551,
 			"genre": "VARIETY"
 		},
 		"id": 1050,
@@ -11770,6 +12817,7 @@
 		"altTitles": [],
 		"artist": "ESTi",
 		"data": {
+			"duration": 122.128,
 			"genre": "VARIETY"
 		},
 		"id": 1051,
@@ -11780,6 +12828,7 @@
 		"altTitles": [],
 		"artist": "HAYAKO",
 		"data": {
+			"duration": 126.047,
 			"genre": "VARIETY"
 		},
 		"id": 1052,
@@ -11790,6 +12839,7 @@
 		"altTitles": [],
 		"artist": "Lin-G",
 		"data": {
+			"duration": 108.857,
 			"genre": "VARIETY"
 		},
 		"id": 1053,
@@ -11800,6 +12850,7 @@
 		"altTitles": [],
 		"artist": "曲：Kijibato／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
+			"duration": 177.295,
 			"genre": "オンゲキ"
 		},
 		"id": 1054,
@@ -11810,6 +12861,7 @@
 		"altTitles": [],
 		"artist": "達見 恵 featured by 佐野宏晃",
 		"data": {
+			"duration": 161.486,
 			"genre": "チュウマイ"
 		},
 		"id": 1055,
@@ -11820,6 +12872,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：星咲 あかり(CV：赤尾 ひかる)",
 		"data": {
+			"duration": 150.216,
 			"genre": "ボーナストラック"
 		},
 		"id": 1056,
@@ -11832,6 +12885,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：桜井 春菜(CV：近藤 玲奈)",
 		"data": {
+			"duration": 150.216,
 			"genre": "ボーナストラック"
 		},
 		"id": 1057,
@@ -11844,6 +12898,7 @@
 		"altTitles": [],
 		"artist": "曲：山本恭平（Arte Refact）／歌：逢坂 茜(CV：大空 直美)",
 		"data": {
+			"duration": 150.216,
 			"genre": "ボーナストラック"
 		},
 		"id": 1058,
@@ -11856,6 +12911,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 142.125,
 			"genre": "ボーナストラック"
 		},
 		"id": 1059,
@@ -11868,6 +12924,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 142.125,
 			"genre": "ボーナストラック"
 		},
 		"id": 1060,
@@ -11880,6 +12937,7 @@
 		"altTitles": [],
 		"artist": "曲：篠崎あやと、橘亮祐／歌：東雲 つむぎ(CV：和泉 風花)",
 		"data": {
+			"duration": 142.125,
 			"genre": "ボーナストラック"
 		},
 		"id": 1061,
@@ -11892,6 +12950,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 134.857,
 			"genre": "チュウマイ"
 		},
 		"id": 1062,
@@ -11902,6 +12961,7 @@
 		"altTitles": [],
 		"artist": "曲：アオワイファイ／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 163.432,
 			"genre": "オンゲキ"
 		},
 		"id": 1063,
@@ -11912,6 +12972,7 @@
 		"altTitles": [],
 		"artist": "曲：ヘリP／歌：Trium Tone＆⊿TRiEDGE",
 		"data": {
+			"duration": 171.25,
 			"genre": "オンゲキ"
 		},
 		"id": 1064,
@@ -11922,6 +12983,7 @@
 		"altTitles": [],
 		"artist": "ミツキヨ",
 		"data": {
+			"duration": 153.3,
 			"genre": "オンゲキ"
 		},
 		"id": 1065,
@@ -11932,6 +12994,7 @@
 		"altTitles": [],
 		"artist": "ARForest",
 		"data": {
+			"duration": 142.5,
 			"genre": "オンゲキ"
 		},
 		"id": 1066,
@@ -11942,6 +13005,7 @@
 		"altTitles": [],
 		"artist": "COOL&CREATE feat.ビートまりおとまろん「東方ダンマクカグラ」",
 		"data": {
+			"duration": 134.978,
 			"genre": "東方Project"
 		},
 		"id": 1067,
@@ -11954,6 +13018,7 @@
 		"altTitles": [],
 		"artist": "にじさんじ",
 		"data": {
+			"duration": 171.869,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1068,
@@ -11964,6 +13029,7 @@
 		"altTitles": [],
 		"artist": "蓮ノ空女学院スクールアイドルクラブ",
 		"data": {
+			"duration": 166.324,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1069,
@@ -11974,6 +13040,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 125.69,
 			"genre": "niconico"
 		},
 		"id": 1070,
@@ -11986,6 +13053,7 @@
 		"altTitles": [],
 		"artist": "サツキ feat.初音ミク・重音テト",
 		"data": {
+			"duration": 157.297,
 			"genre": "niconico"
 		},
 		"id": 1071,
@@ -11998,6 +13066,7 @@
 		"altTitles": [],
 		"artist": "吉田夜世",
 		"data": {
+			"duration": 140.588,
 			"genre": "niconico"
 		},
 		"id": 1072,
@@ -12010,6 +13079,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 147.225,
 			"genre": "VARIETY"
 		},
 		"id": 1073,
@@ -12020,6 +13090,7 @@
 		"altTitles": [],
 		"artist": "ああああ",
 		"data": {
+			"duration": 126.612,
 			"genre": "VARIETY"
 		},
 		"id": 1074,
@@ -12032,6 +13103,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters AYA",
 		"data": {
+			"duration": 148.929,
 			"genre": "チュウマイ"
 		},
 		"id": 1075,
@@ -12044,6 +13116,7 @@
 		"altTitles": [],
 		"artist": "Tanchiky feat.からめる",
 		"data": {
+			"duration": 145.172,
 			"genre": "オンゲキ"
 		},
 		"id": 1076,
@@ -12056,6 +13129,7 @@
 		"altTitles": [],
 		"artist": "アーリャ（CV：上坂すみれ）",
 		"data": {
+			"duration": 98.736,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1077,
@@ -12068,6 +13142,7 @@
 		"altTitles": [],
 		"artist": "星街すいせい(ホロライブ)",
 		"data": {
+			"duration": 168,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1078,
@@ -12080,6 +13155,7 @@
 		"altTitles": [],
 		"artist": "B小町 ルビー（CV：伊駒ゆりえ）、有馬かな（CV：潘めぐみ）、MEMちょ（CV：大久保瑠美）",
 		"data": {
+			"duration": 101.932,
 			"genre": "POPS＆ANIME"
 		},
 		"id": 1079,
@@ -12090,6 +13166,7 @@
 		"altTitles": [],
 		"artist": "曲：eba／歌：高瀬 梨緒(CV：久保 ユリカ)",
 		"data": {
+			"duration": 143.505,
 			"genre": "ボーナストラック"
 		},
 		"id": 1080,
@@ -12102,6 +13179,7 @@
 		"altTitles": [],
 		"artist": "曲：eba／歌：結城 莉玖(CV：朝日奈 丸佳)",
 		"data": {
+			"duration": 143.505,
 			"genre": "ボーナストラック"
 		},
 		"id": 1081,
@@ -12114,6 +13192,7 @@
 		"altTitles": [],
 		"artist": "曲：eba／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 143.505,
 			"genre": "ボーナストラック"
 		},
 		"id": 1082,
@@ -12126,6 +13205,7 @@
 		"altTitles": [],
 		"artist": "曲：渡部チェル／歌：藤沢 柚子(CV：保科 李沙)",
 		"data": {
+			"duration": 152.79,
 			"genre": "ボーナストラック"
 		},
 		"id": 1083,

--- a/seeds/scripts/rerunners/ongeki/parse-song-duration.ts
+++ b/seeds/scripts/rerunners/ongeki/parse-song-duration.ts
@@ -1,0 +1,146 @@
+/* eslint-disable no-await-in-loop */
+import { Command, InvalidArgumentError } from "commander";
+import { exec } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ChartDocument, SongDocument } from "tachi-common";
+import { ReadCollection, WriteCollection } from "../../util";
+import { XMLParser } from "fast-xml-parser";
+import { PathLike } from "fs";
+
+const command = new Command()
+	.requiredOption("-v, --vgms <path-to-vgmstream-cli>")
+	.requiredOption("-d, --data <path-with-AXXX>")
+	.requiredOption("-g, --game <ongeki|chunithm>")
+	.parse(process.argv);
+
+const options = command.opts();
+const vgmsPath = options.vgms;
+const optPath = options.data;
+const game = options.game;
+
+const readOpt = async (
+	musicPath: string,
+	charts: ChartDocument<"ongeki:Single" | "chunithm:Single">[],
+	songs: SongDocument<"ongeki" | "chunithm">[]
+) => {
+	let musicDir: string[];
+	try {
+		musicDir = await fs.readdir(musicPath);
+	} catch (_) {
+		// musicless opt, most likely
+		return;
+	}
+
+	const parser = new XMLParser();
+	for (const songPath of musicDir) {
+		const p = path.join(musicPath, songPath);
+		if (!(await fs.stat(p)).isDirectory()) {
+			console.log(`${p}: not a directory`);
+			continue;
+		}
+		const songDir = await fs.readdir(p);
+		for (const f of songDir) {
+			if (f === "Music.xml") {
+				const parsed = parser.parse(await fs.readFile(path.join(p, f)));
+
+				let sourceId;
+				let id;
+				if (game === "ongeki") {
+					sourceId = parsed.MusicData.MusicSourceName.id;
+					id = parsed.MusicData.Name.id;
+				} else {
+					sourceId = parsed.MusicData.cueFileName.id;
+					id = parsed.MusicData.name.id;
+				}
+
+				const chart = charts.find((c) => c.data.inGameID === id);
+				if (chart === undefined) {
+					if (!(game === "chunithm" && id >= 8000)) {
+						console.error(`Song #${id}: not present in the seeds`);
+					}
+					continue;
+				}
+				const song = songs.find((s) => s.id === chart.songID);
+				if (song === undefined) {
+					console.error(`Song #${id}: orphan`);
+					continue;
+				}
+
+				if ("duration" in song.data) {
+					continue;
+				}
+
+				const padded4 = `${sourceId}`.padStart(4, "0");
+				const padded6 = `${sourceId}`.padStart(6, "0");
+				let cuePath: PathLike;
+				if (game === "ongeki") {
+					cuePath = path.join(
+						p,
+						"..",
+						"..",
+						"musicsource",
+						`musicsource${padded4}`,
+						`music${padded4}.awb`
+					);
+				} else {
+					cuePath = path.join(
+						p,
+						"..",
+						"..",
+						"cueFile",
+						`cueFile${padded6}`,
+						`music${padded4}.awb`
+					);
+				}
+
+				try {
+					await fs.stat(cuePath);
+				} catch (_) {
+					console.error(`Song ${id}: MISSING (expected: ${cuePath}) [${song.title}]`);
+					continue;
+				}
+
+				/* eslint-disable-next-line */
+				await new Promise<void>((resolve, reject) => {
+					exec(`${vgmsPath} -m -I ${cuePath}`, (err, stdout) => {
+						if (err) {
+							reject(new Error(`${err}`));
+						}
+						const res = JSON.parse(stdout);
+						if (res.sampleRate !== 48000) {
+							console.log(`Warning: Song #${id}'s sample rate is ${res.sampleRate}`);
+						}
+						const duration = res.numberOfSamples / res.sampleRate;
+
+						song.data.duration = Number(duration.toFixed(3));
+						console.log(`Song #${id}: ${song.data.duration}`);
+
+						resolve();
+					});
+				});
+			}
+		}
+	}
+};
+
+const main = async () => {
+	if (game !== "ongeki" && game !== "chunithm") {
+		throw new InvalidArgumentError("Bad game");
+	}
+	const charts = ReadCollection(`charts-${game}.json`);
+	const songs = ReadCollection(`songs-${game}.json`);
+	const dir = await fs.readdir(optPath);
+	const promises: Promise<void>[] = [];
+	for (const opt of dir) {
+		if (opt.startsWith("A") && opt.length === 4) {
+			promises.push(readOpt(path.join(optPath, opt, "music"), charts, songs));
+		}
+	}
+
+	await Promise.all(promises);
+
+	WriteCollection(`songs-${game}.json`, songs);
+};
+
+main();

--- a/server/src/test-utils/mock-db/songs-chunithm.json
+++ b/server/src/test-utils/mock-db/songs-chunithm.json
@@ -15,7 +15,8 @@
 		"artist": "分島花音「selector infected WIXOSS」",
 		"data": {
 			"displayVersion": "crystalplus",
-			"genre": "POPS & ANIME"
+			"genre": "POPS & ANIME",
+			"duration": 120
 		},
 		"id": 956,
 		"searchTerms": [],

--- a/server/src/test-utils/mock-db/songs-ongeki.json
+++ b/server/src/test-utils/mock-db/songs-ongeki.json
@@ -3,7 +3,8 @@
 		"altTitles": ["SENOTETOHETSUTEITSUTENNO"],
 		"artist": "本城香澄（CV：岩橋由佳）「Re:ステージ！プリズムステップ」",
 		"data": {
-			"genre": "POPS＆ANIME"
+			"genre": "POPS＆ANIME",
+			"duration": 120
 		},
 		"id": 683,
 		"searchTerms": [],

--- a/server/src/test-utils/test-data.ts
+++ b/server/src/test-utils/test-data.ts
@@ -1470,6 +1470,7 @@ export const TestingOngekiSongConverter: SongDocument<"ongeki"> = {
 	artist: "本城香澄（CV：岩橋由佳）「Re:ステージ！プリズムステップ」",
 	data: {
 		genre: "POPS＆ANIME",
+		duration: 120,
 	},
 	id: 683,
 	searchTerms: [],
@@ -1496,6 +1497,7 @@ export const TestingChunithmSongConverter: SongDocument<"chunithm"> = {
 	data: {
 		displayVersion: "crystalplus",
 		genre: "POPS & ANIME",
+		duration: 120,
 	},
 	id: 956,
 	searchTerms: [],


### PR DESCRIPTION
![screenshot](https://github.com/user-attachments/assets/092de3c8-5de5-4769-9739-d0d454797961)

Re-purposed the Ongeki score and life graphs for Chunithm. Aside from timestamps, the picture contains real data. I went with S+ baseline because Chunithm scores are extremely top-heavy. 