### PR TITLE
seed: SDVX Konasute Song Pack vol. 25 + IIDX INF Monthly June 2025

### DIFF
--- a/seeds/collections/charts-sdvx.json
+++ b/seeds/collections/charts-sdvx.json
@@ -159327,5 +159327,305 @@
 		"versions": [
 			"exceed"
 		]
+	},
+	{
+		"chartID": "b99ad0fa73af8ed151336c1bfd562ebfa909fb1f",
+		"data": {
+			"inGameID": 1999
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2336,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "815930a92f1e3f20ead7804e292dbfa27bc7eff0",
+		"data": {
+			"inGameID": 1999
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"songID": 2336,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "4b4858f6859bcad5ea512bd3fbda506d36b0d0af",
+		"data": {
+			"inGameID": 1999
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"songID": 2336,
+		"versions": [
+			"konaste"
+		]
+	},
+		{
+		"chartID": "4a87cd8d77cc9cdec294751545c73d223fd62d87",
+		"data": {
+			"inGameID": 1999
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2336,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "8e14c6fd47c3b4f500f6e9556a2e6599fc68f3e8",
+		"data": {
+			"inGameID": 2010
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2337,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "ee750f17fac9ee2bc1f7e44a22f25052412797c4",
+		"data": {
+			"inGameID": 2010
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2337,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "18a4552bf6f14f6016f6d0eb2cf6701ca05161c8",
+		"data": {
+			"inGameID": 2010
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2337,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "e1be33e4800c2aee5416bf293ba57228dda1d5b3",
+		"data": {
+			"inGameID": 2010
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2337,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "3ce40edbf25dc38f8595f86b46775ed59afd76fc",
+		"data": {
+			"inGameID": 2013
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2338,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "842a138343f82587d713acc06178864011bf36f5",
+		"data": {
+			"inGameID": 2013
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2338,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "8acd6f5512493d1e65825462fb914e51f6e501b2",
+		"data": {
+			"inGameID": 2013
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2338,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "89af1b7c47f1d78b9b339847ecf9da251dfc7bb1",
+		"data": {
+			"inGameID": 2013
+		},
+		"difficulty": "NMXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2338,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "2934ff821a4ba7d81200ffaaaf5a1c2bffe1c353",
+		"data": {
+			"inGameID": 2018
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"songID": 2339,
+		"versions": [
+			"konaste"
+		]
+	},
+{
+		"chartID": "2a5f93314a02afed7459b161cfbdc45cb11f5edc",
+		"data": {
+			"inGameID": 2018
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"songID": 2339,
+		"versions": [
+			"konaste"
+		]
+	},
+{
+		"chartID": "673888362db8a00593007680c89bfacd18877bf8",
+		"data": {
+			"inGameID": 2018
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2339,
+		"versions": [
+			"konaste"
+		]
+	},
+{
+		"chartID": "9c9b86c9ab2ed7312e87276318f1ae2eaf97337a",
+		"data": {
+			"inGameID": 2018
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2339,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "ab656260a1e948926e753f233631340e6bd9e350",
+		"data": {
+			"inGameID": 2023
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2340,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "d0dac82d0fea6685c91b584fba0758cde80b03d0",
+		"data": {
+			"inGameID": 2023
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2340,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "19b57d7641c4e1aeeecab4db1b7746fcf16f6eed",
+		"data": {
+			"inGameID": 2023
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2340,
+		"versions": [
+			"konaste"
+		]
+	},
+	{
+		"chartID": "98627003297b161b59ceb23de60fb1d1f45c491c",
+		"data": {
+			"inGameID": 2023
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2340,
+		"versions": [
+			"konaste"
+		]
 	}
 ]

--- a/seeds/collections/charts-sdvx.json
+++ b/seeds/collections/charts-sdvx.json
@@ -10882,7 +10882,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -10902,7 +10903,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -10922,7 +10924,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -10942,7 +10945,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -10962,7 +10966,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -10982,7 +10987,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -11002,7 +11008,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -11022,7 +11029,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -11042,7 +11050,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -31123,7 +31132,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -31142,7 +31152,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -31161,7 +31172,8 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -125311,7 +125323,8 @@
 		"playtype": "Single",
 		"songID": 1744,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -125331,7 +125344,8 @@
 		"playtype": "Single",
 		"songID": 1744,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -125356,7 +125370,8 @@
 		"playtype": "Single",
 		"songID": 1744,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -125371,7 +125386,8 @@
 		"playtype": "Single",
 		"songID": 1744,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135753,7 +135769,8 @@
 		"playtype": "Single",
 		"songID": 2009,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135768,7 +135785,8 @@
 		"playtype": "Single",
 		"songID": 2009,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135793,7 +135811,8 @@
 		"playtype": "Single",
 		"songID": 2009,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -135808,7 +135827,8 @@
 		"playtype": "Single",
 		"songID": 2009,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153857,7 +153877,8 @@
 		"playtype": "Single",
 		"songID": 2254,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153872,7 +153893,8 @@
 		"playtype": "Single",
 		"songID": 2254,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153892,7 +153914,8 @@
 		"playtype": "Single",
 		"songID": 2254,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153907,7 +153930,8 @@
 		"playtype": "Single",
 		"songID": 2254,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153922,7 +153946,8 @@
 		"playtype": "Single",
 		"songID": 2255,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153937,7 +153962,8 @@
 		"playtype": "Single",
 		"songID": 2255,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153957,7 +153983,8 @@
 		"playtype": "Single",
 		"songID": 2255,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153972,7 +153999,8 @@
 		"playtype": "Single",
 		"songID": 2255,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -153987,7 +154015,8 @@
 		"playtype": "Single",
 		"songID": 2256,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154002,7 +154031,8 @@
 		"playtype": "Single",
 		"songID": 2256,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154022,7 +154052,8 @@
 		"playtype": "Single",
 		"songID": 2256,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154037,7 +154068,8 @@
 		"playtype": "Single",
 		"songID": 2256,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154052,7 +154084,8 @@
 		"playtype": "Single",
 		"songID": 2257,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154067,7 +154100,8 @@
 		"playtype": "Single",
 		"songID": 2257,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154087,7 +154121,8 @@
 		"playtype": "Single",
 		"songID": 2257,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154102,7 +154137,8 @@
 		"playtype": "Single",
 		"songID": 2257,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154513,7 +154549,8 @@
 		"playtype": "Single",
 		"songID": 2264,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154528,7 +154565,8 @@
 		"playtype": "Single",
 		"songID": 2264,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154548,7 +154586,8 @@
 		"playtype": "Single",
 		"songID": 2264,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154563,7 +154602,8 @@
 		"playtype": "Single",
 		"songID": 2264,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154578,7 +154618,8 @@
 		"playtype": "Single",
 		"songID": 2265,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154593,7 +154634,8 @@
 		"playtype": "Single",
 		"songID": 2265,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154613,7 +154655,8 @@
 		"playtype": "Single",
 		"songID": 2265,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154628,7 +154671,8 @@
 		"playtype": "Single",
 		"songID": 2265,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154643,7 +154687,8 @@
 		"playtype": "Single",
 		"songID": 2266,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154658,7 +154703,8 @@
 		"playtype": "Single",
 		"songID": 2266,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154678,7 +154724,8 @@
 		"playtype": "Single",
 		"songID": 2266,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154693,7 +154740,8 @@
 		"playtype": "Single",
 		"songID": 2266,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154708,7 +154756,8 @@
 		"playtype": "Single",
 		"songID": 2267,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154723,7 +154772,8 @@
 		"playtype": "Single",
 		"songID": 2267,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154743,7 +154793,8 @@
 		"playtype": "Single",
 		"songID": 2267,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -154758,7 +154809,8 @@
 		"playtype": "Single",
 		"songID": 2267,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155108,7 +155160,8 @@
 		"playtype": "Single",
 		"songID": 2273,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155123,7 +155176,8 @@
 		"playtype": "Single",
 		"songID": 2273,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155143,7 +155197,8 @@
 		"playtype": "Single",
 		"songID": 2273,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155158,7 +155213,8 @@
 		"playtype": "Single",
 		"songID": 2273,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155173,7 +155229,8 @@
 		"playtype": "Single",
 		"songID": 2274,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155188,7 +155245,8 @@
 		"playtype": "Single",
 		"songID": 2274,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155208,7 +155266,8 @@
 		"playtype": "Single",
 		"songID": 2274,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155223,7 +155282,8 @@
 		"playtype": "Single",
 		"songID": 2274,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155238,7 +155298,8 @@
 		"playtype": "Single",
 		"songID": 2275,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155253,7 +155314,8 @@
 		"playtype": "Single",
 		"songID": 2275,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155273,7 +155335,8 @@
 		"playtype": "Single",
 		"songID": 2275,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155288,7 +155351,8 @@
 		"playtype": "Single",
 		"songID": 2275,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155303,7 +155367,8 @@
 		"playtype": "Single",
 		"songID": 2276,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155318,7 +155383,8 @@
 		"playtype": "Single",
 		"songID": 2276,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155338,7 +155404,8 @@
 		"playtype": "Single",
 		"songID": 2276,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -155353,7 +155420,8 @@
 		"playtype": "Single",
 		"songID": 2276,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156412,7 +156480,8 @@
 		"playtype": "Single",
 		"songID": 2292,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156427,7 +156496,8 @@
 		"playtype": "Single",
 		"songID": 2292,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156447,7 +156517,8 @@
 		"playtype": "Single",
 		"songID": 2292,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156462,7 +156533,8 @@
 		"playtype": "Single",
 		"songID": 2292,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156477,7 +156549,8 @@
 		"playtype": "Single",
 		"songID": 2293,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156497,7 +156570,8 @@
 		"playtype": "Single",
 		"songID": 2293,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156517,7 +156591,8 @@
 		"playtype": "Single",
 		"songID": 2293,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156532,7 +156607,8 @@
 		"playtype": "Single",
 		"songID": 2293,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156547,7 +156623,8 @@
 		"playtype": "Single",
 		"songID": 2294,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156562,7 +156639,8 @@
 		"playtype": "Single",
 		"songID": 2294,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156582,7 +156660,8 @@
 		"playtype": "Single",
 		"songID": 2294,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156597,7 +156676,8 @@
 		"playtype": "Single",
 		"songID": 2294,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156612,7 +156692,8 @@
 		"playtype": "Single",
 		"songID": 2295,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156632,7 +156713,8 @@
 		"playtype": "Single",
 		"songID": 2295,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156652,7 +156734,8 @@
 		"playtype": "Single",
 		"songID": 2295,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156667,7 +156750,8 @@
 		"playtype": "Single",
 		"songID": 2295,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156682,7 +156766,8 @@
 		"playtype": "Single",
 		"songID": 2296,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156702,7 +156787,8 @@
 		"playtype": "Single",
 		"songID": 2296,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156722,7 +156808,8 @@
 		"playtype": "Single",
 		"songID": 2296,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156737,7 +156824,8 @@
 		"playtype": "Single",
 		"songID": 2296,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156752,7 +156840,8 @@
 		"playtype": "Single",
 		"songID": 2297,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156772,7 +156861,8 @@
 		"playtype": "Single",
 		"songID": 2297,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156792,7 +156882,8 @@
 		"playtype": "Single",
 		"songID": 2297,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156807,7 +156898,8 @@
 		"playtype": "Single",
 		"songID": 2297,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156822,7 +156914,8 @@
 		"playtype": "Single",
 		"songID": 2298,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156837,7 +156930,8 @@
 		"playtype": "Single",
 		"songID": 2298,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156857,7 +156951,8 @@
 		"playtype": "Single",
 		"songID": 2298,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156872,7 +156967,8 @@
 		"playtype": "Single",
 		"songID": 2298,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156887,7 +156983,8 @@
 		"playtype": "Single",
 		"songID": 2299,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156902,7 +156999,8 @@
 		"playtype": "Single",
 		"songID": 2299,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156922,7 +157020,8 @@
 		"playtype": "Single",
 		"songID": 2299,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156937,7 +157036,8 @@
 		"playtype": "Single",
 		"songID": 2299,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156952,7 +157052,8 @@
 		"playtype": "Single",
 		"songID": 2300,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156967,7 +157068,8 @@
 		"playtype": "Single",
 		"songID": 2300,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -156987,7 +157089,8 @@
 		"playtype": "Single",
 		"songID": 2300,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157002,7 +157105,8 @@
 		"playtype": "Single",
 		"songID": 2300,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157017,7 +157121,8 @@
 		"playtype": "Single",
 		"songID": 2301,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157032,7 +157137,8 @@
 		"playtype": "Single",
 		"songID": 2301,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157052,7 +157158,8 @@
 		"playtype": "Single",
 		"songID": 2301,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157067,7 +157174,8 @@
 		"playtype": "Single",
 		"songID": 2301,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157082,7 +157190,8 @@
 		"playtype": "Single",
 		"songID": 2302,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157097,7 +157206,8 @@
 		"playtype": "Single",
 		"songID": 2302,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157117,7 +157227,8 @@
 		"playtype": "Single",
 		"songID": 2302,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157132,7 +157243,8 @@
 		"playtype": "Single",
 		"songID": 2302,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157147,7 +157259,8 @@
 		"playtype": "Single",
 		"songID": 2303,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157162,7 +157275,8 @@
 		"playtype": "Single",
 		"songID": 2303,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157182,7 +157296,8 @@
 		"playtype": "Single",
 		"songID": 2303,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157197,7 +157312,8 @@
 		"playtype": "Single",
 		"songID": 2303,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157212,7 +157328,8 @@
 		"playtype": "Single",
 		"songID": 2304,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157227,7 +157344,8 @@
 		"playtype": "Single",
 		"songID": 2304,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157247,7 +157365,8 @@
 		"playtype": "Single",
 		"songID": 2304,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157262,7 +157381,8 @@
 		"playtype": "Single",
 		"songID": 2304,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157904,7 +158024,8 @@
 		"playtype": "Single",
 		"songID": 2315,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157919,7 +158040,8 @@
 		"playtype": "Single",
 		"songID": 2315,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157934,7 +158056,8 @@
 		"playtype": "Single",
 		"songID": 2315,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157949,7 +158072,8 @@
 		"playtype": "Single",
 		"songID": 2315,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157964,7 +158088,8 @@
 		"playtype": "Single",
 		"songID": 2316,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157979,7 +158104,8 @@
 		"playtype": "Single",
 		"songID": 2316,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -157994,7 +158120,8 @@
 		"playtype": "Single",
 		"songID": 2316,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158009,7 +158136,8 @@
 		"playtype": "Single",
 		"songID": 2316,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158024,7 +158152,8 @@
 		"playtype": "Single",
 		"songID": 2317,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158039,7 +158168,8 @@
 		"playtype": "Single",
 		"songID": 2317,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158054,7 +158184,8 @@
 		"playtype": "Single",
 		"songID": 2317,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158069,7 +158200,8 @@
 		"playtype": "Single",
 		"songID": 2317,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158084,7 +158216,8 @@
 		"playtype": "Single",
 		"songID": 2318,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158099,7 +158232,8 @@
 		"playtype": "Single",
 		"songID": 2318,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158114,7 +158248,8 @@
 		"playtype": "Single",
 		"songID": 2318,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158129,7 +158264,8 @@
 		"playtype": "Single",
 		"songID": 2318,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158144,7 +158280,8 @@
 		"playtype": "Single",
 		"songID": 2319,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158159,7 +158296,8 @@
 		"playtype": "Single",
 		"songID": 2319,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158174,7 +158312,8 @@
 		"playtype": "Single",
 		"songID": 2319,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158189,7 +158328,8 @@
 		"playtype": "Single",
 		"songID": 2319,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158204,7 +158344,8 @@
 		"playtype": "Single",
 		"songID": 2320,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158219,7 +158360,8 @@
 		"playtype": "Single",
 		"songID": 2320,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158234,7 +158376,8 @@
 		"playtype": "Single",
 		"songID": 2320,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158249,7 +158392,8 @@
 		"playtype": "Single",
 		"songID": 2320,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158264,7 +158408,8 @@
 		"playtype": "Single",
 		"songID": 2321,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158279,7 +158424,8 @@
 		"playtype": "Single",
 		"songID": 2321,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158294,7 +158440,8 @@
 		"playtype": "Single",
 		"songID": 2321,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158309,7 +158456,8 @@
 		"playtype": "Single",
 		"songID": 2321,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158324,7 +158472,8 @@
 		"playtype": "Single",
 		"songID": 2322,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158339,7 +158488,8 @@
 		"playtype": "Single",
 		"songID": 2322,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158354,7 +158504,8 @@
 		"playtype": "Single",
 		"songID": 2322,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158369,7 +158520,8 @@
 		"playtype": "Single",
 		"songID": 2322,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158384,7 +158536,8 @@
 		"playtype": "Single",
 		"songID": 2323,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158399,7 +158552,8 @@
 		"playtype": "Single",
 		"songID": 2323,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158414,7 +158568,8 @@
 		"playtype": "Single",
 		"songID": 2323,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158429,7 +158584,8 @@
 		"playtype": "Single",
 		"songID": 2323,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158684,7 +158840,8 @@
 		"playtype": "Single",
 		"songID": 2328,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158699,7 +158856,8 @@
 		"playtype": "Single",
 		"songID": 2328,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158714,7 +158872,8 @@
 		"playtype": "Single",
 		"songID": 2328,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158729,7 +158888,8 @@
 		"playtype": "Single",
 		"songID": 2328,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158744,7 +158904,8 @@
 		"playtype": "Single",
 		"songID": 2329,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158759,7 +158920,8 @@
 		"playtype": "Single",
 		"songID": 2329,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158774,7 +158936,8 @@
 		"playtype": "Single",
 		"songID": 2329,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158789,7 +158952,8 @@
 		"playtype": "Single",
 		"songID": 2329,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158804,7 +158968,8 @@
 		"playtype": "Single",
 		"songID": 2330,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158819,7 +158984,8 @@
 		"playtype": "Single",
 		"songID": 2330,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158834,7 +159000,8 @@
 		"playtype": "Single",
 		"songID": 2330,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158849,7 +159016,8 @@
 		"playtype": "Single",
 		"songID": 2330,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158864,7 +159032,8 @@
 		"playtype": "Single",
 		"songID": 2331,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158879,7 +159048,8 @@
 		"playtype": "Single",
 		"songID": 2331,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158894,7 +159064,8 @@
 		"playtype": "Single",
 		"songID": 2331,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158909,7 +159080,8 @@
 		"playtype": "Single",
 		"songID": 2331,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158924,7 +159096,8 @@
 		"playtype": "Single",
 		"songID": 2332,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158939,7 +159112,8 @@
 		"playtype": "Single",
 		"songID": 2332,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158954,7 +159128,8 @@
 		"playtype": "Single",
 		"songID": 2332,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{
@@ -158969,7 +159144,8 @@
 		"playtype": "Single",
 		"songID": 2332,
 		"versions": [
-			"exceed"
+			"exceed",
+			"konaste"
 		]
 	},
 	{

--- a/seeds/collections/charts-sdvx.json
+++ b/seeds/collections/charts-sdvx.json
@@ -159498,7 +159498,7 @@
 		"data": {
 			"inGameID": 2013
 		},
-		"difficulty": "NMXM",
+		"difficulty": "MXM",
 		"isPrimary": true,
 		"level": "18",
 		"levelNum": 18,

--- a/seeds/collections/songs-sdvx.json
+++ b/seeds/collections/songs-sdvx.json
@@ -25374,5 +25374,55 @@
 			"romancingescape_kokonatsu"
 		],
 		"title": "ロマンシングエスケープ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Tatsunoshin",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2336,
+		"searchTerms": [],
+		"title": "caramel ribbon (Tatsunoshin Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "xi",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2337,
+		"searchTerms": [],
+		"title": "XROSS INFECTION -xiRemix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2338,
+		"searchTerms": [],
+		"title": "The world of sound -celestial mix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "deli.+駄々子",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2339,
+		"searchTerms": [],
+		"title": "回想音楽 - Thank you for your playing music"
+	},
+		{
+		"altTitles": [],
+		"artist": "Ashrount",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2340,
+		"searchTerms": [],
+		"title": "Dynasty -dal segno-"
 	}
 ]


### PR DESCRIPTION
Re-open the PR. from
https://github.com/zkrising/Tachi/pull/1294

+ upstream seed till 2025021200
(https://github.com/zkrising/Tachi/pull/1295)

Still 5 missing song.
- The world of sound -celestial mix-
- XROSS INFECTION -xiRemix-
- 回想音楽 - Thank you for your playing music
- caramel ribbon (Tatsunoshin Remix)
- Dynasty -dal segno-

===================================

+ Accidentially upstreamed to push INFINITAS monthly update T^T 

 beatmania IIDX INFINITASの楽曲公開についてご案内いたします。
2025年6月4日(水) 10時より以下の楽曲が公開となります。

■BITで解禁可能楽曲の追加
・WHA
・DENIM