### PR TITLE
feat(maimaidx): graphs and song durations

### DIFF
--- a/client/src/components/charts/GekichumaiScoreChart.tsx
+++ b/client/src/components/charts/GekichumaiScoreChart.tsx
@@ -272,7 +272,7 @@ export default function GekichumaiScoreChart({
 					{...commonProps}
 					data={limitScoreGraph(game, data)}
 					yScale={{ type: "linear", min: 97, max: 101 }}
-					yFormat={">-,.0f"}
+					yFormat={">-,.4f"}
 					axisLeft={{
 						tickValues: [97, 98, 99, 99.5, 100, 100.5, 101],
 						format: getScoreYAxisNotch(game),
@@ -283,8 +283,8 @@ export default function GekichumaiScoreChart({
 					areaBaselineValue={97}
 					tooltip={(d: PointTooltipProps) => (
 						<ChartTooltip>
-							{d.point.data.y === 96.9999 ? "< 97 " : d.point.data.yFormatted}@{" "}
-							{formatTime(d.point.data.x)}
+							{d.point.data.y === 96.9999 ? "< 97% " : `${d.point.data.yFormatted}% `}
+							@ {formatTime(d.point.data.x)}
 						</ChartTooltip>
 					)}
 				/>

--- a/client/src/components/tables/dropdowns/GPTDropdownSettings.tsx
+++ b/client/src/components/tables/dropdowns/GPTDropdownSettings.tsx
@@ -5,6 +5,7 @@ import { ITGGraphsComponent } from "./components/ITGScoreDropdownParts";
 import { JubeatGraphsComponent } from "./components/JubeatScoreDropdownParts";
 import { OngekiGraphsComponent } from "./components/OngekiScoreDropdownParts";
 import { ChunithmGraphsComponent } from "./components/ChunithmScoreDropdownParts";
+import { MaimaiDXGraphsComponent } from "./components/MaimaiDXScoreDropdownParts";
 
 export function GPTDropdownSettings(game: Game, playtype: Playtype): any {
 	if (game === "iidx") {
@@ -38,6 +39,11 @@ export function GPTDropdownSettings(game: Game, playtype: Playtype): any {
 		return {
 			renderScoreInfo: true,
 			GraphComponent: ChunithmGraphsComponent as any,
+		};
+	} else if (game === "maimaidx") {
+		return {
+			renderScoreInfo: true,
+			GraphComponent: MaimaiDXGraphsComponent as any,
 		};
 	}
 

--- a/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/ChunithmScoreDropdownParts.tsx
@@ -7,7 +7,7 @@ import {
 	ScoreDocument,
 	SongDocument,
 } from "tachi-common";
-import GekichuScoreChart from "components/charts/GekichuScoreChart";
+import GekichumaiScoreChart from "components/charts/GekichumaiScoreChart";
 import SelectNav from "components/util/SelectNav";
 import { Nav } from "react-bootstrap";
 import useApiQuery from "components/util/query/useApiQuery";
@@ -78,7 +78,7 @@ function GraphComponent({
 	const values =
 		type === "Score" ? scoreData.optional.scoreGraph! : scoreData.optional.lifeGraph!;
 	return (
-		<GekichuScoreChart
+		<GekichumaiScoreChart
 			height="360px"
 			mobileHeight="175px"
 			type={type}

--- a/client/src/components/tables/dropdowns/components/MaimaiDXScoreDropdownParts.tsx
+++ b/client/src/components/tables/dropdowns/components/MaimaiDXScoreDropdownParts.tsx
@@ -36,7 +36,7 @@ export function MaimaiDXGraphsComponent({
 		return <Box message="Error retrieving chart" />;
 	}
 
-	if (data.song.data.duration === null) {
+	if (!data.song.data.duration) {
 		return <Box message="No charts available" />;
 	}
 

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -10,6 +10,7 @@ export const MAIMAI_DX_CONF = {
 	playtypes: ["Single"],
 	songData: z.strictObject({
 		genre: z.string(),
+		duration: z.number().optional(),
 	}),
 } as const satisfies INTERNAL_GAME_CONFIG;
 
@@ -134,7 +135,20 @@ export const MAIMAI_DX_SINGLE_CONF = {
 	defaultMetric: "percent",
 	preferredDefaultEnum: "grade",
 
-	optionalMetrics: FAST_SLOW_MAXCOMBO,
+	optionalMetrics: {
+		...FAST_SLOW_MAXCOMBO,
+		percentGraph: {
+			type: "NULLABLE_GRAPH",
+			validate: p.isBetween(0, 101),
+			description:
+				"The history of the projected achievement, queried in one-second intervals.",
+		},
+		lifeGraph: {
+			type: "NULLABLE_GRAPH",
+			validate: p.isBetween(0, 999),
+			description: "Life count history, queried in one-second intervals.",
+		},
+	},
 
 	scoreRatingAlgs: {
 		rate: { description: "Rating as it's implemented in game.", formatter: NoDecimalPlace },

--- a/seeds/collections/songs-maimaidx.json
+++ b/seeds/collections/songs-maimaidx.json
@@ -3,6 +3,7 @@
 		"altTitles": [],
 		"artist": "Kai/クラシック「G線上のアリア」",
 		"data": {
+			"duration": 97.6,
 			"genre": "maimai"
 		},
 		"id": 1,
@@ -13,6 +14,7 @@
 		"altTitles": [],
 		"artist": "GOSH/クラシック「悲愴」",
 		"data": {
+			"duration": 101,
 			"genre": "maimai"
 		},
 		"id": 2,
@@ -25,6 +27,7 @@
 		"altTitles": [],
 		"artist": "★STAR GUiTAR [cover]",
 		"data": {
+			"duration": 105.231,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 3,
@@ -35,6 +38,7 @@
 		"altTitles": [],
 		"artist": "Q;indivi [cover]",
 		"data": {
+			"duration": 112.889,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 4,
@@ -45,6 +49,7 @@
 		"altTitles": [],
 		"artist": "Hiro「Crackin’DJ」",
 		"data": {
+			"duration": 106.275,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 5,
@@ -55,6 +60,7 @@
 		"altTitles": [],
 		"artist": "福山光晴「Crackin’DJ」",
 		"data": {
+			"duration": 103.588,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 6,
@@ -65,6 +71,7 @@
 		"altTitles": [],
 		"artist": "Hiro「Crackin’DJ」",
 		"data": {
+			"duration": 105.588,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 7,
@@ -75,6 +82,7 @@
 		"altTitles": [],
 		"artist": "Team-D",
 		"data": {
+			"duration": 104.886,
 			"genre": "maimai"
 		},
 		"id": 8,
@@ -88,6 +96,7 @@
 		"altTitles": [],
 		"artist": "capsule [cover]",
 		"data": {
+			"duration": 106.523,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 9,
@@ -98,6 +107,7 @@
 		"altTitles": [],
 		"artist": "Kai/能登有沙",
 		"data": {
+			"duration": 91.943,
 			"genre": "maimai"
 		},
 		"id": 10,
@@ -111,6 +121,7 @@
 		"altTitles": [],
 		"artist": "GOSH/manami",
 		"data": {
+			"duration": 94.493,
 			"genre": "maimai"
 		},
 		"id": 11,
@@ -125,6 +136,7 @@
 		"altTitles": [],
 		"artist": "Kai/光吉猛修",
 		"data": {
+			"duration": 102.042,
 			"genre": "maimai"
 		},
 		"id": 12,
@@ -139,6 +151,7 @@
 		"altTitles": [],
 		"artist": "NIKO [cover]",
 		"data": {
+			"duration": 88.749,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 13,
@@ -149,6 +162,7 @@
 		"altTitles": [],
 		"artist": "m-flo [cover]",
 		"data": {
+			"duration": 99.692,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 14,
@@ -159,6 +173,7 @@
 		"altTitles": [],
 		"artist": "capsule [cover]",
 		"data": {
+			"duration": 100.731,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 15,
@@ -169,6 +184,7 @@
 		"altTitles": [],
 		"artist": "EasyPop",
 		"data": {
+			"duration": 90.709,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 16,
@@ -182,6 +198,7 @@
 		"altTitles": [],
 		"artist": "samfree",
 		"data": {
+			"duration": 96,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 17,
@@ -195,6 +212,7 @@
 		"altTitles": [],
 		"artist": "新小田夢童 ＆ キラ★ロッソ",
 		"data": {
+			"duration": 99.474,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 18,
@@ -210,6 +228,7 @@
 		"altTitles": [],
 		"artist": "東京スカパラダイスオーケストラ [cover]",
 		"data": {
+			"duration": 92.96,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 19,
@@ -222,6 +241,7 @@
 		"altTitles": [],
 		"artist": "Caramell/Caramelldansen [cover]",
 		"data": {
+			"duration": 101.574,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 20,
@@ -234,6 +254,7 @@
 		"altTitles": [],
 		"artist": "RYOHEI KOHNO/保立美和子",
 		"data": {
+			"duration": 121.69,
 			"genre": "maimai"
 		},
 		"id": 21,
@@ -244,6 +265,7 @@
 		"altTitles": [],
 		"artist": "Hiro「Crackin’DJ」",
 		"data": {
+			"duration": 99.574,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 22,
@@ -254,6 +276,7 @@
 		"altTitles": [],
 		"artist": "「サクラ大戦」",
 		"data": {
+			"duration": 98.915,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 23,
@@ -266,6 +289,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 108,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 24,
@@ -278,6 +302,7 @@
 		"altTitles": [],
 		"artist": "ちょむP <advanced mix>",
 		"data": {
+			"duration": 104,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 25,
@@ -291,6 +316,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 105.251,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 26,
@@ -301,6 +327,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 102.456,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 27,
@@ -313,6 +340,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 99.594,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 28,
@@ -325,6 +353,7 @@
 		"altTitles": [],
 		"artist": "Hiro/タクマロ",
 		"data": {
+			"duration": 111.504,
 			"genre": "maimai"
 		},
 		"id": 29,
@@ -338,6 +367,7 @@
 		"altTitles": [],
 		"artist": "Hiro/永江理奈",
 		"data": {
+			"duration": 117.205,
 			"genre": "maimai"
 		},
 		"id": 30,
@@ -351,6 +381,7 @@
 		"altTitles": [],
 		"artist": "SEGA Sound Unit [H.]",
 		"data": {
+			"duration": 97.537,
 			"genre": "maimai"
 		},
 		"id": 31,
@@ -365,6 +396,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 106.999,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 32,
@@ -377,6 +409,7 @@
 		"altTitles": [],
 		"artist": "samfree",
 		"data": {
+			"duration": 94.815,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 33,
@@ -390,6 +423,7 @@
 		"altTitles": [],
 		"artist": "スーパーラバーズ「赤ちゃんはどこからくるの？」",
 		"data": {
+			"duration": 110.801,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 34,
@@ -405,6 +439,7 @@
 		"altTitles": [],
 		"artist": "スーパーラバーズ「きみのためなら死ねる」",
 		"data": {
+			"duration": 125.007,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 35,
@@ -418,6 +453,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「リズム怪盗R 皇帝ナポレオンの遺産」",
 		"data": {
+			"duration": 126.294,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 36,
@@ -433,6 +469,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「リズム怪盗R 皇帝ナポレオンの遺産」",
 		"data": {
+			"duration": 120.458,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 37,
@@ -446,6 +483,7 @@
 		"altTitles": [],
 		"artist": "幡谷尚史「リズム怪盗R 皇帝ナポレオンの遺産」",
 		"data": {
+			"duration": 94.713,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 38,
@@ -456,6 +494,7 @@
 		"altTitles": [],
 		"artist": "Cash Cash「ソニック ジェネレーションズ」",
 		"data": {
+			"duration": 120,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 39,
@@ -469,6 +508,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「ソニック ジェネレーションズ」",
 		"data": {
+			"duration": 115.734,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 40,
@@ -481,6 +521,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉, Jean Paul Makhlouf of Cash Cash「ソニック カラーズ」",
 		"data": {
+			"duration": 94.017,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 41,
@@ -491,6 +532,7 @@
 		"altTitles": [],
 		"artist": "「BORDER BREAK」",
 		"data": {
+			"duration": 107.613,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 42,
@@ -503,6 +545,7 @@
 		"altTitles": [],
 		"artist": "「BORDER BREAK UNION」メインテーマ",
 		"data": {
+			"duration": 111.114,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 43,
@@ -513,6 +556,7 @@
 		"altTitles": [],
 		"artist": "「バーチャファイター」",
 		"data": {
+			"duration": 91.424,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 44,
@@ -525,6 +569,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 124.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 45,
@@ -535,6 +580,7 @@
 		"altTitles": [],
 		"artist": "ゴジマジP",
 		"data": {
+			"duration": 93.213,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 46,
@@ -547,6 +593,7 @@
 		"altTitles": [],
 		"artist": "mathru(かにみそP)",
 		"data": {
+			"duration": 129.296,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 47,
@@ -560,6 +607,7 @@
 		"altTitles": [],
 		"artist": "ひとしずくP・やま△",
 		"data": {
+			"duration": 102.353,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 48,
@@ -572,6 +620,7 @@
 		"altTitles": [],
 		"artist": "doriko",
 		"data": {
+			"duration": 105.882,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 49,
@@ -585,6 +634,7 @@
 		"altTitles": [],
 		"artist": "Dixie Flatline",
 		"data": {
+			"duration": 111.348,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 50,
@@ -595,6 +645,7 @@
 		"altTitles": [],
 		"artist": "ピノキオP",
 		"data": {
+			"duration": 121.787,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 51,
@@ -608,6 +659,7 @@
 		"altTitles": [],
 		"artist": "COSIO(ZUNTATA/TAITO)「カルテット」",
 		"data": {
+			"duration": 127.883,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 52,
@@ -620,6 +672,7 @@
 		"altTitles": [],
 		"artist": "大久保 博(BNGI)「デイトナ USA」",
 		"data": {
+			"duration": 116.667,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 53,
@@ -632,6 +685,7 @@
 		"altTitles": [],
 		"artist": "sampling masters MEGA「パワードリフト」",
 		"data": {
+			"duration": 112.479,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 54,
@@ -644,6 +698,7 @@
 		"altTitles": [],
 		"artist": "古代 祐三「ファンタジーゾーン」",
 		"data": {
+			"duration": 109.714,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 55,
@@ -656,6 +711,7 @@
 		"altTitles": [],
 		"artist": "佐野 信義「スペースハリアー」",
 		"data": {
+			"duration": 115.514,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 56,
@@ -670,6 +726,7 @@
 		"altTitles": [],
 		"artist": "Performed by SEGA Sound Unit [H.]",
 		"data": {
+			"duration": 129.246,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 57,
@@ -682,6 +739,7 @@
 		"altTitles": [],
 		"artist": "Hiro/小山あかり",
 		"data": {
+			"duration": 136.554,
 			"genre": "maimai"
 		},
 		"id": 58,
@@ -695,6 +753,7 @@
 		"altTitles": [],
 		"artist": "Hiro/森山愛子",
 		"data": {
+			"duration": 128.889,
 			"genre": "maimai"
 		},
 		"id": 59,
@@ -707,6 +766,7 @@
 		"altTitles": [],
 		"artist": "RYOHEI KOHNO/森綾香",
 		"data": {
+			"duration": 99.155,
 			"genre": "maimai"
 		},
 		"id": 60,
@@ -720,6 +780,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修",
 		"data": {
+			"duration": 96,
 			"genre": "maimai"
 		},
 		"id": 61,
@@ -733,6 +794,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修＆体操隊",
 		"data": {
+			"duration": 85.714,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 62,
@@ -746,6 +808,7 @@
 		"altTitles": [],
 		"artist": "ろん×Junky",
 		"data": {
+			"duration": 127.174,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 63,
@@ -758,6 +821,7 @@
 		"altTitles": [],
 		"artist": "米津玄師",
 		"data": {
+			"duration": 109,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 64,
@@ -770,6 +834,7 @@
 		"altTitles": [],
 		"artist": "黒うさP",
 		"data": {
+			"duration": 113.14,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 65,
@@ -782,6 +847,7 @@
 		"altTitles": [],
 		"artist": "「サクラ大戦」",
 		"data": {
+			"duration": 106.123,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 66,
@@ -794,6 +860,7 @@
 		"altTitles": [],
 		"artist": "ELEMENTAS feat. NAGISA",
 		"data": {
+			"duration": 84.682,
 			"genre": "maimai"
 		},
 		"id": 67,
@@ -804,6 +871,7 @@
 		"altTitles": [],
 		"artist": "Clean Tears feat. Youna",
 		"data": {
+			"duration": 85.432,
 			"genre": "maimai"
 		},
 		"id": 68,
@@ -814,6 +882,7 @@
 		"altTitles": [],
 		"artist": "Clean Tears",
 		"data": {
+			"duration": 85.131,
 			"genre": "maimai"
 		},
 		"id": 69,
@@ -824,6 +893,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 83.019,
 			"genre": "maimai"
 		},
 		"id": 70,
@@ -836,6 +906,7 @@
 		"altTitles": [],
 		"artist": "発熱巫女～ず",
 		"data": {
+			"duration": 85.449,
 			"genre": "maimai"
 		},
 		"id": 71,
@@ -846,6 +917,7 @@
 		"altTitles": [],
 		"artist": "発熱巫女～ず",
 		"data": {
+			"duration": 86.648,
 			"genre": "maimai"
 		},
 		"id": 72,
@@ -856,6 +928,7 @@
 		"altTitles": [],
 		"artist": "ARM(IOSYS)",
 		"data": {
+			"duration": 83.792,
 			"genre": "maimai"
 		},
 		"id": 73,
@@ -866,6 +939,7 @@
 		"altTitles": [],
 		"artist": "D.watt(IOSYS)feat. Asana",
 		"data": {
+			"duration": 82.861,
 			"genre": "maimai"
 		},
 		"id": 74,
@@ -876,6 +950,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
+			"duration": 85.018,
 			"genre": "maimai"
 		},
 		"id": 75,
@@ -886,6 +961,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE",
 		"data": {
+			"duration": 84.359,
 			"genre": "maimai"
 		},
 		"id": 76,
@@ -896,6 +972,7 @@
 		"altTitles": [],
 		"artist": "Taishi",
 		"data": {
+			"duration": 83.457,
 			"genre": "maimai"
 		},
 		"id": 77,
@@ -906,6 +983,7 @@
 		"altTitles": [],
 		"artist": "Taishi",
 		"data": {
+			"duration": 83.714,
 			"genre": "maimai"
 		},
 		"id": 78,
@@ -916,6 +994,7 @@
 		"altTitles": [],
 		"artist": "Tsukasa(Arte Refact)",
 		"data": {
+			"duration": 84.826,
 			"genre": "maimai"
 		},
 		"id": 79,
@@ -926,6 +1005,7 @@
 		"altTitles": [],
 		"artist": "Tsukasa(Arte Refact)",
 		"data": {
+			"duration": 83.333,
 			"genre": "maimai"
 		},
 		"id": 80,
@@ -936,6 +1016,7 @@
 		"altTitles": [],
 		"artist": "zts",
 		"data": {
+			"duration": 84.699,
 			"genre": "maimai"
 		},
 		"id": 81,
@@ -946,6 +1027,7 @@
 		"altTitles": [],
 		"artist": "loos feat. Meramipop",
 		"data": {
+			"duration": 84.811,
 			"genre": "maimai"
 		},
 		"id": 82,
@@ -956,6 +1038,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK x DECO*27",
 		"data": {
+			"duration": 118.971,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 83,
@@ -966,6 +1049,7 @@
 		"altTitles": [],
 		"artist": "「サクラ大戦」",
 		"data": {
+			"duration": 107.943,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 84,
@@ -978,6 +1062,7 @@
 		"altTitles": [],
 		"artist": "Keitarou Hanada「戦国大戦」",
 		"data": {
+			"duration": 114.375,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 85,
@@ -990,6 +1075,7 @@
 		"altTitles": [],
 		"artist": "Keitarou Hanada「戦国大戦」",
 		"data": {
+			"duration": 108.406,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 86,
@@ -1002,6 +1088,7 @@
 		"altTitles": [],
 		"artist": "怒髪天「百鬼大戦絵巻」",
 		"data": {
+			"duration": 106.105,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 87,
@@ -1012,6 +1099,7 @@
 		"altTitles": [],
 		"artist": "Hiro/友香",
 		"data": {
+			"duration": 136.236,
 			"genre": "maimai"
 		},
 		"id": 88,
@@ -1024,6 +1112,7 @@
 		"altTitles": [],
 		"artist": "KENTARO「Crackin’DJ」",
 		"data": {
+			"duration": 106.029,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 89,
@@ -1034,6 +1123,7 @@
 		"altTitles": [],
 		"artist": "YMCK",
 		"data": {
+			"duration": 106.293,
 			"genre": "maimai"
 		},
 		"id": 90,
@@ -1059,6 +1149,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 118.182,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 92,
@@ -1071,6 +1162,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 122.1,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 93,
@@ -1083,6 +1175,7 @@
 		"altTitles": [],
 		"artist": "samfree",
 		"data": {
+			"duration": 109.63,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 94,
@@ -1096,6 +1189,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 122.1,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 95,
@@ -1109,6 +1203,7 @@
 		"altTitles": [],
 		"artist": "164",
 		"data": {
+			"duration": 129.191,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 96,
@@ -1121,6 +1216,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 134,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 97,
@@ -1136,6 +1232,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 139.832,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 98,
@@ -1149,6 +1246,7 @@
 		"altTitles": [],
 		"artist": "れるりり",
 		"data": {
+			"duration": 106.065,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 99,
@@ -1163,6 +1261,7 @@
 		"altTitles": [],
 		"artist": "とくP",
 		"data": {
+			"duration": 144.444,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 100,
@@ -1173,6 +1272,7 @@
 		"altTitles": [],
 		"artist": "Last Note.",
 		"data": {
+			"duration": 119.172,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 101,
@@ -1185,6 +1285,7 @@
 		"altTitles": [],
 		"artist": "Last Note.",
 		"data": {
+			"duration": 138.667,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 102,
@@ -1197,6 +1298,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 109.2,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 103,
@@ -1210,6 +1312,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)feat. miko",
 		"data": {
+			"duration": 126.171,
 			"genre": "東方Project"
 		},
 		"id": 104,
@@ -1223,6 +1326,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
+			"duration": 132.174,
 			"genre": "東方Project"
 		},
 		"id": 105,
@@ -1235,6 +1339,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)feat. 藤咲かりん",
 		"data": {
+			"duration": 122.824,
 			"genre": "東方Project"
 		},
 		"id": 106,
@@ -1247,6 +1352,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 139.12,
 			"genre": "東方Project"
 		},
 		"id": 107,
@@ -1259,6 +1365,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 127.213,
 			"genre": "東方Project"
 		},
 		"id": 108,
@@ -1271,6 +1378,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 112.398,
 			"genre": "東方Project"
 		},
 		"id": 109,
@@ -1288,6 +1396,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. 匠眞",
 		"data": {
+			"duration": 119.479,
 			"genre": "東方Project"
 		},
 		"id": 110,
@@ -1300,6 +1409,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 138,
 			"genre": "東方Project"
 		},
 		"id": 111,
@@ -1313,6 +1423,7 @@
 		"altTitles": [],
 		"artist": "アルル(CV 園崎未恵)「ぷよぷよ」",
 		"data": {
+			"duration": 109.241,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 112,
@@ -1325,6 +1436,7 @@
 		"altTitles": [],
 		"artist": "アミティ(CV 菊池志穂)「ぷよぷよ」",
 		"data": {
+			"duration": 90.353,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 113,
@@ -1335,6 +1447,7 @@
 		"altTitles": [],
 		"artist": "ササキトモコ「音声感情測定器ココロスキャン」",
 		"data": {
+			"duration": 120.591,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 114,
@@ -1348,6 +1461,7 @@
 		"altTitles": [],
 		"artist": "桐生 一馬「龍が如く」",
 		"data": {
+			"duration": 98.108,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 115,
@@ -1360,6 +1474,7 @@
 		"altTitles": [],
 		"artist": "澤村 遥「龍が如く５ 夢、叶えし者」",
 		"data": {
+			"duration": 117.677,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 116,
@@ -1372,6 +1487,7 @@
 		"altTitles": [],
 		"artist": "下田麻美「Shining・Force CROSS ELYSION」",
 		"data": {
+			"duration": 92.249,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 117,
@@ -1382,6 +1498,7 @@
 		"altTitles": [],
 		"artist": "「BAYONETTA(ベヨネッタ)」",
 		"data": {
+			"duration": 114.857,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 118,
@@ -1392,6 +1509,7 @@
 		"altTitles": [],
 		"artist": "「BAYONETTA(ベヨネッタ)」",
 		"data": {
+			"duration": 109.735,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 119,
@@ -1402,6 +1520,7 @@
 		"altTitles": [],
 		"artist": "三草康二郎「CODE OF JOKER」",
 		"data": {
+			"duration": 93.75,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 120,
@@ -1412,6 +1531,7 @@
 		"altTitles": [],
 		"artist": "LOPIT(SEGA)",
 		"data": {
+			"duration": 109.953,
 			"genre": "maimai"
 		},
 		"id": 121,
@@ -1425,6 +1545,7 @@
 		"altTitles": [],
 		"artist": "Hiro",
 		"data": {
+			"duration": 82.703,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 122,
@@ -1439,6 +1560,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 117.692,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 123,
@@ -1452,6 +1574,7 @@
 		"altTitles": [],
 		"artist": "あまね＋ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 108.632,
 			"genre": "東方Project"
 		},
 		"id": 124,
@@ -1464,6 +1587,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 129.161,
 			"genre": "東方Project"
 		},
 		"id": 125,
@@ -1474,6 +1598,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 124.076,
 			"genre": "maimai"
 		},
 		"id": 126,
@@ -1484,6 +1609,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 128.438,
 			"genre": "maimai"
 		},
 		"id": 127,
@@ -1498,6 +1624,7 @@
 		"altTitles": [],
 		"artist": "Sta feat.tigerlily and DOT96",
 		"data": {
+			"duration": 112.363,
 			"genre": "maimai"
 		},
 		"id": 128,
@@ -1508,6 +1635,7 @@
 		"altTitles": [],
 		"artist": "D.watt(IOSYS)feat.ちよこ",
 		"data": {
+			"duration": 123.869,
 			"genre": "maimai"
 		},
 		"id": 129,
@@ -1522,6 +1650,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima feat. 綾倉盟",
 		"data": {
+			"duration": 120.889,
 			"genre": "maimai"
 		},
 		"id": 130,
@@ -1532,6 +1661,7 @@
 		"altTitles": [],
 		"artist": "RAMM feat. 若井友希",
 		"data": {
+			"duration": 108.706,
 			"genre": "maimai"
 		},
 		"id": 131,
@@ -1542,6 +1672,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 119.844,
 			"genre": "maimai"
 		},
 		"id": 132,
@@ -1552,6 +1683,7 @@
 		"altTitles": [],
 		"artist": "Cranky feat. まらしぃ ＆ てっぺい先生",
 		"data": {
+			"duration": 122.633,
 			"genre": "maimai"
 		},
 		"id": 133,
@@ -1562,6 +1694,7 @@
 		"altTitles": [],
 		"artist": "ALiCE'S EMOTiON feat. Ayumi Nomiya",
 		"data": {
+			"duration": 119.763,
 			"genre": "maimai"
 		},
 		"id": 134,
@@ -1572,6 +1705,7 @@
 		"altTitles": [],
 		"artist": "山根ミチル",
 		"data": {
+			"duration": 111.68,
 			"genre": "maimai"
 		},
 		"id": 135,
@@ -1586,6 +1720,7 @@
 		"altTitles": [],
 		"artist": "山根ミチル",
 		"data": {
+			"duration": 125.517,
 			"genre": "maimai"
 		},
 		"id": 136,
@@ -1598,6 +1733,7 @@
 		"altTitles": [],
 		"artist": "YMCK",
 		"data": {
+			"duration": 134.853,
 			"genre": "maimai"
 		},
 		"id": 137,
@@ -1608,6 +1744,7 @@
 		"altTitles": [],
 		"artist": "Jimmy Weckl",
 		"data": {
+			"duration": 123.616,
 			"genre": "maimai"
 		},
 		"id": 138,
@@ -1618,6 +1755,7 @@
 		"altTitles": [],
 		"artist": "Jimmy Weckl",
 		"data": {
+			"duration": 113.265,
 			"genre": "maimai"
 		},
 		"id": 139,
@@ -1628,6 +1766,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata",
 		"data": {
+			"duration": 125.301,
 			"genre": "maimai"
 		},
 		"id": 140,
@@ -1640,6 +1779,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.SUIMI",
 		"data": {
+			"duration": 128.769,
 			"genre": "maimai"
 		},
 		"id": 141,
@@ -1650,6 +1790,7 @@
 		"altTitles": [],
 		"artist": "芳川よしの",
 		"data": {
+			"duration": 126.055,
 			"genre": "maimai"
 		},
 		"id": 142,
@@ -1663,6 +1804,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修",
 		"data": {
+			"duration": 119.185,
 			"genre": "maimai"
 		},
 		"id": 143,
@@ -1676,6 +1818,7 @@
 		"altTitles": [],
 		"artist": "にしもと先生、タクマ、どんちゃん「ちょっと盛りました。」",
 		"data": {
+			"duration": 132.02,
 			"genre": "maimai"
 		},
 		"id": 144,
@@ -1690,6 +1833,7 @@
 		"altTitles": [],
 		"artist": "福山光晴",
 		"data": {
+			"duration": 117.38,
 			"genre": "maimai"
 		},
 		"id": 145,
@@ -1700,6 +1844,7 @@
 		"altTitles": [],
 		"artist": "青木千紘/愛海",
 		"data": {
+			"duration": 111.701,
 			"genre": "maimai"
 		},
 		"id": 146,
@@ -1714,6 +1859,7 @@
 		"altTitles": [],
 		"artist": "Sta",
 		"data": {
+			"duration": 110.273,
 			"genre": "maimai"
 		},
 		"id": 147,
@@ -1724,6 +1870,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお(COOL＆CREATE)+ ARM(IOSYS)",
 		"data": {
+			"duration": 116.436,
 			"genre": "maimai"
 		},
 		"id": 148,
@@ -1736,6 +1883,7 @@
 		"altTitles": [],
 		"artist": "「サクラ大戦奏組」",
 		"data": {
+			"duration": 115.373,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 149,
@@ -1748,6 +1896,7 @@
 		"altTitles": [],
 		"artist": "Crush 40「ソニックアドベンチャー2」",
 		"data": {
+			"duration": 110.233,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 150,
@@ -1760,6 +1909,7 @@
 		"altTitles": [],
 		"artist": "幡谷尚史 Arranged by SEGA Sound Unit [H.]「バーニングレンジャー」",
 		"data": {
+			"duration": 107.613,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 151,
@@ -1774,6 +1924,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 119.172,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 152,
@@ -1787,6 +1938,7 @@
 		"altTitles": [],
 		"artist": "daniwell",
 		"data": {
+			"duration": 104,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 153,
@@ -1799,6 +1951,7 @@
 		"altTitles": [],
 		"artist": "",
 		"data": {
+			"duration": 100.507,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 154,
@@ -1811,6 +1964,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 123.117,
 			"genre": "maimai"
 		},
 		"id": 155,
@@ -1821,6 +1975,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 125.81,
 			"genre": "maimai"
 		},
 		"id": 156,
@@ -1831,6 +1986,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 135.09,
 			"genre": "maimai"
 		},
 		"id": 157,
@@ -1841,6 +1997,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 124.037,
 			"genre": "maimai"
 		},
 		"id": 158,
@@ -1851,6 +2008,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 131.208,
 			"genre": "maimai"
 		},
 		"id": 159,
@@ -1863,6 +2021,7 @@
 		"altTitles": [],
 		"artist": "「PHANTASY STAR PORTABLE」",
 		"data": {
+			"duration": 131.625,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 160,
@@ -1875,6 +2034,7 @@
 		"altTitles": [],
 		"artist": "「PHANTASY STAR PORTABLE2」",
 		"data": {
+			"duration": 88.16,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 161,
@@ -1885,6 +2045,7 @@
 		"altTitles": [],
 		"artist": "「PHANTASY STAR PORTABLE2 ∞」",
 		"data": {
+			"duration": 103.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 162,
@@ -1895,6 +2056,7 @@
 		"altTitles": [],
 		"artist": "オワタP",
 		"data": {
+			"duration": 120,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 163,
@@ -1909,6 +2071,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 111.993,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 164,
@@ -1922,6 +2085,7 @@
 		"altTitles": [],
 		"artist": "「龍が如く２」",
 		"data": {
+			"duration": 117.517,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 165,
@@ -1934,6 +2098,7 @@
 		"altTitles": [],
 		"artist": "「龍が如く 見参！」",
 		"data": {
+			"duration": 110.474,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 166,
@@ -1944,6 +2109,7 @@
 		"altTitles": [],
 		"artist": "「新豪血寺一族 -煩悩解放-」",
 		"data": {
+			"duration": 142.4,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 167,
@@ -1957,6 +2123,7 @@
 		"altTitles": [],
 		"artist": "iroha(sasaki)／kuma(alfred)",
 		"data": {
+			"duration": 99.818,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 168,
@@ -1970,6 +2137,7 @@
 		"altTitles": [],
 		"artist": "アゴアニキ",
 		"data": {
+			"duration": 107.509,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 169,
@@ -1982,6 +2150,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 123.29,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 170,
@@ -1994,6 +2163,7 @@
 		"altTitles": [],
 		"artist": "さつき が てんこもり",
 		"data": {
+			"duration": 147.429,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 171,
@@ -2008,6 +2178,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 137.795,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 172,
@@ -2020,6 +2191,7 @@
 		"altTitles": [],
 		"artist": "EZFG",
 		"data": {
+			"duration": 118.548,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 173,
@@ -2030,6 +2202,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 109.078,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 174,
@@ -2046,6 +2219,7 @@
 		"altTitles": [],
 		"artist": "ika",
 		"data": {
+			"duration": 101.233,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 175,
@@ -2059,6 +2233,7 @@
 		"altTitles": [],
 		"artist": "samfree",
 		"data": {
+			"duration": 118.182,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 176,
@@ -2071,6 +2246,7 @@
 		"altTitles": [],
 		"artist": "ナノウ",
 		"data": {
+			"duration": 133.257,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 177,
@@ -2094,6 +2270,7 @@
 		"altTitles": [],
 		"artist": "岸田教団＆THE明星ロケッツ",
 		"data": {
+			"duration": 106.037,
 			"genre": "東方Project"
 		},
 		"id": 179,
@@ -2106,6 +2283,7 @@
 		"altTitles": [],
 		"artist": "岸田教団＆THE明星ロケッツ",
 		"data": {
+			"duration": 98.65,
 			"genre": "東方Project"
 		},
 		"id": 180,
@@ -2118,6 +2296,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修「ホルカ・トルカ」",
 		"data": {
+			"duration": 118.674,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 181,
@@ -2128,6 +2307,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)",
 		"data": {
+			"duration": 116.5,
 			"genre": "東方Project"
 		},
 		"id": 182,
@@ -2140,6 +2320,7 @@
 		"altTitles": [],
 		"artist": "Neru",
 		"data": {
+			"duration": 132.461,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 183,
@@ -2155,6 +2336,7 @@
 		"altTitles": [],
 		"artist": "八王子P",
 		"data": {
+			"duration": 107.66,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 184,
@@ -2165,6 +2347,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)feat. miko",
 		"data": {
+			"duration": 114.425,
 			"genre": "東方Project"
 		},
 		"id": 185,
@@ -2179,6 +2362,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 125.581,
 			"genre": "東方Project"
 		},
 		"id": 186,
@@ -2192,6 +2376,7 @@
 		"altTitles": [],
 		"artist": "samfree feat.(V)・∀・(V)かにぱん。(A-ONE)",
 		"data": {
+			"duration": 122.379,
 			"genre": "東方Project"
 		},
 		"id": 187,
@@ -2202,6 +2387,7 @@
 		"altTitles": [],
 		"artist": "平井堅 [cover]",
 		"data": {
+			"duration": 123.34,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 188,
@@ -2212,6 +2398,7 @@
 		"altTitles": [],
 		"artist": "長沼英樹「ソニック ラッシュ」",
 		"data": {
+			"duration": 112.739,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 189,
@@ -2225,6 +2412,7 @@
 		"altTitles": [],
 		"artist": "舞風-MAIKAZE/沙紗飛鳥",
 		"data": {
+			"duration": 116.769,
 			"genre": "東方Project"
 		},
 		"id": 190,
@@ -2237,6 +2425,7 @@
 		"altTitles": [],
 		"artist": "SYNC.ART'S feat. 美里",
 		"data": {
+			"duration": 117.194,
 			"genre": "東方Project"
 		},
 		"id": 191,
@@ -2250,6 +2439,7 @@
 		"altTitles": [],
 		"artist": "あまね＋ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 117.684,
 			"genre": "東方Project"
 		},
 		"id": 192,
@@ -2262,6 +2452,7 @@
 		"altTitles": [],
 		"artist": "石鹸屋",
 		"data": {
+			"duration": 126.92,
 			"genre": "東方Project"
 		},
 		"id": 193,
@@ -2274,6 +2465,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 133.5,
 			"genre": "東方Project"
 		},
 		"id": 194,
@@ -2287,6 +2479,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 112.61,
 			"genre": "東方Project"
 		},
 		"id": 195,
@@ -2297,6 +2490,7 @@
 		"altTitles": [],
 		"artist": "ゆうゆ",
 		"data": {
+			"duration": 135.842,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 196,
@@ -2312,6 +2506,7 @@
 		"altTitles": [],
 		"artist": "M.S.S Project",
 		"data": {
+			"duration": 125.441,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 197,
@@ -2322,6 +2517,7 @@
 		"altTitles": [],
 		"artist": "Innocent Keyと小宮真央、ココ、樹詩音",
 		"data": {
+			"duration": 110.643,
 			"genre": "東方Project"
 		},
 		"id": 198,
@@ -2334,6 +2530,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 134.089,
 			"genre": "東方Project"
 		},
 		"id": 199,
@@ -2349,6 +2546,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお(COOL＆CREATE)",
 		"data": {
+			"duration": 121.057,
 			"genre": "東方Project"
 		},
 		"id": 200,
@@ -2361,6 +2559,7 @@
 		"altTitles": [],
 		"artist": "Performed by 光吉猛修",
 		"data": {
+			"duration": 108,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 201,
@@ -2373,6 +2572,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお母(尾崎順子)",
 		"data": {
+			"duration": 147.029,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 202,
@@ -2385,6 +2585,7 @@
 		"altTitles": [],
 		"artist": "はっぱ隊 [cover]",
 		"data": {
+			"duration": 133.377,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 203,
@@ -2395,6 +2596,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 143.416,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 204,
@@ -2407,6 +2609,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「ソニック ロストワールド」",
 		"data": {
+			"duration": 126.12,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 205,
@@ -2419,6 +2622,7 @@
 		"altTitles": [],
 		"artist": "うたよめ575＜正岡小豆(大坪由佳)小林抹茶(大橋彩香)＞",
 		"data": {
+			"duration": 91.497,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 206,
@@ -2433,6 +2637,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお + ARM feat. 高橋名人",
 		"data": {
+			"duration": 146.5,
 			"genre": "maimai"
 		},
 		"id": 207,
@@ -2446,6 +2651,7 @@
 		"altTitles": [],
 		"artist": "そらる・ろん×れるりり",
 		"data": {
+			"duration": 144.597,
 			"genre": "maimai"
 		},
 		"id": 208,
@@ -2458,6 +2664,7 @@
 		"altTitles": [],
 		"artist": "角田信朗「ヒーローバンク」",
 		"data": {
+			"duration": 92.449,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 209,
@@ -2470,6 +2677,7 @@
 		"altTitles": [],
 		"artist": "Trefle「チェインクロニクル」",
 		"data": {
+			"duration": 129.73,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 210,
@@ -2483,6 +2691,7 @@
 		"altTitles": [],
 		"artist": "向日葵×emon(Tes.)",
 		"data": {
+			"duration": 143.438,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 211,
@@ -2493,6 +2702,7 @@
 		"altTitles": [],
 		"artist": "Mitchie M",
 		"data": {
+			"duration": 93.257,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 212,
@@ -2505,6 +2715,7 @@
 		"altTitles": [],
 		"artist": "青木 千紘「龍が如く 維新！」",
 		"data": {
+			"duration": 97.19,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 213,
@@ -2518,6 +2729,7 @@
 		"altTitles": [],
 		"artist": "Nankumo/CUBE3",
 		"data": {
+			"duration": 93.229,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 214,
@@ -2528,6 +2740,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 111,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 215,
@@ -2540,6 +2753,7 @@
 		"altTitles": [],
 		"artist": "Hiro(SEGA)「ファンタジーゾーン」",
 		"data": {
+			"duration": 126.761,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 216,
@@ -2553,6 +2767,7 @@
 		"altTitles": [],
 		"artist": "COSIO(ZUNTATA/TAITO)/沢城千春「電車でGO!」",
 		"data": {
+			"duration": 111.894,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 217,
@@ -2566,6 +2781,7 @@
 		"altTitles": [],
 		"artist": "Yuji Masubuchi(BNGI)「RIDGE RACER」",
 		"data": {
+			"duration": 126.467,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 218,
@@ -2578,6 +2794,7 @@
 		"altTitles": [],
 		"artist": "Hiro(SEGA)「RIDGE RACER」「電車でGO!」",
 		"data": {
+			"duration": 126.575,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 219,
@@ -2590,6 +2807,7 @@
 		"altTitles": [],
 		"artist": "COSIO(ZUNTATA/TAITO)「ファンタジーゾーン」「RIDGE RACER」",
 		"data": {
+			"duration": 111.628,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 220,
@@ -2602,6 +2820,7 @@
 		"altTitles": [],
 		"artist": "Yuji Masubuchi(BNGI)「電車でGO!」「ファンタジーゾーン」",
 		"data": {
+			"duration": 131.451,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 221,
@@ -2615,6 +2834,7 @@
 		"altTitles": [],
 		"artist": "AcuticNotes",
 		"data": {
+			"duration": 115.476,
 			"genre": "maimai"
 		},
 		"id": 222,
@@ -2625,6 +2845,7 @@
 		"altTitles": [],
 		"artist": "カタオカツグミ",
 		"data": {
+			"duration": 105.073,
 			"genre": "maimai"
 		},
 		"id": 223,
@@ -2638,6 +2859,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.SUIMI",
 		"data": {
+			"duration": 122.667,
 			"genre": "maimai"
 		},
 		"id": 224,
@@ -2648,6 +2870,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)feat. 藤枝あかね",
 		"data": {
+			"duration": 104.798,
 			"genre": "東方Project"
 		},
 		"id": 225,
@@ -2661,6 +2884,7 @@
 		"altTitles": [],
 		"artist": "emon",
 		"data": {
+			"duration": 121.512,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 226,
@@ -2683,6 +2907,7 @@
 		"altTitles": [],
 		"artist": "岸田教団＆THE明星ロケッツ",
 		"data": {
+			"duration": 109.5,
 			"genre": "東方Project"
 		},
 		"id": 228,
@@ -2693,6 +2918,7 @@
 		"altTitles": [],
 		"artist": "Halozy",
 		"data": {
+			"duration": 105.333,
 			"genre": "東方Project"
 		},
 		"id": 229,
@@ -2705,6 +2931,7 @@
 		"altTitles": [],
 		"artist": "Jimmy Weckl feat.高貴みな",
 		"data": {
+			"duration": 118.547,
 			"genre": "maimai"
 		},
 		"id": 230,
@@ -2715,6 +2942,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 124.245,
 			"genre": "maimai"
 		},
 		"id": 231,
@@ -2727,6 +2955,7 @@
 		"altTitles": [],
 		"artist": "EB(aka EarBreaker)",
 		"data": {
+			"duration": 128.571,
 			"genre": "maimai"
 		},
 		"id": 232,
@@ -2740,6 +2969,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 121.2,
 			"genre": "maimai"
 		},
 		"id": 233,
@@ -2756,6 +2986,7 @@
 		"altTitles": [],
 		"artist": "ヒゲドライバー",
 		"data": {
+			"duration": 115.59,
 			"genre": "maimai"
 		},
 		"id": 234,
@@ -2766,6 +2997,7 @@
 		"altTitles": [],
 		"artist": "Shandy kubota",
 		"data": {
+			"duration": 122.722,
 			"genre": "maimai"
 		},
 		"id": 235,
@@ -2776,6 +3008,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 119.413,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 236,
@@ -2788,6 +3021,7 @@
 		"altTitles": [],
 		"artist": "伊東歌詞太郎",
 		"data": {
+			"duration": 122.719,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 237,
@@ -2798,6 +3032,7 @@
 		"altTitles": [],
 		"artist": "paraoka",
 		"data": {
+			"duration": 125.138,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 238,
@@ -2808,6 +3043,7 @@
 		"altTitles": [],
 		"artist": "樽木栄一郎",
 		"data": {
+			"duration": 124.812,
 			"genre": "maimai"
 		},
 		"id": 239,
@@ -2818,6 +3054,7 @@
 		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
+			"duration": 146.943,
 			"genre": "maimai"
 		},
 		"id": 240,
@@ -2831,6 +3068,7 @@
 		"altTitles": [],
 		"artist": "うどんゲルゲ",
 		"data": {
+			"duration": 137.844,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 241,
@@ -2843,6 +3081,7 @@
 		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
+			"duration": 130.146,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 242,
@@ -2858,6 +3097,7 @@
 		"altTitles": [],
 		"artist": "ギガ/れをる",
 		"data": {
+			"duration": 121.981,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 243,
@@ -2871,6 +3111,7 @@
 		"altTitles": [],
 		"artist": "Circle of friends(天月-あまつき-・un:c・伊東歌詞太郎・コニー・はしやん)",
 		"data": {
+			"duration": 139.256,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 244,
@@ -2885,6 +3126,7 @@
 		"altTitles": [],
 		"artist": "Hiro「maimai」より",
 		"data": {
+			"duration": 119.719,
 			"genre": "maimai"
 		},
 		"id": 245,
@@ -2895,6 +3137,7 @@
 		"altTitles": [],
 		"artist": "Yuji Masubuchi「太鼓の達人」より",
 		"data": {
+			"duration": 124.39,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 246,
@@ -2907,6 +3150,7 @@
 		"altTitles": [],
 		"artist": "猫叉Master「jubeat」より",
 		"data": {
+			"duration": 122.157,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 247,
@@ -2919,6 +3163,7 @@
 		"altTitles": [],
 		"artist": "COSIO(ZUNTATA)「グルーヴコースター」より",
 		"data": {
+			"duration": 125.124,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 248,
@@ -2929,6 +3174,7 @@
 		"altTitles": [],
 		"artist": "LindaAI-CUE(BNGI)「太鼓の達人」より",
 		"data": {
+			"duration": 124.813,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 249,
@@ -2943,6 +3189,7 @@
 		"altTitles": [],
 		"artist": "DJ YOSHITAKA「jubeat」より",
 		"data": {
+			"duration": 125.148,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 250,
@@ -2953,6 +3200,7 @@
 		"altTitles": [],
 		"artist": "E.G.G.「グルーヴコースター」より",
 		"data": {
+			"duration": 124.512,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 251,
@@ -2963,6 +3211,7 @@
 		"altTitles": [],
 		"artist": "ぽてんしゃる0",
 		"data": {
+			"duration": 131.281,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 252,
@@ -2975,6 +3224,7 @@
 		"altTitles": [],
 		"artist": "MARUDARUMA",
 		"data": {
+			"duration": 140.036,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 253,
@@ -2987,6 +3237,7 @@
 		"altTitles": [],
 		"artist": "スズム",
 		"data": {
+			"duration": 144.601,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 254,
@@ -3000,6 +3251,7 @@
 		"altTitles": [],
 		"artist": "ろん×田中秀和(MONACA)",
 		"data": {
+			"duration": 128.525,
 			"genre": "maimai"
 		},
 		"id": 255,
@@ -3012,6 +3264,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 125,
 			"genre": "東方Project"
 		},
 		"id": 256,
@@ -3024,6 +3277,7 @@
 		"altTitles": [],
 		"artist": "KeN/エンドケイプ",
 		"data": {
+			"duration": 135.592,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 257,
@@ -3036,6 +3290,7 @@
 		"altTitles": [],
 		"artist": "ゆうゆ",
 		"data": {
+			"duration": 132.935,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 258,
@@ -3049,6 +3304,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 116.499,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 259,
@@ -3062,6 +3318,7 @@
 		"altTitles": [],
 		"artist": "くちばしP",
 		"data": {
+			"duration": 119.742,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 260,
@@ -3077,6 +3334,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 138.454,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 261,
@@ -3092,6 +3350,7 @@
 		"altTitles": [],
 		"artist": "HoneyWorks",
 		"data": {
+			"duration": 140.715,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 262,
@@ -3104,6 +3363,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ(IOSYS)feat.山本椛",
 		"data": {
+			"duration": 94.899,
 			"genre": "東方Project"
 		},
 		"id": 263,
@@ -3117,6 +3377,7 @@
 		"altTitles": [],
 		"artist": "SC-3000(シーさん)/CV.相沢 舞、SG-1000(せん)/CV.芹澤 優、SG-1000Ⅱ(せんつー)/CV.大空直美、ゲームギア(ムギ)/CV.田中美海、ロボピッチャ(ぴっちゃん)/CV.もものはるな「Hi☆sCoool! セハガール」 [アニメPV]",
 		"data": {
+			"duration": 122.92,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 264,
@@ -3130,6 +3391,7 @@
 		"altTitles": [],
 		"artist": "n-buna",
 		"data": {
+			"duration": 137.321,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 265,
@@ -3143,6 +3405,7 @@
 		"altTitles": [],
 		"artist": "Hiro feat.越田Rute隆人&ビートまりお",
 		"data": {
+			"duration": 146.131,
 			"genre": "maimai"
 		},
 		"id": 266,
@@ -3157,6 +3420,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 136.048,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 267,
@@ -3169,6 +3433,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 146.521,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 268,
@@ -3179,6 +3444,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 132.69,
 			"genre": "maimai"
 		},
 		"id": 269,
@@ -3189,6 +3455,7 @@
 		"altTitles": [],
 		"artist": "Ras",
 		"data": {
+			"duration": 130.212,
 			"genre": "maimai"
 		},
 		"id": 270,
@@ -3199,6 +3466,7 @@
 		"altTitles": [],
 		"artist": "発熱巫女～ず",
 		"data": {
+			"duration": 99.043,
 			"genre": "東方Project"
 		},
 		"id": 271,
@@ -3211,6 +3479,7 @@
 		"altTitles": [],
 		"artist": "石鹸屋",
 		"data": {
+			"duration": 145.792,
 			"genre": "東方Project"
 		},
 		"id": 272,
@@ -3224,6 +3493,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 144,
 			"genre": "東方Project"
 		},
 		"id": 273,
@@ -3236,6 +3506,7 @@
 		"altTitles": [],
 		"artist": "どぶウサギ",
 		"data": {
+			"duration": 134.476,
 			"genre": "東方Project"
 		},
 		"id": 274,
@@ -3249,6 +3520,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 129.78,
 			"genre": "maimai"
 		},
 		"id": 275,
@@ -3261,6 +3533,7 @@
 		"altTitles": [],
 		"artist": "うたたP",
 		"data": {
+			"duration": 148.059,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 276,
@@ -3278,6 +3551,7 @@
 		"altTitles": [],
 		"artist": "発熱巫女～ず",
 		"data": {
+			"duration": 147,
 			"genre": "東方Project"
 		},
 		"id": 277,
@@ -3292,6 +3566,7 @@
 		"altTitles": [],
 		"artist": "舞風-MAIKAZE/時音-TOKINE",
 		"data": {
+			"duration": 93.647,
 			"genre": "東方Project"
 		},
 		"id": 278,
@@ -3317,6 +3592,7 @@
 		"altTitles": [],
 		"artist": "myu314 feat.あまね(COOL&CREATE)",
 		"data": {
+			"duration": 118.725,
 			"genre": "東方Project"
 		},
 		"id": 280,
@@ -3327,6 +3603,7 @@
 		"altTitles": [],
 		"artist": "koutaq",
 		"data": {
+			"duration": 125.055,
 			"genre": "東方Project"
 		},
 		"id": 281,
@@ -3340,6 +3617,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお",
 		"data": {
+			"duration": 137.897,
 			"genre": "東方Project"
 		},
 		"id": 282,
@@ -3366,6 +3644,7 @@
 		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
+			"duration": 141.571,
 			"genre": "maimai"
 		},
 		"id": 284,
@@ -3376,6 +3655,7 @@
 		"altTitles": [],
 		"artist": "ギガ/れをる　ダンス　アルスマグナ",
 		"data": {
+			"duration": 141.322,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 285,
@@ -3395,6 +3675,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 142.422,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 286,
@@ -3407,6 +3688,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 146.41,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 287,
@@ -3419,6 +3701,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 139.346,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 288,
@@ -3432,6 +3715,7 @@
 		"altTitles": [],
 		"artist": "Kai「Wonderland Wars」",
 		"data": {
+			"duration": 113.777,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 289,
@@ -3442,6 +3726,7 @@
 		"altTitles": [],
 		"artist": "東京アクティブNEETs",
 		"data": {
+			"duration": 140.226,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 290,
@@ -3452,6 +3737,7 @@
 		"altTitles": [],
 		"artist": "DECO*27 feat.echo",
 		"data": {
+			"duration": 145.339,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 291,
@@ -3462,6 +3748,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 122.636,
 			"genre": "maimai"
 		},
 		"id": 292,
@@ -3474,6 +3761,7 @@
 		"altTitles": [],
 		"artist": "S!N・高橋菜々×ひとしずく・やま△",
 		"data": {
+			"duration": 116.273,
 			"genre": "maimai"
 		},
 		"id": 293,
@@ -3486,6 +3774,7 @@
 		"altTitles": [],
 		"artist": "高橋菜々×岡部啓一(MONACA)",
 		"data": {
+			"duration": 135.999,
 			"genre": "maimai"
 		},
 		"id": 294,
@@ -3498,6 +3787,7 @@
 		"altTitles": [],
 		"artist": "M.S.S Project",
 		"data": {
+			"duration": 146.286,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 295,
@@ -3511,6 +3801,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 143.079,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 296,
@@ -3525,6 +3816,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 145.045,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 297,
@@ -3539,6 +3831,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 131.886,
 			"genre": "maimai"
 		},
 		"id": 298,
@@ -3551,6 +3844,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 133.431,
 			"genre": "maimai"
 		},
 		"id": 299,
@@ -3561,6 +3855,7 @@
 		"altTitles": [],
 		"artist": "void(Mournfinale)",
 		"data": {
+			"duration": 130.564,
 			"genre": "maimai"
 		},
 		"id": 300,
@@ -3573,6 +3868,7 @@
 		"altTitles": [],
 		"artist": "tilt-six feat.串伊トモミ",
 		"data": {
+			"duration": 140.979,
 			"genre": "maimai"
 		},
 		"id": 301,
@@ -3585,6 +3881,7 @@
 		"altTitles": [],
 		"artist": "じまんぐ",
 		"data": {
+			"duration": 144.78,
 			"genre": "東方Project"
 		},
 		"id": 302,
@@ -3595,6 +3892,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 121.935,
 			"genre": "東方Project"
 		},
 		"id": 303,
@@ -3607,6 +3905,7 @@
 		"altTitles": [],
 		"artist": "あべにゅうぷろじぇくと feat.佐倉紗織&井上みゆ「パチスロ快盗天使ツインエンジェル」",
 		"data": {
+			"duration": 97.107,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 304,
@@ -3620,6 +3919,7 @@
 		"altTitles": [],
 		"artist": "loos feat. 柊莉杏",
 		"data": {
+			"duration": 137.606,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 305,
@@ -3632,6 +3932,7 @@
 		"altTitles": [],
 		"artist": "Sta feat.b",
 		"data": {
+			"duration": 132.743,
 			"genre": "maimai"
 		},
 		"id": 306,
@@ -3645,6 +3946,7 @@
 		"altTitles": [],
 		"artist": "れるりり",
 		"data": {
+			"duration": 145.699,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 307,
@@ -3660,6 +3962,7 @@
 		"altTitles": [],
 		"artist": "カラスは真っ白",
 		"data": {
+			"duration": 138.203,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 308,
@@ -3672,6 +3975,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 104.91,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 309,
@@ -3685,6 +3989,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 134.635,
 			"genre": "東方Project"
 		},
 		"id": 310,
@@ -3697,6 +4002,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 122.827,
 			"genre": "maimai"
 		},
 		"id": 311,
@@ -3707,6 +4013,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 147.559,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 312,
@@ -3717,6 +4024,7 @@
 		"altTitles": [],
 		"artist": "INNOCENT NOIZE",
 		"data": {
+			"duration": 131.409,
 			"genre": "maimai"
 		},
 		"id": 313,
@@ -3727,6 +4035,7 @@
 		"altTitles": [],
 		"artist": "Ino(chronoize)",
 		"data": {
+			"duration": 120.414,
 			"genre": "maimai"
 		},
 		"id": 314,
@@ -3737,6 +4046,7 @@
 		"altTitles": [],
 		"artist": "D-Cee",
 		"data": {
+			"duration": 126.571,
 			"genre": "maimai"
 		},
 		"id": 315,
@@ -3749,6 +4059,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 142.125,
 			"genre": "maimai"
 		},
 		"id": 316,
@@ -3759,6 +4070,7 @@
 		"altTitles": [],
 		"artist": "WAiKURO",
 		"data": {
+			"duration": 141.435,
 			"genre": "maimai"
 		},
 		"id": 317,
@@ -3774,6 +4086,7 @@
 		"altTitles": [],
 		"artist": "カラスは真っ白",
 		"data": {
+			"duration": 141.283,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 318,
@@ -3786,6 +4099,7 @@
 		"altTitles": [],
 		"artist": "Hi☆sCoool! セハガール",
 		"data": {
+			"duration": 135.381,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 319,
@@ -3799,6 +4113,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 123.204,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 320,
@@ -3812,6 +4127,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 135.143,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 321,
@@ -3825,6 +4141,7 @@
 		"altTitles": [],
 		"artist": "Dixie Flatline",
 		"data": {
+			"duration": 146.953,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 322,
@@ -3847,6 +4164,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 146.363,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 324,
@@ -3860,6 +4178,7 @@
 		"altTitles": [],
 		"artist": "骨盤P",
 		"data": {
+			"duration": 136.923,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 325,
@@ -3870,6 +4189,7 @@
 		"altTitles": [],
 		"artist": "40mP",
 		"data": {
+			"duration": 139.03,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 326,
@@ -3883,6 +4203,7 @@
 		"altTitles": [],
 		"artist": "椎名もた (ぽわぽわP)",
 		"data": {
+			"duration": 132.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 327,
@@ -3895,6 +4216,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 135.243,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 328,
@@ -3907,6 +4229,7 @@
 		"altTitles": [],
 		"artist": "トラボルタ",
 		"data": {
+			"duration": 148.071,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 329,
@@ -3919,6 +4242,7 @@
 		"altTitles": [],
 		"artist": "out of service",
 		"data": {
+			"duration": 142.927,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 330,
@@ -3931,6 +4255,7 @@
 		"altTitles": [],
 		"artist": "SLAVE.V-V-R",
 		"data": {
+			"duration": 138.98,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 331,
@@ -3944,6 +4269,7 @@
 		"altTitles": [],
 		"artist": "今日犬",
 		"data": {
+			"duration": 114.53,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 332,
@@ -3957,6 +4283,7 @@
 		"altTitles": [],
 		"artist": "hanzo/赤飯歌唱Ver",
 		"data": {
+			"duration": 151.736,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 333,
@@ -3969,6 +4296,7 @@
 		"altTitles": [],
 		"artist": "CIRCRUSH",
 		"data": {
+			"duration": 131.786,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 334,
@@ -3979,6 +4307,7 @@
 		"altTitles": [],
 		"artist": "ワンダフル☆オポチュニティ！",
 		"data": {
+			"duration": 120.621,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 335,
@@ -3992,6 +4321,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 132.265,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 336,
@@ -4002,6 +4332,7 @@
 		"altTitles": [],
 		"artist": "日向電工",
 		"data": {
+			"duration": 132,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 337,
@@ -4014,6 +4345,7 @@
 		"altTitles": [],
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
+			"duration": 144.594,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 338,
@@ -4024,6 +4356,7 @@
 		"altTitles": [],
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
+			"duration": 146.73,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 339,
@@ -4038,6 +4371,7 @@
 		"altTitles": [],
 		"artist": "れるりり feat.ろん",
 		"data": {
+			"duration": 142.857,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 340,
@@ -4048,6 +4382,7 @@
 		"altTitles": [],
 		"artist": "Takahiro Eguchi feat. 三澤秋",
 		"data": {
+			"duration": 150.521,
 			"genre": "maimai"
 		},
 		"id": 341,
@@ -4058,6 +4393,7 @@
 		"altTitles": [],
 		"artist": "小野隊長とJimmy親分",
 		"data": {
+			"duration": 131.502,
 			"genre": "maimai"
 		},
 		"id": 342,
@@ -4073,6 +4409,7 @@
 		"altTitles": [],
 		"artist": "vox2（小野秀幸）",
 		"data": {
+			"duration": 131.851,
 			"genre": "maimai"
 		},
 		"id": 343,
@@ -4085,6 +4422,7 @@
 		"altTitles": [],
 		"artist": "ゆりん・柿チョコ×Neru",
 		"data": {
+			"duration": 142.092,
 			"genre": "maimai"
 		},
 		"id": 344,
@@ -4097,6 +4435,7 @@
 		"altTitles": [],
 		"artist": "柿チョコ×みきとP",
 		"data": {
+			"duration": 148.322,
 			"genre": "maimai"
 		},
 		"id": 345,
@@ -4107,6 +4446,7 @@
 		"altTitles": [],
 		"artist": "Jun Senoue",
 		"data": {
+			"duration": 115.675,
 			"genre": "maimai"
 		},
 		"id": 346,
@@ -4119,6 +4459,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 128.698,
 			"genre": "東方Project"
 		},
 		"id": 347,
@@ -4133,6 +4474,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 106.5,
 			"genre": "東方Project"
 		},
 		"id": 348,
@@ -4145,6 +4487,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 139.814,
 			"genre": "東方Project"
 		},
 		"id": 349,
@@ -4155,6 +4498,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.miko",
 		"data": {
+			"duration": 139.566,
 			"genre": "東方Project"
 		},
 		"id": 350,
@@ -4169,6 +4513,7 @@
 		"altTitles": [],
 		"artist": "IRON ATTACK!",
 		"data": {
+			"duration": 143.773,
 			"genre": "東方Project"
 		},
 		"id": 351,
@@ -4182,6 +4527,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 104.517,
 			"genre": "東方Project"
 		},
 		"id": 352,
@@ -4194,6 +4540,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 139.512,
 			"genre": "東方Project"
 		},
 		"id": 353,
@@ -4207,6 +4554,7 @@
 		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
+			"duration": 119.926,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 354,
@@ -4217,6 +4565,7 @@
 		"altTitles": [],
 		"artist": "クーナ(CV 喜多村英梨)「PHANTASY STAR ONLINE 2」",
 		"data": {
+			"duration": 135.245,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 355,
@@ -4230,6 +4579,7 @@
 		"altTitles": [],
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
+			"duration": 145.537,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 356,
@@ -4242,6 +4592,7 @@
 		"altTitles": [],
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
+			"duration": 147.943,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 357,
@@ -4257,6 +4608,7 @@
 		"altTitles": [],
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
+			"duration": 146.453,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 358,
@@ -4269,6 +4621,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 134,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 359,
@@ -4281,6 +4634,7 @@
 		"altTitles": [],
 		"artist": "和田たけあき(くらげP)",
 		"data": {
+			"duration": 136.636,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 360,
@@ -4294,6 +4648,7 @@
 		"altTitles": [],
 		"artist": "EBIMAYO",
 		"data": {
+			"duration": 128.228,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 361,
@@ -4304,6 +4659,7 @@
 		"altTitles": [],
 		"artist": "BNSI（Taku Inoue）「シンクロニカ」より",
 		"data": {
+			"duration": 134.192,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 362,
@@ -4320,6 +4676,7 @@
 		"altTitles": [],
 		"artist": "MECHANiCAL PANDA「BORDER BREAK」",
 		"data": {
+			"duration": 135.455,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 363,
@@ -4332,6 +4689,7 @@
 		"altTitles": [],
 		"artist": "Yosh(Survive Said The Prophet)",
 		"data": {
+			"duration": 124,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 364,
@@ -4342,6 +4700,7 @@
 		"altTitles": [],
 		"artist": "un:c・ろん×じーざすP",
 		"data": {
+			"duration": 135.484,
 			"genre": "maimai"
 		},
 		"id": 365,
@@ -4355,6 +4714,7 @@
 		"altTitles": [],
 		"artist": "歌組雪月花 夜々(原田ひとみ)/いろり(茅野愛衣)/小紫(小倉唯)「機巧少女は傷つかない」",
 		"data": {
+			"duration": 92.438,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 366,
@@ -4368,6 +4728,7 @@
 		"altTitles": [],
 		"artist": "さつき が てんこもり feat. YURiCa/花たん",
 		"data": {
+			"duration": 137.5,
 			"genre": "maimai"
 		},
 		"id": 367,
@@ -4382,6 +4743,7 @@
 		"altTitles": [],
 		"artist": "LOPIT",
 		"data": {
+			"duration": 124.2,
 			"genre": "maimai"
 		},
 		"id": 368,
@@ -4392,6 +4754,7 @@
 		"altTitles": [],
 		"artist": "鬱P feat.flower",
 		"data": {
+			"duration": 130.714,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 369,
@@ -4405,6 +4768,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 140.129,
 			"genre": "maimai"
 		},
 		"id": 370,
@@ -4420,6 +4784,7 @@
 		"altTitles": [],
 		"artist": "ルゼ",
 		"data": {
+			"duration": 140.595,
 			"genre": "maimai"
 		},
 		"id": 371,
@@ -4430,6 +4795,7 @@
 		"altTitles": [],
 		"artist": "ろん×黒魔",
 		"data": {
+			"duration": 120.9,
 			"genre": "maimai"
 		},
 		"id": 372,
@@ -4442,6 +4808,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 134.857,
 			"genre": "maimai"
 		},
 		"id": 373,
@@ -4455,6 +4822,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 146.207,
 			"genre": "東方Project"
 		},
 		"id": 374,
@@ -4467,6 +4835,7 @@
 		"altTitles": [],
 		"artist": "cubesato",
 		"data": {
+			"duration": 129.114,
 			"genre": "maimai"
 		},
 		"id": 375,
@@ -4481,6 +4850,7 @@
 		"altTitles": [],
 		"artist": "Aliesrite* (Ym1024 feat. lamie*)",
 		"data": {
+			"duration": 129.73,
 			"genre": "maimai"
 		},
 		"id": 376,
@@ -4491,6 +4861,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 146.745,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 377,
@@ -4503,6 +4874,7 @@
 		"altTitles": [],
 		"artist": "ONIGAWARA",
 		"data": {
+			"duration": 146.444,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 378,
@@ -4516,6 +4888,7 @@
 		"altTitles": [],
 		"artist": "亜沙",
 		"data": {
+			"duration": 140.178,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 379,
@@ -4529,6 +4902,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 138.83,
 			"genre": "maimai"
 		},
 		"id": 380,
@@ -4543,6 +4917,7 @@
 		"altTitles": [],
 		"artist": "セブンスヘブンMAXION",
 		"data": {
+			"duration": 127.25,
 			"genre": "東方Project"
 		},
 		"id": 381,
@@ -4556,6 +4931,7 @@
 		"altTitles": [],
 		"artist": "矢鴇つかさ feat. 三澤秋",
 		"data": {
+			"duration": 125.333,
 			"genre": "東方Project"
 		},
 		"id": 382,
@@ -4566,6 +4942,7 @@
 		"altTitles": [],
 		"artist": "void＋夕野ヨシミ (IOSYS) feat.藤原鞠菜",
 		"data": {
+			"duration": 102.857,
 			"genre": "東方Project"
 		},
 		"id": 383,
@@ -4579,6 +4956,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 134.286,
 			"genre": "東方Project"
 		},
 		"id": 384,
@@ -4589,6 +4967,7 @@
 		"altTitles": [],
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
+			"duration": 140.129,
 			"genre": "東方Project"
 		},
 		"id": 385,
@@ -4602,6 +4981,7 @@
 		"altTitles": [],
 		"artist": "n-buna",
 		"data": {
+			"duration": 131.714,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 386,
@@ -4615,6 +4995,7 @@
 		"altTitles": [],
 		"artist": "cybermiso",
 		"data": {
+			"duration": 136.352,
 			"genre": "maimai"
 		},
 		"id": 387,
@@ -4627,6 +5008,7 @@
 		"altTitles": [],
 		"artist": "Street",
 		"data": {
+			"duration": 119.974,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 388,
@@ -4637,6 +5019,7 @@
 		"altTitles": [],
 		"artist": "siromaru + cranky",
 		"data": {
+			"duration": 138.938,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 389,
@@ -4647,6 +5030,7 @@
 		"altTitles": [],
 		"artist": "まふまふ",
 		"data": {
+			"duration": 126.65,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 390,
@@ -4660,6 +5044,7 @@
 		"altTitles": [],
 		"artist": "YASUHIRO(康寛)",
 		"data": {
+			"duration": 116.667,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 391,
@@ -4672,6 +5057,7 @@
 		"altTitles": [],
 		"artist": "uno(IOSYS) feat.miko",
 		"data": {
+			"duration": 128.211,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 392,
@@ -4684,6 +5070,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE (HARDCORE TANO*C)",
 		"data": {
+			"duration": 142.258,
 			"genre": "東方Project"
 		},
 		"id": 393,
@@ -4696,6 +5083,7 @@
 		"altTitles": [],
 		"artist": "n-buna feat.ヤギヌマカナ",
 		"data": {
+			"duration": 142.636,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 394,
@@ -4709,6 +5097,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 146.4,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 395,
@@ -4719,6 +5108,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 130.865,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 396,
@@ -4731,6 +5121,7 @@
 		"altTitles": [],
 		"artist": "Innocent Keyと梨本悠里、JUNCA、小宮真央、樹詩音、大瀬良あい",
 		"data": {
+			"duration": 125.333,
 			"genre": "東方Project"
 		},
 		"id": 397,
@@ -4744,6 +5135,7 @@
 		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
+			"duration": 140.824,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 398,
@@ -4756,6 +5148,7 @@
 		"altTitles": [],
 		"artist": "伊東歌詞太郎・ろん×れるりり",
 		"data": {
+			"duration": 139.111,
 			"genre": "maimai"
 		},
 		"id": 399,
@@ -4768,6 +5161,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 136.774,
 			"genre": "maimai"
 		},
 		"id": 400,
@@ -4791,6 +5185,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 139.071,
 			"genre": "maimai"
 		},
 		"id": 402,
@@ -4805,6 +5200,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 134.393,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 403,
@@ -4818,6 +5214,7 @@
 		"altTitles": [],
 		"artist": "すこっぷ",
 		"data": {
+			"duration": 127.734,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 404,
@@ -4830,6 +5227,7 @@
 		"altTitles": [],
 		"artist": "niki",
 		"data": {
+			"duration": 136.129,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 405,
@@ -4840,6 +5238,7 @@
 		"altTitles": [],
 		"artist": "ぱなまん/カラスヤサボウ",
 		"data": {
+			"duration": 133.421,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 406,
@@ -4853,6 +5252,7 @@
 		"altTitles": [],
 		"artist": "カラフル・サウンズ・ポート",
 		"data": {
+			"duration": 139.088,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 407,
@@ -4863,6 +5263,7 @@
 		"altTitles": [],
 		"artist": "Nizikawa",
 		"data": {
+			"duration": 118,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 408,
@@ -4873,6 +5274,7 @@
 		"altTitles": [],
 		"artist": "伊東歌詞太郎・ろん×まらしぃ",
 		"data": {
+			"duration": 143.973,
 			"genre": "maimai"
 		},
 		"id": 409,
@@ -4886,6 +5288,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 142.894,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 410,
@@ -4899,6 +5302,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 146.526,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 411,
@@ -4912,6 +5316,7 @@
 		"altTitles": [],
 		"artist": "DiGiTAL WiNG",
 		"data": {
+			"duration": 125.294,
 			"genre": "maimai"
 		},
 		"id": 412,
@@ -4922,6 +5327,7 @@
 		"altTitles": [],
 		"artist": "Halozy",
 		"data": {
+			"duration": 128.444,
 			"genre": "maimai"
 		},
 		"id": 413,
@@ -4935,6 +5341,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 130.227,
 			"genre": "maimai"
 		},
 		"id": 414,
@@ -4945,6 +5352,7 @@
 		"altTitles": [],
 		"artist": "A4paper",
 		"data": {
+			"duration": 121.346,
 			"genre": "maimai"
 		},
 		"id": 415,
@@ -4957,6 +5365,7 @@
 		"altTitles": [],
 		"artist": "加賀美 祥「学園ハンサム」",
 		"data": {
+			"duration": 111.6,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 416,
@@ -4969,6 +5378,7 @@
 		"altTitles": [],
 		"artist": "打首獄門同好会",
 		"data": {
+			"duration": 114.783,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 417,
@@ -4981,6 +5391,7 @@
 		"altTitles": [],
 		"artist": "ナイセン - momoco-",
 		"data": {
+			"duration": 143.163,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 418,
@@ -4993,6 +5404,7 @@
 		"altTitles": [],
 		"artist": "発熱巫女～ず",
 		"data": {
+			"duration": 113.209,
 			"genre": "東方Project"
 		},
 		"id": 419,
@@ -5003,6 +5415,7 @@
 		"altTitles": [],
 		"artist": "どぶウサギ",
 		"data": {
+			"duration": 106.308,
 			"genre": "東方Project"
 		},
 		"id": 420,
@@ -5015,6 +5428,7 @@
 		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
+			"duration": 136.499,
 			"genre": "東方Project"
 		},
 		"id": 421,
@@ -5025,6 +5439,7 @@
 		"altTitles": [],
 		"artist": "MintJam feat.光吉猛修",
 		"data": {
+			"duration": 135.568,
 			"genre": "maimai"
 		},
 		"id": 422,
@@ -5035,6 +5450,7 @@
 		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
+			"duration": 133.2,
 			"genre": "maimai"
 		},
 		"id": 423,
@@ -5049,6 +5465,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 145.077,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 424,
@@ -5061,6 +5478,7 @@
 		"altTitles": [],
 		"artist": "月鈴 白奈(CV:高野 麻里佳)",
 		"data": {
+			"duration": 148.138,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 425,
@@ -5071,6 +5489,7 @@
 		"altTitles": [],
 		"artist": "月鈴 那知(CV:今村 彩夏)",
 		"data": {
+			"duration": 148.102,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 426,
@@ -5084,6 +5503,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修「デイトナ Championship USA」",
 		"data": {
+			"duration": 128.75,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 427,
@@ -5096,6 +5516,7 @@
 		"altTitles": [],
 		"artist": "10Re;「学園ハンサム」",
 		"data": {
+			"duration": 113.143,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 428,
@@ -5108,6 +5529,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 131.853,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 429,
@@ -5120,6 +5542,7 @@
 		"altTitles": [],
 		"artist": "D.watt(IOSYS)＋らっぷびと",
 		"data": {
+			"duration": 120.911,
 			"genre": "東方Project"
 		},
 		"id": 430,
@@ -5134,6 +5557,7 @@
 		"altTitles": [],
 		"artist": "ねこみりん + nora2r feat. 小宮真央",
 		"data": {
+			"duration": 132.552,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 431,
@@ -5148,6 +5572,7 @@
 		"altTitles": [],
 		"artist": "愛(C.V.大坪由佳) 麻衣(C.V.内田彩) ミイ(C.V.内田真礼)「あいまいみー」",
 		"data": {
+			"duration": 106.378,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 432,
@@ -5160,6 +5585,7 @@
 		"altTitles": [],
 		"artist": "カルロス袴田(サイゼP)",
 		"data": {
+			"duration": 129.945,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 433,
@@ -5172,6 +5598,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 122.4,
 			"genre": "maimai"
 		},
 		"id": 434,
@@ -5184,6 +5611,7 @@
 		"altTitles": [],
 		"artist": "IOSYSと愉快な⑨周年フレンズ",
 		"data": {
+			"duration": 128.914,
 			"genre": "東方Project"
 		},
 		"id": 435,
@@ -5202,6 +5630,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 124.966,
 			"genre": "maimai"
 		},
 		"id": 436,
@@ -5215,6 +5644,7 @@
 		"altTitles": [],
 		"artist": "どうぶつビスケッツ×PPP「けものフレンズ」",
 		"data": {
+			"duration": 95.294,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 437,
@@ -5241,6 +5671,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 140.109,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 439,
@@ -5253,6 +5684,7 @@
 		"altTitles": [],
 		"artist": "モリモリあつし",
 		"data": {
+			"duration": 120.8,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 440,
@@ -5263,6 +5695,7 @@
 		"altTitles": [],
 		"artist": "Sou×マチゲリータ",
 		"data": {
+			"duration": 141.982,
 			"genre": "maimai"
 		},
 		"id": 441,
@@ -5275,6 +5708,7 @@
 		"altTitles": [],
 		"artist": "DECO*27 feat.Tia",
 		"data": {
+			"duration": 129.184,
 			"genre": "maimai"
 		},
 		"id": 442,
@@ -5285,6 +5719,7 @@
 		"altTitles": [],
 		"artist": "のぼる↑",
 		"data": {
+			"duration": 135.3,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 443,
@@ -5297,6 +5732,7 @@
 		"altTitles": [],
 		"artist": "Mitchie M",
 		"data": {
+			"duration": 145.15,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 444,
@@ -5310,6 +5746,7 @@
 		"altTitles": [],
 		"artist": "n-buna × Orangestar",
 		"data": {
+			"duration": 138,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 445,
@@ -5342,6 +5779,7 @@
 		"altTitles": [],
 		"artist": "naotyu- feat. 佐々木恵梨",
 		"data": {
+			"duration": 127.731,
 			"genre": "maimai"
 		},
 		"id": 448,
@@ -5352,6 +5790,7 @@
 		"altTitles": [],
 		"artist": "Palme",
 		"data": {
+			"duration": 138.75,
 			"genre": "maimai"
 		},
 		"id": 449,
@@ -5362,6 +5801,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 135.6,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 450,
@@ -5375,6 +5815,7 @@
 		"altTitles": [],
 		"artist": "どぶウサギ",
 		"data": {
+			"duration": 123.48,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 451,
@@ -5387,6 +5828,7 @@
 		"altTitles": [],
 		"artist": "谷屋楽",
 		"data": {
+			"duration": 146.667,
 			"genre": "東方Project"
 		},
 		"id": 452,
@@ -5399,6 +5841,7 @@
 		"altTitles": [],
 		"artist": "ササノマリイ",
 		"data": {
+			"duration": 139.565,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 453,
@@ -5411,6 +5854,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 133.091,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 454,
@@ -5423,6 +5867,7 @@
 		"altTitles": [],
 		"artist": "Frums",
 		"data": {
+			"duration": 100.56,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 455,
@@ -5433,6 +5878,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 147.791,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 456,
@@ -5445,6 +5891,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 129.114,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 457,
@@ -5459,6 +5906,7 @@
 		"altTitles": [],
 		"artist": "MARETU",
 		"data": {
+			"duration": 131.538,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 458,
@@ -5472,6 +5920,7 @@
 		"altTitles": [],
 		"artist": "ポリスピカデリー",
 		"data": {
+			"duration": 128.471,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 459,
@@ -5485,6 +5934,7 @@
 		"altTitles": [],
 		"artist": "箱部 なる(CV:M・A・O)",
 		"data": {
+			"duration": 145.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 460,
@@ -5497,6 +5947,7 @@
 		"altTitles": [],
 		"artist": "小仏 凪(CV:佐倉 薫)",
 		"data": {
+			"duration": 132.632,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 461,
@@ -5507,6 +5958,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 147.273,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 462,
@@ -5529,6 +5981,7 @@
 		"altTitles": [],
 		"artist": "Machico「この素晴らしい世界に祝福を！」",
 		"data": {
+			"duration": 92.108,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 464,
@@ -5539,6 +5992,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 139.5,
 			"genre": "東方Project"
 		},
 		"id": 465,
@@ -5552,6 +6006,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 135.385,
 			"genre": "東方Project"
 		},
 		"id": 466,
@@ -5565,6 +6020,7 @@
 		"altTitles": [],
 		"artist": "ぬるはち",
 		"data": {
+			"duration": 144.973,
 			"genre": "東方Project"
 		},
 		"id": 467,
@@ -5575,6 +6031,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 145.031,
 			"genre": "東方Project"
 		},
 		"id": 468,
@@ -5585,6 +6042,7 @@
 		"altTitles": [],
 		"artist": "矢鴇つかさ feat. kalon.",
 		"data": {
+			"duration": 138.592,
 			"genre": "maimai"
 		},
 		"id": 469,
@@ -5597,6 +6055,7 @@
 		"altTitles": [],
 		"artist": "M2U",
 		"data": {
+			"duration": 136,
 			"genre": "maimai"
 		},
 		"id": 470,
@@ -5607,6 +6066,7 @@
 		"altTitles": [],
 		"artist": "バルーン",
 		"data": {
+			"duration": 138.246,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 471,
@@ -5619,6 +6079,7 @@
 		"altTitles": [],
 		"artist": "ねじ式",
 		"data": {
+			"duration": 140.801,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 472,
@@ -5631,6 +6092,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 130.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 473,
@@ -5645,6 +6107,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 131.692,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 474,
@@ -5657,6 +6120,7 @@
 		"altTitles": [],
 		"artist": "MY FIRST STORY",
 		"data": {
+			"duration": 98.285,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 475,
@@ -5672,6 +6136,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 144.945,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 476,
@@ -5685,6 +6150,7 @@
 		"altTitles": [],
 		"artist": "田中マイミ",
 		"data": {
+			"duration": 137.964,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 477,
@@ -5698,6 +6164,7 @@
 		"altTitles": [],
 		"artist": "good-cool ft. Pete Klassen",
 		"data": {
+			"duration": 132.284,
 			"genre": "maimai"
 		},
 		"id": 478,
@@ -5708,6 +6175,7 @@
 		"altTitles": [],
 		"artist": "あべにゅうぷろじぇくと feat.天月めぐる＆如月すみれ「ツインエンジェルBREAK」",
 		"data": {
+			"duration": 93,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 479,
@@ -5721,6 +6189,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 141.245,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 480,
@@ -5734,6 +6203,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 144.935,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 481,
@@ -5747,6 +6217,7 @@
 		"altTitles": [],
 		"artist": "御形 アリシアナ(CV:福原 綾香)",
 		"data": {
+			"duration": 127.8,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 482,
@@ -5757,6 +6228,7 @@
 		"altTitles": [],
 		"artist": "天王洲 なずな(CV:山本 彩乃)",
 		"data": {
+			"duration": 147.535,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 483,
@@ -5767,6 +6239,7 @@
 		"altTitles": [],
 		"artist": "明坂 芹菜(CV:新田 恵海)",
 		"data": {
+			"duration": 118.175,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 484,
@@ -5777,6 +6250,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 136.864,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 485,
@@ -5791,6 +6265,7 @@
 		"altTitles": [],
 		"artist": "wowaka",
 		"data": {
+			"duration": 136.283,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 486,
@@ -5803,6 +6278,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 145.99,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 487,
@@ -5815,6 +6291,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 129,
 			"genre": "東方Project"
 		},
 		"id": 488,
@@ -5825,6 +6302,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉, Douglas Robb from Hoobastank「ソニック フォース」",
 		"data": {
+			"duration": 129.954,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 489,
@@ -5835,6 +6313,7 @@
 		"altTitles": [],
 		"artist": "Tanchiky",
 		"data": {
+			"duration": 126,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 490,
@@ -5847,6 +6326,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 96.7,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 491,
@@ -5859,6 +6339,7 @@
 		"altTitles": [],
 		"artist": "void (Mournfinale)",
 		"data": {
+			"duration": 146,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 492,
@@ -5871,6 +6352,7 @@
 		"altTitles": [],
 		"artist": "霜月はるか",
 		"data": {
+			"duration": 117.3,
 			"genre": "maimai"
 		},
 		"id": 493,
@@ -5881,6 +6363,7 @@
 		"altTitles": [],
 		"artist": "ノマ",
 		"data": {
+			"duration": 114.6,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 494,
@@ -5891,6 +6374,7 @@
 		"altTitles": [],
 		"artist": "dawn-system",
 		"data": {
+			"duration": 121.4,
 			"genre": "東方Project"
 		},
 		"id": 495,
@@ -5903,6 +6387,7 @@
 		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
+			"duration": 125,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 496,
@@ -5913,6 +6398,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 133.75,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 497,
@@ -5925,6 +6411,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 148.552,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 498,
@@ -5950,6 +6437,7 @@
 		"altTitles": [],
 		"artist": "kamome sano",
 		"data": {
+			"duration": 132.5,
 			"genre": "maimai"
 		},
 		"id": 500,
@@ -5960,6 +6448,7 @@
 		"altTitles": [],
 		"artist": "ガリガリさむし",
 		"data": {
+			"duration": 147,
 			"genre": "maimai"
 		},
 		"id": 501,
@@ -5970,6 +6459,7 @@
 		"altTitles": [],
 		"artist": "ヤスオ",
 		"data": {
+			"duration": 139.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 502,
@@ -5982,6 +6472,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 146.116,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 503,
@@ -5994,6 +6485,7 @@
 		"altTitles": [],
 		"artist": "Storyteller",
 		"data": {
+			"duration": 147,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 504,
@@ -6011,6 +6503,7 @@
 		"altTitles": [],
 		"artist": "MOSAIC.WAV",
 		"data": {
+			"duration": 128.198,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 505,
@@ -6023,6 +6516,7 @@
 		"altTitles": [],
 		"artist": "ave;new feat.佐倉紗織",
 		"data": {
+			"duration": 142.2,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 506,
@@ -6033,6 +6527,7 @@
 		"altTitles": [],
 		"artist": "HALFBY",
 		"data": {
+			"duration": 133.965,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 507,
@@ -6043,6 +6538,7 @@
 		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
+			"duration": 134.2,
 			"genre": "東方Project"
 		},
 		"id": 508,
@@ -6053,6 +6549,7 @@
 		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
+			"duration": 139.57,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 509,
@@ -6063,6 +6560,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 121.2,
 			"genre": "東方Project"
 		},
 		"id": 510,
@@ -6073,6 +6571,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 131.1,
 			"genre": "東方Project"
 		},
 		"id": 511,
@@ -6086,6 +6585,7 @@
 		"altTitles": [],
 		"artist": "sky_delta",
 		"data": {
+			"duration": 124,
 			"genre": "maimai"
 		},
 		"id": 512,
@@ -6096,6 +6596,7 @@
 		"altTitles": [],
 		"artist": "n.k",
 		"data": {
+			"duration": 136,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 513,
@@ -6109,6 +6610,7 @@
 		"altTitles": [],
 		"artist": "SLAVE.V-V-R",
 		"data": {
+			"duration": 144,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 514,
@@ -6123,6 +6625,7 @@
 		"altTitles": [],
 		"artist": "キノシタ feat. 音街ウナ",
 		"data": {
+			"duration": 149,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 515,
@@ -6136,6 +6639,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 143.2,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 516,
@@ -6148,6 +6652,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 125,
 			"genre": "東方Project"
 		},
 		"id": 517,
@@ -6162,6 +6667,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 128,
 			"genre": "東方Project"
 		},
 		"id": 518,
@@ -6176,6 +6682,7 @@
 		"altTitles": [],
 		"artist": "sumijun(Halozy) feat. ななひら(Confetto)",
 		"data": {
+			"duration": 128.627,
 			"genre": "東方Project"
 		},
 		"id": 519,
@@ -6188,6 +6695,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 145,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 520,
@@ -6200,6 +6708,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 126.111,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 521,
@@ -6214,6 +6723,7 @@
 		"altTitles": [],
 		"artist": "月鈴姉妹（イロドリミドリ）",
 		"data": {
+			"duration": 137.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 522,
@@ -6226,6 +6736,7 @@
 		"altTitles": [],
 		"artist": "Queen P.A.L.",
 		"data": {
+			"duration": 136,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 523,
@@ -6236,6 +6747,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 140.165,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 524,
@@ -6249,6 +6761,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 136.5,
 			"genre": "maimai"
 		},
 		"id": 525,
@@ -6261,6 +6774,7 @@
 		"altTitles": [],
 		"artist": "仁井山征弘 Feat. GREAT G and surprise",
 		"data": {
+			"duration": 135.6,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 526,
@@ -6273,6 +6787,7 @@
 		"altTitles": [],
 		"artist": "にじよめちゃんとZIPたん",
 		"data": {
+			"duration": 96.188,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 527,
@@ -6286,6 +6801,7 @@
 		"altTitles": [],
 		"artist": "kanone feat. せんざい",
 		"data": {
+			"duration": 139.083,
 			"genre": "maimai"
 		},
 		"id": 528,
@@ -6306,6 +6822,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修「バーチャロン」",
 		"data": {
+			"duration": 146.143,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 529,
@@ -6316,6 +6833,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修",
 		"data": {
+			"duration": 148,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 530,
@@ -6328,6 +6846,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 125.417,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 531,
@@ -6341,6 +6860,7 @@
 		"altTitles": [],
 		"artist": "ONE (song by ナナホシ管弦楽団)",
 		"data": {
+			"duration": 138,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 532,
@@ -6354,6 +6874,7 @@
 		"altTitles": [],
 		"artist": "cubesato",
 		"data": {
+			"duration": 143.158,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 533,
@@ -6376,6 +6897,7 @@
 		"altTitles": [],
 		"artist": "パトリシア・オブ・エンド・黒木未知・夕莉シャチ・明日原ユウキ「ノラと皇女と野良猫ハート」",
 		"data": {
+			"duration": 117,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 535,
@@ -6399,6 +6921,7 @@
 		"altTitles": [],
 		"artist": "そらまふうらさか",
 		"data": {
+			"duration": 143.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 537,
@@ -6412,6 +6935,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 138.7,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 538,
@@ -6424,6 +6948,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 148.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 539,
@@ -6437,6 +6962,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 139.285,
 			"genre": "東方Project"
 		},
 		"id": 540,
@@ -6447,6 +6973,7 @@
 		"altTitles": [],
 		"artist": "cosMo VS dj TAKA「SOUND VOLTEX」より",
 		"data": {
+			"duration": 124,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 541,
@@ -6459,6 +6986,7 @@
 		"altTitles": [],
 		"artist": "MASAKI（ZUNTATA）「グルーヴコースター3EXドリームパーティー」より",
 		"data": {
+			"duration": 130,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 542,
@@ -6469,6 +6997,7 @@
 		"altTitles": [],
 		"artist": "Drop＆祇羽 feat. 葉月ゆら「太鼓の達人」より",
 		"data": {
+			"duration": 135.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 543,
@@ -6481,6 +7010,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 139.934,
 			"genre": "maimai"
 		},
 		"id": 544,
@@ -6495,6 +7025,7 @@
 		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
+			"duration": 120.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 545,
@@ -6505,6 +7036,7 @@
 		"altTitles": [],
 		"artist": "デッドボールP",
 		"data": {
+			"duration": 148,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 546,
@@ -6517,6 +7049,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. 3L",
 		"data": {
+			"duration": 143,
 			"genre": "東方Project"
 		},
 		"id": 547,
@@ -6530,6 +7063,7 @@
 		"altTitles": [],
 		"artist": "Tsukasa",
 		"data": {
+			"duration": 121.2,
 			"genre": "maimai"
 		},
 		"id": 548,
@@ -6543,6 +7077,7 @@
 		"altTitles": [],
 		"artist": "HIRO/曲者P",
 		"data": {
+			"duration": 147.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 549,
@@ -6555,6 +7090,7 @@
 		"altTitles": [],
 		"artist": "オワタP",
 		"data": {
+			"duration": 134.3,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 550,
@@ -6567,6 +7103,7 @@
 		"altTitles": [],
 		"artist": "くちばしP",
 		"data": {
+			"duration": 148,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 551,
@@ -6579,6 +7116,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 141.871,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 552,
@@ -6592,6 +7130,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 129,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 553,
@@ -6606,6 +7145,7 @@
 		"altTitles": [],
 		"artist": "baker",
 		"data": {
+			"duration": 132.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 554,
@@ -6618,6 +7158,7 @@
 		"altTitles": [],
 		"artist": "のりP",
 		"data": {
+			"duration": 147.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 555,
@@ -6632,6 +7173,7 @@
 		"altTitles": [],
 		"artist": "BlackY fused with WAiKURO",
 		"data": {
+			"duration": 136.5,
 			"genre": "maimai"
 		},
 		"id": 556,
@@ -6645,6 +7187,7 @@
 		"altTitles": [],
 		"artist": "Sprite Recordings",
 		"data": {
+			"duration": 114,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 557,
@@ -6659,6 +7202,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお＋あまね（COOL&CREATE）",
 		"data": {
+			"duration": 136,
 			"genre": "東方Project"
 		},
 		"id": 558,
@@ -6671,6 +7215,7 @@
 		"altTitles": [],
 		"artist": "ARM (IOSYS)",
 		"data": {
+			"duration": 147.5,
 			"genre": "東方Project"
 		},
 		"id": 559,
@@ -6684,6 +7229,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 141.943,
 			"genre": "東方Project"
 		},
 		"id": 560,
@@ -6696,6 +7242,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 138.1,
 			"genre": "東方Project"
 		},
 		"id": 561,
@@ -6706,6 +7253,7 @@
 		"altTitles": [],
 		"artist": "cybermiso",
 		"data": {
+			"duration": 134.7,
 			"genre": "maimai"
 		},
 		"id": 562,
@@ -6716,6 +7264,7 @@
 		"altTitles": [],
 		"artist": "箱部なる(CV:M・A・O)",
 		"data": {
+			"duration": 144,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 563,
@@ -6726,6 +7275,7 @@
 		"altTitles": [],
 		"artist": "小仏凪(CV:佐倉薫)",
 		"data": {
+			"duration": 118.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 564,
@@ -6738,6 +7288,7 @@
 		"altTitles": [],
 		"artist": "月鈴那知(CV:今村彩夏)",
 		"data": {
+			"duration": 148.044,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 565,
@@ -6750,6 +7301,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 135.5,
 			"genre": "maimai"
 		},
 		"id": 566,
@@ -6760,6 +7312,7 @@
 		"altTitles": [],
 		"artist": "ジータ（CV:金元寿子）、ルリア（CV:東山奈央）、ヴィーラ（CV:今井麻美）、マリー（CV:長谷川明子）",
 		"data": {
+			"duration": 116,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 567,
@@ -6772,6 +7325,7 @@
 		"altTitles": [],
 		"artist": "ペコリーヌ（CV：M・A・O）、コッコロ（CV：伊藤美来）、キャル（CV：立花理香）",
 		"data": {
+			"duration": 94.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 568,
@@ -6782,6 +7336,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 146.6,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 569,
@@ -6796,6 +7351,7 @@
 		"altTitles": [],
 		"artist": "まふまふ",
 		"data": {
+			"duration": 146.4,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 570,
@@ -6821,6 +7377,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 128.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 572,
@@ -6835,6 +7392,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 129,
 			"genre": "maimai"
 		},
 		"id": 573,
@@ -6849,6 +7407,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 147.2,
 			"genre": "maimai"
 		},
 		"id": 574,
@@ -6863,6 +7422,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.Sana",
 		"data": {
+			"duration": 146,
 			"genre": "maimai"
 		},
 		"id": 575,
@@ -6873,6 +7433,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 144,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 576,
@@ -6885,6 +7446,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 154.2,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 577,
@@ -6895,6 +7457,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお（COOL&CREATE）",
 		"data": {
+			"duration": 135,
 			"genre": "東方Project"
 		},
 		"id": 578,
@@ -6908,6 +7471,7 @@
 		"altTitles": [],
 		"artist": "Demetori",
 		"data": {
+			"duration": 148.5,
 			"genre": "東方Project"
 		},
 		"id": 579,
@@ -6921,6 +7485,7 @@
 		"altTitles": [],
 		"artist": "ゆうゆ / 篠螺悠那",
 		"data": {
+			"duration": 135.1,
 			"genre": "東方Project"
 		},
 		"id": 580,
@@ -6934,6 +7499,7 @@
 		"altTitles": [],
 		"artist": "cosMo@暴走P",
 		"data": {
+			"duration": 119.3,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 581,
@@ -6946,6 +7512,7 @@
 		"altTitles": [],
 		"artist": "ハチ",
 		"data": {
+			"duration": 130.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 582,
@@ -6956,6 +7523,7 @@
 		"altTitles": [],
 		"artist": "Cres.",
 		"data": {
+			"duration": 134,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 583,
@@ -6966,6 +7534,7 @@
 		"altTitles": [],
 		"artist": "ちーむMOER",
 		"data": {
+			"duration": 113,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 584,
@@ -6980,6 +7549,7 @@
 		"altTitles": [],
 		"artist": "ねこみりん feat.小宮真央",
 		"data": {
+			"duration": 136.2,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 585,
@@ -6994,6 +7564,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 148.891,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 586,
@@ -7006,6 +7577,7 @@
 		"altTitles": [],
 		"artist": "光吉猛修の父",
 		"data": {
+			"duration": 98,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 587,
@@ -7018,6 +7590,7 @@
 		"altTitles": [],
 		"artist": "Team Grimoire",
 		"data": {
+			"duration": 137.116,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 588,
@@ -7030,6 +7603,7 @@
 		"altTitles": [],
 		"artist": "RADWIMPS",
 		"data": {
+			"duration": 117.474,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 589,
@@ -7043,6 +7617,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 128,
 			"genre": "maimai"
 		},
 		"id": 590,
@@ -7053,6 +7628,7 @@
 		"altTitles": [],
 		"artist": "削除 feat. Nikki Simmons",
 		"data": {
+			"duration": 160,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 591,
@@ -7065,6 +7641,7 @@
 		"altTitles": [],
 		"artist": "SAMBA MASTER 佐藤",
 		"data": {
+			"duration": 125.455,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 592,
@@ -7078,6 +7655,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 156.908,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 593,
@@ -7088,6 +7666,7 @@
 		"altTitles": [],
 		"artist": "S!N・+α/あるふぁきゅん。×ALI PROJECT",
 		"data": {
+			"duration": 152.276,
 			"genre": "maimai"
 		},
 		"id": 594,
@@ -7098,6 +7677,7 @@
 		"altTitles": [],
 		"artist": "島爺×蜂屋ななし",
 		"data": {
+			"duration": 131.668,
 			"genre": "maimai"
 		},
 		"id": 595,
@@ -7108,6 +7688,7 @@
 		"altTitles": [],
 		"artist": "やしきん feat.でらっくま(CV:三森すずこ)",
 		"data": {
+			"duration": 152.36,
 			"genre": "maimai"
 		},
 		"id": 596,
@@ -7121,6 +7702,7 @@
 		"altTitles": [],
 		"artist": "EBIMAYO",
 		"data": {
+			"duration": 135.138,
 			"genre": "maimai"
 		},
 		"id": 597,
@@ -7131,6 +7713,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
+			"duration": 139.429,
 			"genre": "maimai"
 		},
 		"id": 598,
@@ -7143,6 +7726,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 131.657,
 			"genre": "maimai"
 		},
 		"id": 599,
@@ -7155,6 +7739,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 142.934,
 			"genre": "maimai"
 		},
 		"id": 600,
@@ -7168,6 +7753,7 @@
 		"altTitles": [],
 		"artist": "みきとP feat. FantasticYouth",
 		"data": {
+			"duration": 163.862,
 			"genre": "maimai"
 		},
 		"id": 601,
@@ -7178,6 +7764,7 @@
 		"altTitles": [],
 		"artist": "164 feat. めいちゃん",
 		"data": {
+			"duration": 146.688,
 			"genre": "maimai"
 		},
 		"id": 602,
@@ -7188,6 +7775,7 @@
 		"altTitles": [],
 		"artist": "曲：kz(livetune)／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.111,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 603,
@@ -7198,6 +7786,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお",
 		"data": {
+			"duration": 122.824,
 			"genre": "maimai"
 		},
 		"id": 604,
@@ -7211,6 +7800,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 132.245,
 			"genre": "maimai"
 		},
 		"id": 605,
@@ -7225,6 +7815,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 142.857,
 			"genre": "maimai"
 		},
 		"id": 606,
@@ -7237,6 +7828,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 145.185,
 			"genre": "maimai"
 		},
 		"id": 607,
@@ -7251,6 +7843,7 @@
 		"altTitles": [],
 		"artist": "MintJam",
 		"data": {
+			"duration": 139.345,
 			"genre": "maimai"
 		},
 		"id": 608,
@@ -7261,6 +7854,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE feat. Ayumi Nomiya",
 		"data": {
+			"duration": 139.016,
 			"genre": "maimai"
 		},
 		"id": 609,
@@ -7271,6 +7865,7 @@
 		"altTitles": [],
 		"artist": "Nothing But Requiem (feat.Aikapin & Chiyoko)",
 		"data": {
+			"duration": 141.474,
 			"genre": "maimai"
 		},
 		"id": 610,
@@ -7286,6 +7881,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 124.8,
 			"genre": "maimai"
 		},
 		"id": 611,
@@ -7298,6 +7894,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 135.554,
 			"genre": "maimai"
 		},
 		"id": 612,
@@ -7310,6 +7907,7 @@
 		"altTitles": [],
 		"artist": "舞ヶ原高校軽音部",
 		"data": {
+			"duration": 126.626,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 613,
@@ -7320,6 +7918,7 @@
 		"altTitles": [],
 		"artist": "月鈴 那知（ヴァイオリン） 伴奏：イロドリミドリ",
 		"data": {
+			"duration": 155.167,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 614,
@@ -7337,6 +7936,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 144,
 			"genre": "maimai"
 		},
 		"id": 615,
@@ -7347,6 +7947,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走AlterEgo",
 		"data": {
+			"duration": 141.374,
 			"genre": "maimai"
 		},
 		"id": 616,
@@ -7363,6 +7964,7 @@
 		"altTitles": [],
 		"artist": "きくお",
 		"data": {
+			"duration": 153.692,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 617,
@@ -7379,6 +7981,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 136.981,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 618,
@@ -7389,6 +7992,7 @@
 		"altTitles": [],
 		"artist": "じーざすP feat.kradness",
 		"data": {
+			"duration": 150.479,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 619,
@@ -7399,6 +8003,7 @@
 		"altTitles": [],
 		"artist": "青島探偵事務所器楽捜査部B担",
 		"data": {
+			"duration": 146.571,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 620,
@@ -7413,6 +8018,7 @@
 		"altTitles": [],
 		"artist": "YUC'e",
 		"data": {
+			"duration": 131.684,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 621,
@@ -7423,6 +8029,7 @@
 		"altTitles": [],
 		"artist": "DIVELA feat.初音ミク",
 		"data": {
+			"duration": 113.079,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 622,
@@ -7433,6 +8040,7 @@
 		"altTitles": [],
 		"artist": "T.M.Revolution [covered by 光吉猛修]",
 		"data": {
+			"duration": 113.043,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 623,
@@ -7443,6 +8051,7 @@
 		"altTitles": [],
 		"artist": "supercell",
 		"data": {
+			"duration": 158.118,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 624,
@@ -7456,6 +8065,7 @@
 		"altTitles": [],
 		"artist": "はるまきごはん feat.初音ミク",
 		"data": {
+			"duration": 146.124,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 625,
@@ -7468,6 +8078,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
+			"duration": 114,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 626,
@@ -7480,6 +8091,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお × Cranky",
 		"data": {
+			"duration": 144.733,
 			"genre": "東方Project"
 		},
 		"id": 627,
@@ -7497,6 +8109,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima × REDALiCE",
 		"data": {
+			"duration": 150.745,
 			"genre": "東方Project"
 		},
 		"id": 628,
@@ -7510,6 +8123,7 @@
 		"altTitles": [],
 		"artist": "colate",
 		"data": {
+			"duration": 120.626,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 629,
@@ -7520,6 +8134,7 @@
 		"altTitles": [],
 		"artist": "Omoi feat. 初音ミク",
 		"data": {
+			"duration": 144,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 630,
@@ -7533,6 +8148,7 @@
 		"altTitles": [],
 		"artist": "lumo",
 		"data": {
+			"duration": 142.909,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 631,
@@ -7545,6 +8161,7 @@
 		"altTitles": [],
 		"artist": "トーマ",
 		"data": {
+			"duration": 133.846,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 632,
@@ -7559,6 +8176,7 @@
 		"altTitles": [],
 		"artist": "otetsu",
 		"data": {
+			"duration": 145.376,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 633,
@@ -7572,6 +8190,7 @@
 		"altTitles": [],
 		"artist": "まらしぃ",
 		"data": {
+			"duration": 142.737,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 634,
@@ -7584,6 +8203,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 153.081,
 			"genre": "東方Project"
 		},
 		"id": 635,
@@ -7594,6 +8214,7 @@
 		"altTitles": [],
 		"artist": "くっちー (DARKSIDE APPROACH)",
 		"data": {
+			"duration": 125.775,
 			"genre": "東方Project"
 		},
 		"id": 636,
@@ -7607,6 +8228,7 @@
 		"altTitles": [],
 		"artist": "ARM (IOSYS)",
 		"data": {
+			"duration": 118.8,
 			"genre": "東方Project"
 		},
 		"id": 637,
@@ -7619,6 +8241,7 @@
 		"altTitles": [],
 		"artist": "XYZ",
 		"data": {
+			"duration": 131.25,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 638,
@@ -7629,6 +8252,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 146.501,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 639,
@@ -7642,6 +8266,7 @@
 		"altTitles": [],
 		"artist": "あわのあゆむ",
 		"data": {
+			"duration": 144,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 640,
@@ -7655,6 +8280,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 153.144,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 641,
@@ -7669,6 +8295,7 @@
 		"altTitles": [],
 		"artist": "立秋 feat.ちょこ",
 		"data": {
+			"duration": 132.841,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 642,
@@ -7685,6 +8312,7 @@
 		"altTitles": [],
 		"artist": "アイラ（CV：三森すずこ）シマ（CV:井口裕香）はな（CV:花澤香菜）",
 		"data": {
+			"duration": 92.667,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 643,
@@ -7697,6 +8325,7 @@
 		"altTitles": [],
 		"artist": "有機酸",
 		"data": {
+			"duration": 137.419,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 644,
@@ -7707,6 +8336,7 @@
 		"altTitles": [],
 		"artist": "曲：宮崎誠／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 145.574,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 645,
@@ -7717,6 +8347,7 @@
 		"altTitles": [],
 		"artist": "くらげP",
 		"data": {
+			"duration": 146.135,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 646,
@@ -7730,6 +8361,7 @@
 		"altTitles": [],
 		"artist": "kemu",
 		"data": {
+			"duration": 155.403,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 647,
@@ -7743,6 +8375,7 @@
 		"altTitles": [],
 		"artist": "ユリイ・カノン feat.GUMI",
 		"data": {
+			"duration": 137.379,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 648,
@@ -7756,6 +8389,7 @@
 		"altTitles": [],
 		"artist": "なきゃむりゃ",
 		"data": {
+			"duration": 138.052,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 649,
@@ -7768,6 +8402,7 @@
 		"altTitles": [],
 		"artist": "みきとP",
 		"data": {
+			"duration": 138.462,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 650,
@@ -7781,6 +8416,7 @@
 		"altTitles": [],
 		"artist": "BlackY vs. WAiKURO",
 		"data": {
+			"duration": 138.814,
 			"genre": "maimai"
 		},
 		"id": 651,
@@ -7791,6 +8427,7 @@
 		"altTitles": [],
 		"artist": "Yooh",
 		"data": {
+			"duration": 137.829,
 			"genre": "maimai"
 		},
 		"id": 652,
@@ -7801,6 +8438,7 @@
 		"altTitles": [],
 		"artist": "Maozon",
 		"data": {
+			"duration": 137.667,
 			"genre": "maimai"
 		},
 		"id": 653,
@@ -7811,6 +8449,7 @@
 		"altTitles": [],
 		"artist": "C-Show",
 		"data": {
+			"duration": 126.171,
 			"genre": "maimai"
 		},
 		"id": 654,
@@ -7821,6 +8460,7 @@
 		"altTitles": [],
 		"artist": "Masahiro \"Godspeed\" Aoki VS Kai",
 		"data": {
+			"duration": 155.561,
 			"genre": "maimai"
 		},
 		"id": 655,
@@ -7831,6 +8471,7 @@
 		"altTitles": [],
 		"artist": "ああああ",
 		"data": {
+			"duration": 131.538,
 			"genre": "maimai"
 		},
 		"id": 656,
@@ -7846,6 +8487,7 @@
 		"altTitles": [],
 		"artist": "じーざす（ワンダフル☆オポチュニティ！）feat.Kradness",
 		"data": {
+			"duration": 145.6,
 			"genre": "maimai"
 		},
 		"id": 657,
@@ -7859,6 +8501,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 134.574,
 			"genre": "maimai"
 		},
 		"id": 658,
@@ -7874,6 +8517,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア feat.利香",
 		"data": {
+			"duration": 146.177,
 			"genre": "maimai"
 		},
 		"id": 659,
@@ -7886,6 +8530,7 @@
 		"altTitles": [],
 		"artist": "SADA 2Futureanthem feat. ellie",
 		"data": {
+			"duration": 141.379,
 			"genre": "maimai"
 		},
 		"id": 660,
@@ -7899,6 +8544,7 @@
 		"altTitles": [],
 		"artist": "中山真斗",
 		"data": {
+			"duration": 136.395,
 			"genre": "maimai"
 		},
 		"id": 661,
@@ -7909,6 +8555,7 @@
 		"altTitles": [],
 		"artist": "OSTER project feat. かなたん",
 		"data": {
+			"duration": 133.068,
 			"genre": "maimai"
 		},
 		"id": 662,
@@ -7921,6 +8568,7 @@
 		"altTitles": [],
 		"artist": "Rigel Theatre feat. ミーウェル",
 		"data": {
+			"duration": 149.517,
 			"genre": "maimai"
 		},
 		"id": 663,
@@ -7933,6 +8581,7 @@
 		"altTitles": [],
 		"artist": "大国奏音",
 		"data": {
+			"duration": 138,
 			"genre": "maimai"
 		},
 		"id": 664,
@@ -7948,6 +8597,7 @@
 		"altTitles": [],
 		"artist": "山本真央樹",
 		"data": {
+			"duration": 154.79,
 			"genre": "maimai"
 		},
 		"id": 665,
@@ -7964,6 +8614,7 @@
 		"altTitles": [],
 		"artist": "MARETU",
 		"data": {
+			"duration": 153.462,
 			"genre": "maimai"
 		},
 		"id": 666,
@@ -7976,6 +8627,7 @@
 		"altTitles": [],
 		"artist": "syudou",
 		"data": {
+			"duration": 140.584,
 			"genre": "maimai"
 		},
 		"id": 667,
@@ -7988,6 +8640,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree feat.chi＊tree",
 		"data": {
+			"duration": 159.85,
 			"genre": "maimai"
 		},
 		"id": 668,
@@ -8000,6 +8653,7 @@
 		"altTitles": [],
 		"artist": "曲：村カワ基成／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.769,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 669,
@@ -8013,6 +8667,7 @@
 		"altTitles": [],
 		"artist": "曲：ゆよゆっぺ／歌：九條 楓(CV：佳村 はるか)",
 		"data": {
+			"duration": 140.108,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 670,
@@ -8023,6 +8678,7 @@
 		"altTitles": [],
 		"artist": "曲：鯨井国家／歌：藍原 椿(CV：橋本 ちなみ)",
 		"data": {
+			"duration": 126.167,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 671,
@@ -8036,6 +8692,7 @@
 		"altTitles": [],
 		"artist": "Yunomi feat.nicamoq",
 		"data": {
+			"duration": 135.938,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 672,
@@ -8048,6 +8705,7 @@
 		"altTitles": [],
 		"artist": "happy machine",
 		"data": {
+			"duration": 140.214,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 673,
@@ -8058,6 +8716,7 @@
 		"altTitles": [],
 		"artist": "ハムちゃんず [covered by 光吉猛修]",
 		"data": {
+			"duration": 116.571,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 674,
@@ -8070,6 +8729,7 @@
 		"altTitles": [],
 		"artist": "ヨルシカ",
 		"data": {
+			"duration": 159.36,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 675,
@@ -8099,6 +8759,7 @@
 		"altTitles": [],
 		"artist": "ラティナ(CV:高尾奏音)",
 		"data": {
+			"duration": 95.354,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 677,
@@ -8109,6 +8770,7 @@
 		"altTitles": [],
 		"artist": "syudou",
 		"data": {
+			"duration": 140,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 678,
@@ -8121,6 +8783,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 148.75,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 679,
@@ -8133,6 +8796,7 @@
 		"altTitles": [],
 		"artist": "キノシタ feat. 音街ウナ・鏡音リン",
 		"data": {
+			"duration": 155.254,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 680,
@@ -8145,6 +8809,7 @@
 		"altTitles": [],
 		"artist": "ろくろ",
 		"data": {
+			"duration": 139.794,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 681,
@@ -8157,6 +8822,7 @@
 		"altTitles": [],
 		"artist": "さつき が てんこもり",
 		"data": {
+			"duration": 139.846,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 682,
@@ -8170,6 +8836,7 @@
 		"altTitles": [],
 		"artist": "八王子P",
 		"data": {
+			"duration": 144.49,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 683,
@@ -8182,6 +8849,7 @@
 		"altTitles": [],
 		"artist": "niki",
 		"data": {
+			"duration": 129.405,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 684,
@@ -8194,6 +8862,7 @@
 		"altTitles": [],
 		"artist": "梅とら",
 		"data": {
+			"duration": 142.154,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 685,
@@ -8204,6 +8873,7 @@
 		"altTitles": [],
 		"artist": "まふまふ",
 		"data": {
+			"duration": 145.237,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 686,
@@ -8216,6 +8886,7 @@
 		"altTitles": [],
 		"artist": "M.S.S Project",
 		"data": {
+			"duration": 149.278,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 687,
@@ -8228,6 +8899,7 @@
 		"altTitles": [],
 		"artist": "田中Ｂ",
 		"data": {
+			"duration": 157.546,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 688,
@@ -8241,6 +8913,7 @@
 		"altTitles": [],
 		"artist": "すりぃ",
 		"data": {
+			"duration": 158.9,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 689,
@@ -8254,6 +8927,7 @@
 		"altTitles": [],
 		"artist": "livetune",
 		"data": {
+			"duration": 145.012,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 690,
@@ -8264,6 +8938,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 131.216,
 			"genre": "東方Project"
 		},
 		"id": 691,
@@ -8276,6 +8951,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 157.777,
 			"genre": "東方Project"
 		},
 		"id": 692,
@@ -8289,6 +8965,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 142.326,
 			"genre": "東方Project"
 		},
 		"id": 693,
@@ -8299,6 +8976,7 @@
 		"altTitles": [],
 		"artist": "Liz Triangle",
 		"data": {
+			"duration": 145.053,
 			"genre": "東方Project"
 		},
 		"id": 694,
@@ -8309,6 +8987,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 142.134,
 			"genre": "東方Project"
 		},
 		"id": 695,
@@ -8319,6 +8998,7 @@
 		"altTitles": [],
 		"artist": "Syrufit + HDLV",
 		"data": {
+			"duration": 145.368,
 			"genre": "東方Project"
 		},
 		"id": 696,
@@ -8329,6 +9009,7 @@
 		"altTitles": [],
 		"artist": "削除 feat. void (Mournfinale)",
 		"data": {
+			"duration": 147.6,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 697,
@@ -8339,6 +9020,7 @@
 		"altTitles": [],
 		"artist": "KAH",
 		"data": {
+			"duration": 147.499,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 698,
@@ -8349,6 +9031,7 @@
 		"altTitles": [],
 		"artist": "Silentroom",
 		"data": {
+			"duration": 153.49,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 699,
@@ -8359,6 +9042,7 @@
 		"altTitles": [],
 		"artist": "しーけー",
 		"data": {
+			"duration": 157.565,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 700,
@@ -8383,6 +9067,7 @@
 		"altTitles": [],
 		"artist": "Ice",
 		"data": {
+			"duration": 107.894,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 702,
@@ -8393,6 +9078,7 @@
 		"altTitles": [],
 		"artist": "xi vs sakuzyo",
 		"data": {
+			"duration": 148,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 703,
@@ -8403,6 +9089,7 @@
 		"altTitles": [],
 		"artist": "Rabpit",
 		"data": {
+			"duration": 120,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 704,
@@ -8413,6 +9100,7 @@
 		"altTitles": [],
 		"artist": "Æsir",
 		"data": {
+			"duration": 159.2,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 705,
@@ -8423,6 +9111,7 @@
 		"altTitles": [],
 		"artist": "かめりあ(EDP)",
 		"data": {
+			"duration": 159.947,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 706,
@@ -8433,6 +9122,7 @@
 		"altTitles": [],
 		"artist": "UMAINA",
 		"data": {
+			"duration": 107.609,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 707,
@@ -8445,6 +9135,7 @@
 		"altTitles": [],
 		"artist": "ヒゲドライバー feat.らいむっくま(CV:村川梨衣) ＆ れもんっくま(CV:MoeMi)",
 		"data": {
+			"duration": 118.182,
 			"genre": "maimai"
 		},
 		"id": 708,
@@ -8459,6 +9150,7 @@
 		"altTitles": [],
 		"artist": "technoplanet",
 		"data": {
+			"duration": 133.053,
 			"genre": "maimai"
 		},
 		"id": 709,
@@ -8469,6 +9161,7 @@
 		"altTitles": [],
 		"artist": "hanzo",
 		"data": {
+			"duration": 157.5,
 			"genre": "maimai"
 		},
 		"id": 710,
@@ -8483,6 +9176,7 @@
 		"altTitles": [],
 		"artist": "千本松 仁",
 		"data": {
+			"duration": 139.333,
 			"genre": "maimai"
 		},
 		"id": 711,
@@ -8493,6 +9187,7 @@
 		"altTitles": [],
 		"artist": "キノシタ feat. そらみこ (ホロライブ ときのそら＆さくらみこ)",
 		"data": {
+			"duration": 139.016,
 			"genre": "maimai"
 		},
 		"id": 712,
@@ -8507,6 +9202,7 @@
 		"altTitles": [],
 		"artist": "aran",
 		"data": {
+			"duration": 133.463,
 			"genre": "maimai"
 		},
 		"id": 713,
@@ -8517,6 +9213,7 @@
 		"altTitles": [],
 		"artist": "雄之助 feat. Sennzai",
 		"data": {
+			"duration": 138.909,
 			"genre": "maimai"
 		},
 		"id": 714,
@@ -8527,6 +9224,7 @@
 		"altTitles": [],
 		"artist": "PSYQUI",
 		"data": {
+			"duration": 141.628,
 			"genre": "maimai"
 		},
 		"id": 715,
@@ -8537,6 +9235,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 145.548,
 			"genre": "maimai"
 		},
 		"id": 716,
@@ -8547,6 +9246,7 @@
 		"altTitles": [],
 		"artist": "40mP feat. シャノ",
 		"data": {
+			"duration": 146.1,
 			"genre": "maimai"
 		},
 		"id": 717,
@@ -8559,6 +9259,7 @@
 		"altTitles": [],
 		"artist": "RD-Sounds feat.中恵光城",
 		"data": {
+			"duration": 125.96,
 			"genre": "maimai"
 		},
 		"id": 718,
@@ -8571,6 +9272,7 @@
 		"altTitles": [],
 		"artist": "達見 恵 featured by 佐野 宏晃",
 		"data": {
+			"duration": 157.377,
 			"genre": "maimai"
 		},
 		"id": 719,
@@ -8581,6 +9283,7 @@
 		"altTitles": [],
 		"artist": "*Luna feat.NORISTRY",
 		"data": {
+			"duration": 160,
 			"genre": "maimai"
 		},
 		"id": 720,
@@ -8594,6 +9297,7 @@
 		"altTitles": [],
 		"artist": "お月さま交響曲",
 		"data": {
+			"duration": 135,
 			"genre": "maimai"
 		},
 		"id": 721,
@@ -8604,6 +9308,7 @@
 		"altTitles": [],
 		"artist": "アリスシャッハと魔法の楽団",
 		"data": {
+			"duration": 125.294,
 			"genre": "maimai"
 		},
 		"id": 722,
@@ -8622,6 +9327,7 @@
 		"altTitles": [],
 		"artist": "llliiillliiilll",
 		"data": {
+			"duration": 143.182,
 			"genre": "maimai"
 		},
 		"id": 723,
@@ -8632,6 +9338,7 @@
 		"altTitles": [],
 		"artist": "ユリイ・カノン feat.ウォルピスカーター&まひる",
 		"data": {
+			"duration": 159.6,
 			"genre": "maimai"
 		},
 		"id": 724,
@@ -8644,6 +9351,7 @@
 		"altTitles": [],
 		"artist": "YASUHIRO(康寛)",
 		"data": {
+			"duration": 156.387,
 			"genre": "maimai"
 		},
 		"id": 725,
@@ -8657,6 +9365,7 @@
 		"altTitles": [],
 		"artist": "ELECTROCUTICA",
 		"data": {
+			"duration": 158.667,
 			"genre": "maimai"
 		},
 		"id": 726,
@@ -8670,6 +9379,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 141.444,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 727,
@@ -8680,6 +9390,7 @@
 		"altTitles": [],
 		"artist": "曲：中山真斗／歌：マーチングポケッツ [日向 千夏(CV：岡咲 美保)、柏木 美亜(CV：和氣 あず未)、東雲 つむぎ(CV：和泉 風花)]",
 		"data": {
+			"duration": 152.381,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 728,
@@ -8692,6 +9403,7 @@
 		"altTitles": [],
 		"artist": "曲：やしきん／歌：柏木 美亜(CV：和氣 あず未)",
 		"data": {
+			"duration": 145.946,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 729,
@@ -8706,6 +9418,7 @@
 		"altTitles": [],
 		"artist": "ぺのれり",
 		"data": {
+			"duration": 139.186,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 730,
@@ -8718,6 +9431,7 @@
 		"altTitles": [],
 		"artist": "Cranky feat.おもしろ三国志",
 		"data": {
+			"duration": 171.244,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 731,
@@ -8735,6 +9449,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 156.632,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 732,
@@ -8745,6 +9460,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア feat.松下",
 		"data": {
+			"duration": 145.532,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 733,
@@ -8803,6 +9519,7 @@
 		"altTitles": [],
 		"artist": "紗倉ひびき（CV:ファイルーズあい）＆街雄鳴造（CV:石川界人）",
 		"data": {
+			"duration": 93.636,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 738,
@@ -8815,6 +9532,7 @@
 		"altTitles": [],
 		"artist": "にじさんじ",
 		"data": {
+			"duration": 130,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 739,
@@ -8825,6 +9543,7 @@
 		"altTitles": [],
 		"artist": "カンザキイオリ",
 		"data": {
+			"duration": 158.4,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 740,
@@ -8838,6 +9557,7 @@
 		"altTitles": [],
 		"artist": "作曲：カジャ　作詞：傘村トータ　編曲：ねじ式　調声：シリア",
 		"data": {
+			"duration": 152.314,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 741,
@@ -8850,6 +9570,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 152.239,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 742,
@@ -8864,6 +9585,7 @@
 		"altTitles": [],
 		"artist": "獅子志司",
 		"data": {
+			"duration": 141.12,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 743,
@@ -8877,6 +9599,7 @@
 		"altTitles": [],
 		"artist": "ピコン",
 		"data": {
+			"duration": 138.069,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 744,
@@ -8890,6 +9613,7 @@
 		"altTitles": [],
 		"artist": "作詞作曲：椎名もた　編曲：KTG　映像：Yuma Saito",
 		"data": {
+			"duration": 138.857,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 745,
@@ -8903,6 +9627,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 154.286,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 746,
@@ -8917,6 +9642,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 159.21,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 747,
@@ -8933,6 +9659,7 @@
 		"altTitles": [],
 		"artist": "ナナホシ管弦楽団",
 		"data": {
+			"duration": 156.158,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 748,
@@ -8947,6 +9674,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア feat.flower",
 		"data": {
+			"duration": 142.105,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 749,
@@ -8959,6 +9687,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア feat.GUMI",
 		"data": {
+			"duration": 133.384,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 750,
@@ -8971,6 +9700,7 @@
 		"altTitles": [],
 		"artist": "Giga / 鏡音リン・レン / Vivid BAD SQUAD「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 98.625,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 751,
@@ -8985,6 +9715,7 @@
 		"altTitles": [],
 		"artist": "Orangestar feat.IA",
 		"data": {
+			"duration": 146.595,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 752,
@@ -8998,6 +9729,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 120,
 			"genre": "東方Project"
 		},
 		"id": 753,
@@ -9010,6 +9742,7 @@
 		"altTitles": [],
 		"artist": "DiGiTAL WiNG feat. 花たん",
 		"data": {
+			"duration": 139.8,
 			"genre": "東方Project"
 		},
 		"id": 754,
@@ -9020,6 +9753,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
+			"duration": 126.632,
 			"genre": "東方Project"
 		},
 		"id": 755,
@@ -9032,6 +9766,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 141.017,
 			"genre": "東方Project"
 		},
 		"id": 756,
@@ -9044,6 +9779,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE & aran",
 		"data": {
+			"duration": 127.579,
 			"genre": "東方Project"
 		},
 		"id": 757,
@@ -9054,6 +9790,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 145.455,
 			"genre": "東方Project"
 		},
 		"id": 758,
@@ -9066,6 +9803,7 @@
 		"altTitles": [],
 		"artist": "TANO*C Sound Team",
 		"data": {
+			"duration": 131.993,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 759,
@@ -9078,6 +9816,7 @@
 		"altTitles": [],
 		"artist": "Akira Complex",
 		"data": {
+			"duration": 142.283,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 760,
@@ -9088,6 +9827,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 141.6,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 761,
@@ -9098,6 +9838,7 @@
 		"altTitles": [],
 		"artist": "Team Grimoire vs Laur",
 		"data": {
+			"duration": 144.286,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 762,
@@ -9111,6 +9852,7 @@
 		"altTitles": [],
 		"artist": "Aoi",
 		"data": {
+			"duration": 124.139,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 763,
@@ -9121,6 +9863,7 @@
 		"altTitles": [],
 		"artist": "Ino(chronoize) feat. 柳瀬マサキ",
 		"data": {
+			"duration": 149.647,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 764,
@@ -9133,6 +9876,7 @@
 		"altTitles": [],
 		"artist": "Ras",
 		"data": {
+			"duration": 135.724,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 765,
@@ -9143,6 +9887,7 @@
 		"altTitles": [],
 		"artist": "yaseta",
 		"data": {
+			"duration": 116,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 766,
@@ -9153,6 +9898,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree feat.yu＊tree",
 		"data": {
+			"duration": 157.959,
 			"genre": "maimai"
 		},
 		"id": 767,
@@ -9165,6 +9911,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree Remixed by Camellia",
 		"data": {
+			"duration": 166.753,
 			"genre": "maimai"
 		},
 		"id": 768,
@@ -9177,6 +9924,7 @@
 		"altTitles": [],
 		"artist": "onoken",
 		"data": {
+			"duration": 171,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 769,
@@ -9199,6 +9947,7 @@
 		"altTitles": [],
 		"artist": "ササノマリイ / 初音ミク / 25時、ナイトコードで。「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 107.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 771,
@@ -9216,6 +9965,7 @@
 		"altTitles": [],
 		"artist": "CielArc",
 		"data": {
+			"duration": 151,
 			"genre": "東方Project"
 		},
 		"id": 772,
@@ -9226,6 +9976,7 @@
 		"altTitles": [],
 		"artist": "水野健治",
 		"data": {
+			"duration": 149.73,
 			"genre": "maimai"
 		},
 		"id": 773,
@@ -9239,6 +9990,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA vs Cranky",
 		"data": {
+			"duration": 149.818,
 			"genre": "maimai"
 		},
 		"id": 774,
@@ -9252,6 +10004,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 137.314,
 			"genre": "maimai"
 		},
 		"id": 775,
@@ -9264,6 +10017,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 149,
 			"genre": "maimai"
 		},
 		"id": 776,
@@ -9274,6 +10028,7 @@
 		"altTitles": [],
 		"artist": "DIVELA feat.桐谷こむぎ",
 		"data": {
+			"duration": 121.213,
 			"genre": "maimai"
 		},
 		"id": 777,
@@ -9284,6 +10039,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 145.667,
 			"genre": "maimai"
 		},
 		"id": 778,
@@ -9300,6 +10056,7 @@
 		"altTitles": [],
 		"artist": "Juggernaut.",
 		"data": {
+			"duration": 152.571,
 			"genre": "maimai"
 		},
 		"id": 779,
@@ -9310,6 +10067,7 @@
 		"altTitles": [],
 		"artist": "TAKU1175 ft.駄々子",
 		"data": {
+			"duration": 150.857,
 			"genre": "maimai"
 		},
 		"id": 780,
@@ -9323,6 +10081,7 @@
 		"altTitles": [],
 		"artist": "Endorfin.",
 		"data": {
+			"duration": 139.784,
 			"genre": "maimai"
 		},
 		"id": 781,
@@ -9335,6 +10094,7 @@
 		"altTitles": [],
 		"artist": "ツミキ × 宮下遊",
 		"data": {
+			"duration": 145,
 			"genre": "maimai"
 		},
 		"id": 782,
@@ -9350,6 +10110,7 @@
 		"altTitles": [],
 		"artist": "蜂屋ななし",
 		"data": {
+			"duration": 134.4,
 			"genre": "maimai"
 		},
 		"id": 783,
@@ -9363,6 +10124,7 @@
 		"altTitles": [],
 		"artist": "nanobii",
 		"data": {
+			"duration": 138.246,
 			"genre": "maimai"
 		},
 		"id": 784,
@@ -9373,6 +10135,7 @@
 		"altTitles": [],
 		"artist": "BlackY feat. Risa Yuzuki",
 		"data": {
+			"duration": 153.559,
 			"genre": "maimai"
 		},
 		"id": 785,
@@ -9385,6 +10148,7 @@
 		"altTitles": [],
 		"artist": "奏音",
 		"data": {
+			"duration": 163.239,
 			"genre": "maimai"
 		},
 		"id": 786,
@@ -9398,6 +10162,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 136.277,
 			"genre": "maimai"
 		},
 		"id": 787,
@@ -9414,6 +10179,7 @@
 		"altTitles": [],
 		"artist": "Street",
 		"data": {
+			"duration": 131.163,
 			"genre": "maimai"
 		},
 		"id": 788,
@@ -9424,6 +10190,7 @@
 		"altTitles": [],
 		"artist": "Capchii",
 		"data": {
+			"duration": 135.385,
 			"genre": "maimai"
 		},
 		"id": 789,
@@ -9437,6 +10204,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 143.052,
 			"genre": "maimai"
 		},
 		"id": 790,
@@ -9447,6 +10215,7 @@
 		"altTitles": [],
 		"artist": "五十嵐 撫子(CV:花井 美春)",
 		"data": {
+			"duration": 154.2,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 791,
@@ -9460,6 +10229,7 @@
 		"altTitles": [],
 		"artist": "萩原 七々瀬(CV:東城 日沙子)",
 		"data": {
+			"duration": 131.99,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 792,
@@ -9472,6 +10242,7 @@
 		"altTitles": [],
 		"artist": "葛城 華(CV:丸岡 和佳奈)",
 		"data": {
+			"duration": 158.734,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 793,
@@ -9485,6 +10256,7 @@
 		"altTitles": [],
 		"artist": "小野 美苗(CV:伊藤 美来)",
 		"data": {
+			"duration": 155.73,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 794,
@@ -9497,6 +10269,7 @@
 		"altTitles": [],
 		"artist": "ゆゆうた",
 		"data": {
+			"duration": 151.579,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 795,
@@ -9509,6 +10282,7 @@
 		"altTitles": [],
 		"artist": "IOSYS TRAX",
 		"data": {
+			"duration": 160.444,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 796,
@@ -9521,6 +10295,7 @@
 		"altTitles": [],
 		"artist": "曲：大畑拓也／歌：bitter flavor [桜井 春菜(CV：近藤 玲奈)、早乙女 彩華(CV：中島 唯)]",
 		"data": {
+			"duration": 149.571,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 797,
@@ -9531,6 +10306,7 @@
 		"altTitles": [],
 		"artist": "BlackY vs. Yooh",
 		"data": {
+			"duration": 151.856,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 798,
@@ -9541,6 +10317,7 @@
 		"altTitles": [],
 		"artist": "曲：Q-MHz／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.484,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 799,
@@ -9587,6 +10364,7 @@
 		"altTitles": [],
 		"artist": "covered by 光吉猛修",
 		"data": {
+			"duration": 151.837,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 803,
@@ -9613,6 +10391,7 @@
 		"altTitles": [],
 		"artist": "タケモトピアノCM",
 		"data": {
+			"duration": 61.71,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 805,
@@ -9652,6 +10431,7 @@
 		"altTitles": [],
 		"artist": "ナイセン - momoco-",
 		"data": {
+			"duration": 148.34,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 808,
@@ -9674,6 +10454,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 129,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 810,
@@ -9687,6 +10468,7 @@
 		"altTitles": [],
 		"artist": "バルーン",
 		"data": {
+			"duration": 145.231,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 811,
@@ -9700,6 +10482,7 @@
 		"altTitles": [],
 		"artist": "GYARI",
 		"data": {
+			"duration": 152.381,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 812,
@@ -9714,6 +10497,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 137.349,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 813,
@@ -9724,6 +10508,7 @@
 		"altTitles": [],
 		"artist": "Ayase",
 		"data": {
+			"duration": 151.452,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 814,
@@ -9737,6 +10522,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 132.62,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 815,
@@ -9750,6 +10536,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 136.981,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 816,
@@ -9762,6 +10549,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 154.355,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 817,
@@ -9774,6 +10562,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 151.791,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 818,
@@ -9787,6 +10576,7 @@
 		"altTitles": [],
 		"artist": "P.I.N.A.",
 		"data": {
+			"duration": 148.767,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 819,
@@ -9802,6 +10592,7 @@
 		"altTitles": [],
 		"artist": "羽生まゐご",
 		"data": {
+			"duration": 151.453,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 820,
@@ -9816,6 +10607,7 @@
 		"altTitles": [],
 		"artist": "はるまきごはん",
 		"data": {
+			"duration": 147.591,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 821,
@@ -9829,6 +10621,7 @@
 		"altTitles": [],
 		"artist": "はるまきごはん",
 		"data": {
+			"duration": 161.471,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 822,
@@ -9843,6 +10636,7 @@
 		"altTitles": [],
 		"artist": "煮ル果実",
 		"data": {
+			"duration": 150,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 823,
@@ -9855,6 +10649,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 144,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 824,
@@ -9867,6 +10662,7 @@
 		"altTitles": [],
 		"artist": "東方LostWord feat.いとうかなこ",
 		"data": {
+			"duration": 145.435,
 			"genre": "東方Project"
 		},
 		"id": 825,
@@ -9880,6 +10676,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 149.231,
 			"genre": "東方Project"
 		},
 		"id": 826,
@@ -9892,6 +10689,7 @@
 		"altTitles": [],
 		"artist": "あ～るの～と（いえろ～ぜぶら）",
 		"data": {
+			"duration": 152.229,
 			"genre": "東方Project"
 		},
 		"id": 827,
@@ -9902,6 +10700,7 @@
 		"altTitles": [],
 		"artist": "豚乙女",
 		"data": {
+			"duration": 135,
 			"genre": "東方Project"
 		},
 		"id": 828,
@@ -9915,6 +10714,7 @@
 		"altTitles": [],
 		"artist": "Liz Triangle",
 		"data": {
+			"duration": 151,
 			"genre": "東方Project"
 		},
 		"id": 829,
@@ -9927,6 +10727,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 155.692,
 			"genre": "東方Project"
 		},
 		"id": 830,
@@ -9939,6 +10740,7 @@
 		"altTitles": [],
 		"artist": "uma vs. モリモリあつし",
 		"data": {
+			"duration": 143.774,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 831,
@@ -9951,6 +10753,7 @@
 		"altTitles": [],
 		"artist": "LeaF & Optie",
 		"data": {
+			"duration": 114.6,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 832,
@@ -9964,6 +10767,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 141.474,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 833,
@@ -9974,6 +10778,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 137.806,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 834,
@@ -9986,6 +10791,7 @@
 		"altTitles": [],
 		"artist": "DOT96",
 		"data": {
+			"duration": 122.877,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 835,
@@ -9996,6 +10802,7 @@
 		"altTitles": [],
 		"artist": "litmus*",
 		"data": {
+			"duration": 115.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 836,
@@ -10006,6 +10813,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 150.545,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 837,
@@ -10016,6 +10824,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 152.211,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 838,
@@ -10026,6 +10835,7 @@
 		"altTitles": [],
 		"artist": "かめりあ feat. ななひら",
 		"data": {
+			"duration": 149.531,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 839,
@@ -10044,6 +10854,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE",
 		"data": {
+			"duration": 130,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 840,
@@ -10054,6 +10865,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 153.053,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 841,
@@ -10067,6 +10879,7 @@
 		"altTitles": [],
 		"artist": "DJ Myosuke",
 		"data": {
+			"duration": 148.364,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 842,
@@ -10077,6 +10890,7 @@
 		"altTitles": [],
 		"artist": "Massive New Krew",
 		"data": {
+			"duration": 123.239,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 843,
@@ -10087,6 +10901,7 @@
 		"altTitles": [],
 		"artist": "suzu",
 		"data": {
+			"duration": 140.952,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 844,
@@ -10101,6 +10916,7 @@
 		"altTitles": [],
 		"artist": "黒沢ダイスケ VS 穴山大輔",
 		"data": {
+			"duration": 173.793,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 845,
@@ -10115,6 +10931,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite feat. しゃま(CV:種﨑 敦美) & みるく(CV:伊藤 あすか)",
 		"data": {
+			"duration": 160,
 			"genre": "maimai"
 		},
 		"id": 846,
@@ -10130,6 +10947,7 @@
 		"altTitles": [],
 		"artist": "さつき が てんこもり feat.96猫",
 		"data": {
+			"duration": 141.892,
 			"genre": "maimai"
 		},
 		"id": 847,
@@ -10143,6 +10961,7 @@
 		"altTitles": [],
 		"artist": "niki feat.noire",
 		"data": {
+			"duration": 145,
 			"genre": "maimai"
 		},
 		"id": 848,
@@ -10155,6 +10974,7 @@
 		"altTitles": [],
 		"artist": "梅干茶漬け",
 		"data": {
+			"duration": 125,
 			"genre": "maimai"
 		},
 		"id": 849,
@@ -10167,6 +10987,7 @@
 		"altTitles": [],
 		"artist": "Kai VS 大国奏音 VS 水野健治",
 		"data": {
+			"duration": 163.821,
 			"genre": "maimai"
 		},
 		"id": 850,
@@ -10181,6 +11002,7 @@
 		"altTitles": [],
 		"artist": "Umiai",
 		"data": {
+			"duration": 138.182,
 			"genre": "maimai"
 		},
 		"id": 851,
@@ -10199,6 +11021,7 @@
 		"altTitles": [],
 		"artist": "ぺのれり",
 		"data": {
+			"duration": 132,
 			"genre": "maimai"
 		},
 		"id": 852,
@@ -10209,6 +11032,7 @@
 		"altTitles": [],
 		"artist": "しょご/野村渉悟",
 		"data": {
+			"duration": 131,
 			"genre": "maimai"
 		},
 		"id": 853,
@@ -10225,6 +11049,7 @@
 		"altTitles": [],
 		"artist": "Nhato",
 		"data": {
+			"duration": 134,
 			"genre": "maimai"
 		},
 		"id": 854,
@@ -10237,6 +11062,7 @@
 		"altTitles": [],
 		"artist": "PRASTIK DANCEFLOOR",
 		"data": {
+			"duration": 154.059,
 			"genre": "maimai"
 		},
 		"id": 855,
@@ -10247,6 +11073,7 @@
 		"altTitles": [],
 		"artist": "Kobaryo",
 		"data": {
+			"duration": 137.098,
 			"genre": "maimai"
 		},
 		"id": 856,
@@ -10257,6 +11084,7 @@
 		"altTitles": [],
 		"artist": "An & Ryunosuke Kudo",
 		"data": {
+			"duration": 131,
 			"genre": "maimai"
 		},
 		"id": 857,
@@ -10267,6 +11095,7 @@
 		"altTitles": [],
 		"artist": "Limonène (サノカモメ+月島春果)",
 		"data": {
+			"duration": 147,
 			"genre": "maimai"
 		},
 		"id": 858,
@@ -10280,6 +11109,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA feat. RANASOL",
 		"data": {
+			"duration": 122,
 			"genre": "maimai"
 		},
 		"id": 859,
@@ -10294,6 +11124,7 @@
 		"altTitles": [],
 		"artist": "しーけー",
 		"data": {
+			"duration": 131.892,
 			"genre": "maimai"
 		},
 		"id": 860,
@@ -10304,6 +11135,7 @@
 		"altTitles": [],
 		"artist": "隣の庭は青い(庭師+Aoi)",
 		"data": {
+			"duration": 137.062,
 			"genre": "maimai"
 		},
 		"id": 861,
@@ -10318,6 +11150,7 @@
 		"altTitles": [],
 		"artist": "曲：齋藤大／歌：珠洲島 有栖(CV：長縄 まりあ)",
 		"data": {
+			"duration": 166.612,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 862,
@@ -10331,6 +11164,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 157.397,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 863,
@@ -10341,6 +11175,7 @@
 		"altTitles": [],
 		"artist": "MAYA AKAI",
 		"data": {
+			"duration": 137.956,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 864,
@@ -10351,6 +11186,7 @@
 		"altTitles": [],
 		"artist": "kanone",
 		"data": {
+			"duration": 154.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 865,
@@ -10363,6 +11199,7 @@
 		"altTitles": [],
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
+			"duration": 124.138,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 866,
@@ -10373,6 +11210,7 @@
 		"altTitles": [],
 		"artist": "舞ヶ原シンセ研究会",
 		"data": {
+			"duration": 170.571,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 867,
@@ -10383,6 +11221,7 @@
 		"altTitles": [],
 		"artist": "Acotto",
 		"data": {
+			"duration": 167.857,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 868,
@@ -10399,6 +11238,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite (HARDCORE TANO*C) feat.TANO*C ALL STARS",
 		"data": {
+			"duration": 155.351,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 869,
@@ -10464,6 +11304,7 @@
 		"altTitles": [],
 		"artist": "すりぃ",
 		"data": {
+			"duration": 106.813,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 874,
@@ -10476,6 +11317,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 115,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 875,
@@ -10490,6 +11332,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 151.2,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 876,
@@ -10503,6 +11346,7 @@
 		"altTitles": [],
 		"artist": "COOL&CREATE × 宝鐘マリン",
 		"data": {
+			"duration": 145.455,
 			"genre": "東方Project"
 		},
 		"id": 877,
@@ -10515,6 +11359,7 @@
 		"altTitles": [],
 		"artist": "立秋 feat.ちょこ",
 		"data": {
+			"duration": 142.334,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 878,
@@ -10528,6 +11373,7 @@
 		"altTitles": [],
 		"artist": "Sta feat. b",
 		"data": {
+			"duration": 161.143,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 879,
@@ -10541,6 +11387,7 @@
 		"altTitles": [],
 		"artist": "403",
 		"data": {
+			"duration": 149.338,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 880,
@@ -10551,6 +11398,7 @@
 		"altTitles": [],
 		"artist": "s-don as Iriss-Frantzz",
 		"data": {
+			"duration": 140.903,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 881,
@@ -10561,6 +11409,7 @@
 		"altTitles": [],
 		"artist": "Dachs",
 		"data": {
+			"duration": 168.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 882,
@@ -10571,6 +11420,7 @@
 		"altTitles": [],
 		"artist": "オーイシマサヨシ×加藤純一",
 		"data": {
+			"duration": 142.703,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 883,
@@ -10583,6 +11433,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー / 初音ミク / ワンダーランズ×ショウタイム「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 122.609,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 884,
@@ -10597,6 +11448,7 @@
 		"altTitles": [],
 		"artist": "SYNC.ART'S feat. 3L",
 		"data": {
+			"duration": 156.8,
 			"genre": "東方Project"
 		},
 		"id": 885,
@@ -10607,6 +11459,7 @@
 		"altTitles": [],
 		"artist": "東京アクティブNEETs",
 		"data": {
+			"duration": 140.253,
 			"genre": "東方Project"
 		},
 		"id": 886,
@@ -10621,6 +11474,7 @@
 		"altTitles": [],
 		"artist": "岸田教団&THE明星ロケッツ×草野華余子「東方ダンマクカグラ」",
 		"data": {
+			"duration": 147.846,
 			"genre": "東方Project"
 		},
 		"id": 887,
@@ -10634,6 +11488,7 @@
 		"altTitles": [],
 		"artist": "COOL&CREATE feat.ビートまりおとまろん「東方ダンマクカグラ」",
 		"data": {
+			"duration": 134.978,
 			"genre": "東方Project"
 		},
 		"id": 888,
@@ -10648,6 +11503,7 @@
 		"altTitles": [],
 		"artist": "キノシタ",
 		"data": {
+			"duration": 146.526,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 889,
@@ -10661,6 +11517,7 @@
 		"altTitles": [],
 		"artist": "キノシタ",
 		"data": {
+			"duration": 121.875,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 890,
@@ -10673,6 +11530,7 @@
 		"altTitles": [],
 		"artist": "yama",
 		"data": {
+			"duration": 149,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 891,
@@ -10712,6 +11570,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア・MARETU feat.初音ミク",
 		"data": {
+			"duration": 133.66,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 894,
@@ -10725,6 +11584,7 @@
 		"altTitles": [],
 		"artist": "キタニタツヤ",
 		"data": {
+			"duration": 142.642,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 895,
@@ -10738,6 +11598,7 @@
 		"altTitles": [],
 		"artist": "蜂屋ななし",
 		"data": {
+			"duration": 144.9,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 896,
@@ -10760,6 +11621,7 @@
 		"altTitles": [],
 		"artist": "Chinozo",
 		"data": {
+			"duration": 127.059,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 898,
@@ -10772,6 +11634,7 @@
 		"altTitles": [],
 		"artist": "john",
 		"data": {
+			"duration": 113.143,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 899,
@@ -10784,6 +11647,7 @@
 		"altTitles": [],
 		"artist": "稲葉曇",
 		"data": {
+			"duration": 148.571,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 900,
@@ -10796,6 +11660,7 @@
 		"altTitles": [],
 		"artist": "鹿乃と宇崎ちゃん",
 		"data": {
+			"duration": 92.8,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 901,
@@ -10809,6 +11674,7 @@
 		"altTitles": [],
 		"artist": "Yunomi & nicamoq",
 		"data": {
+			"duration": 140.156,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 902,
@@ -10822,6 +11688,7 @@
 		"altTitles": [],
 		"artist": "Last Note.",
 		"data": {
+			"duration": 154.543,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 903,
@@ -10835,6 +11702,7 @@
 		"altTitles": [],
 		"artist": "じーざす（ワンダフル☆オポチュニティ！）",
 		"data": {
+			"duration": 136.001,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 904,
@@ -10849,6 +11717,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 121.6,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 905,
@@ -10859,6 +11728,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 113.702,
 			"genre": "東方Project"
 		},
 		"id": 906,
@@ -10871,6 +11741,7 @@
 		"altTitles": [],
 		"artist": "Unlucky Morpheus",
 		"data": {
+			"duration": 148.645,
 			"genre": "東方Project"
 		},
 		"id": 907,
@@ -10884,6 +11755,7 @@
 		"altTitles": [],
 		"artist": "Team Grimoire",
 		"data": {
+			"duration": 139.355,
 			"genre": "maimai"
 		},
 		"id": 908,
@@ -10896,6 +11768,7 @@
 		"altTitles": [],
 		"artist": "すりぃ×相沢",
 		"data": {
+			"duration": 161.711,
 			"genre": "maimai"
 		},
 		"id": 909,
@@ -10918,6 +11791,7 @@
 		"altTitles": [],
 		"artist": "Eve TVアニメ「呪術廻戦」第1クールオープニングテーマ",
 		"data": {
+			"duration": 150.486,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 911,
@@ -10943,6 +11817,7 @@
 		"altTitles": [],
 		"artist": "Mitchie M / 初音ミク / MORE MORE JUMP！「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 107.727,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 913,
@@ -10956,6 +11831,7 @@
 		"altTitles": [],
 		"artist": "DECO*27 / 初音ミク / Leo/need「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 115.855,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 914,
@@ -10966,6 +11842,7 @@
 		"altTitles": [],
 		"artist": "PSYQUI",
 		"data": {
+			"duration": 131.429,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 915,
@@ -10978,6 +11855,7 @@
 		"altTitles": [],
 		"artist": "BlackYooh vs. siromaru",
 		"data": {
+			"duration": 137.424,
 			"genre": "maimai"
 		},
 		"id": 916,
@@ -10993,6 +11871,7 @@
 		"altTitles": [],
 		"artist": "烏屋茶房 feat. 利香",
 		"data": {
+			"duration": 157.826,
 			"genre": "maimai"
 		},
 		"id": 917,
@@ -11005,6 +11884,7 @@
 		"altTitles": [],
 		"artist": "パソコン音楽クラブ feat.ぷにぷに電機",
 		"data": {
+			"duration": 153,
 			"genre": "maimai"
 		},
 		"id": 918,
@@ -11017,6 +11897,7 @@
 		"altTitles": [],
 		"artist": "翡乃イスカ",
 		"data": {
+			"duration": 134.054,
 			"genre": "maimai"
 		},
 		"id": 919,
@@ -11030,6 +11911,7 @@
 		"altTitles": [],
 		"artist": "Noah",
 		"data": {
+			"duration": 128.612,
 			"genre": "maimai"
 		},
 		"id": 920,
@@ -11042,6 +11924,7 @@
 		"altTitles": [],
 		"artist": "rintaro soma",
 		"data": {
+			"duration": 145.929,
 			"genre": "maimai"
 		},
 		"id": 921,
@@ -11054,6 +11937,7 @@
 		"altTitles": [],
 		"artist": "柊マグネタイト",
 		"data": {
+			"duration": 159.158,
 			"genre": "maimai"
 		},
 		"id": 922,
@@ -11066,6 +11950,7 @@
 		"altTitles": [],
 		"artist": "ちいたな feat.flower",
 		"data": {
+			"duration": 157.009,
 			"genre": "maimai"
 		},
 		"id": 923,
@@ -11080,6 +11965,7 @@
 		"altTitles": [],
 		"artist": "Yuta Imai",
 		"data": {
+			"duration": 148.103,
 			"genre": "maimai"
 		},
 		"id": 924,
@@ -11094,6 +11980,7 @@
 		"altTitles": [],
 		"artist": "MK",
 		"data": {
+			"duration": 134.14,
 			"genre": "maimai"
 		},
 		"id": 925,
@@ -11104,6 +11991,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Iimori",
 		"data": {
+			"duration": 135.349,
 			"genre": "maimai"
 		},
 		"id": 926,
@@ -11114,6 +12002,7 @@
 		"altTitles": [],
 		"artist": "C-Show",
 		"data": {
+			"duration": 120,
 			"genre": "maimai"
 		},
 		"id": 927,
@@ -11126,6 +12015,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 124.8,
 			"genre": "maimai"
 		},
 		"id": 928,
@@ -11136,6 +12026,7 @@
 		"altTitles": [],
 		"artist": "OSTER project feat. そらこ",
 		"data": {
+			"duration": 146.087,
 			"genre": "maimai"
 		},
 		"id": 929,
@@ -11149,6 +12040,7 @@
 		"altTitles": [],
 		"artist": "Frums",
 		"data": {
+			"duration": 137.145,
 			"genre": "maimai"
 		},
 		"id": 930,
@@ -11168,6 +12060,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 151.448,
 			"genre": "maimai"
 		},
 		"id": 931,
@@ -11180,6 +12073,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお",
 		"data": {
+			"duration": 139.035,
 			"genre": "maimai"
 		},
 		"id": 932,
@@ -11190,6 +12084,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 137.143,
 			"genre": "maimai"
 		},
 		"id": 933,
@@ -11203,6 +12098,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 149.583,
 			"genre": "maimai"
 		},
 		"id": 934,
@@ -11218,6 +12114,7 @@
 		"altTitles": [],
 		"artist": "Yu-dachi",
 		"data": {
+			"duration": 145.2,
 			"genre": "maimai"
 		},
 		"id": 935,
@@ -11232,6 +12129,7 @@
 		"altTitles": [],
 		"artist": "打打だいず",
 		"data": {
+			"duration": 150.286,
 			"genre": "maimai"
 		},
 		"id": 936,
@@ -11244,6 +12142,7 @@
 		"altTitles": [],
 		"artist": "Retropolitaliens (Ms.+駄々子)",
 		"data": {
+			"duration": 138.333,
 			"genre": "maimai"
 		},
 		"id": 937,
@@ -11266,6 +12165,7 @@
 		"altTitles": [],
 		"artist": "Yooh",
 		"data": {
+			"duration": 126.487,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 939,
@@ -11278,6 +12178,7 @@
 		"altTitles": [],
 		"artist": "ユリイ・カノン feat.nameless",
 		"data": {
+			"duration": 143.721,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 940,
@@ -11290,6 +12191,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 142.65,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 941,
@@ -11300,6 +12202,7 @@
 		"altTitles": [],
 		"artist": "ナユタン星人",
 		"data": {
+			"duration": 143.256,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 942,
@@ -11313,6 +12216,7 @@
 		"altTitles": [],
 		"artist": "曲：Haggy Rock & 佐藤厚仁／歌：⊿TRiEDGE [高瀬 梨緒(CV：久保 ユリカ)、結城 莉玖(CV：朝日奈 丸佳)、藍原 椿(CV：橋本 ちなみ)]",
 		"data": {
+			"duration": 155.466,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 943,
@@ -11325,6 +12229,7 @@
 		"altTitles": [],
 		"artist": "anubasu-anubasu",
 		"data": {
+			"duration": 139.2,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 944,
@@ -11335,6 +12240,7 @@
 		"altTitles": [],
 		"artist": "ルゼ",
 		"data": {
+			"duration": 157.097,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 945,
@@ -11351,6 +12257,7 @@
 		"altTitles": [],
 		"artist": "fhána",
 		"data": {
+			"duration": 92.443,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 946,
@@ -11393,6 +12300,7 @@
 		"altTitles": [],
 		"artist": "スペシャルウィーク （CV.和氣あず未）、サイレンススズカ （CV.高野麻里佳）、トウカイテイオー （CV.Machico）",
 		"data": {
+			"duration": 136.575,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 949,
@@ -11407,6 +12315,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 133.171,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 950,
@@ -11419,6 +12328,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 137.544,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 951,
@@ -11431,6 +12341,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
+			"duration": 154,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 952,
@@ -11444,6 +12355,7 @@
 		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
+			"duration": 149.714,
 			"genre": "東方Project"
 		},
 		"id": 953,
@@ -11456,6 +12368,7 @@
 		"altTitles": [],
 		"artist": "Mastermind(xi+nora2r)",
 		"data": {
+			"duration": 140.938,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 954,
@@ -11466,6 +12379,7 @@
 		"altTitles": [],
 		"artist": "linear ring",
 		"data": {
+			"duration": 132.632,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 955,
@@ -11476,6 +12390,7 @@
 		"altTitles": [],
 		"artist": "Bitplane feat. 葉月ゆら",
 		"data": {
+			"duration": 123.667,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 956,
@@ -11486,6 +12401,7 @@
 		"altTitles": [],
 		"artist": "Photon Maiden",
 		"data": {
+			"duration": 114.375,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 957,
@@ -11496,6 +12412,7 @@
 		"altTitles": [],
 		"artist": "Lyrical Lily",
 		"data": {
+			"duration": 128.813,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 958,
@@ -11509,6 +12426,7 @@
 		"altTitles": [],
 		"artist": "x0o0x_",
 		"data": {
+			"duration": 136.615,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 959,
@@ -11522,6 +12440,7 @@
 		"altTitles": [],
 		"artist": "Tatsh x NAOKI",
 		"data": {
+			"duration": 122.278,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 960,
@@ -11532,6 +12451,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 123.141,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 961,
@@ -11542,6 +12462,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 146.724,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 962,
@@ -11552,6 +12473,7 @@
 		"altTitles": [],
 		"artist": "xi",
 		"data": {
+			"duration": 148.649,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 963,
@@ -11564,6 +12486,7 @@
 		"altTitles": [],
 		"artist": "Zekk",
 		"data": {
+			"duration": 127.543,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 964,
@@ -11574,6 +12497,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.Sana",
 		"data": {
+			"duration": 129.844,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 965,
@@ -11584,6 +12508,7 @@
 		"altTitles": [],
 		"artist": "Hommarju",
 		"data": {
+			"duration": 135.445,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 966,
@@ -11597,6 +12522,7 @@
 		"altTitles": [],
 		"artist": "Rain Drops",
 		"data": {
+			"duration": 148.125,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 967,
@@ -11609,6 +12535,7 @@
 		"altTitles": [],
 		"artist": "メッセメッセクラブ",
 		"data": {
+			"duration": 148.429,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 968,
@@ -11622,6 +12549,7 @@
 		"altTitles": [],
 		"artist": "TOPHAMHAT-KYO",
 		"data": {
+			"duration": 121.297,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 969,
@@ -11632,6 +12560,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 157.2,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 970,
@@ -11644,6 +12573,7 @@
 		"altTitles": [],
 		"artist": "3L (NJK Record)",
 		"data": {
+			"duration": 149.093,
 			"genre": "東方Project"
 		},
 		"id": 971,
@@ -11654,6 +12584,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 137.518,
 			"genre": "東方Project"
 		},
 		"id": 972,
@@ -11666,6 +12597,7 @@
 		"altTitles": [],
 		"artist": "幽閉サテライト(Produce:嵯峨飛鳥 Arranged:Iceon)",
 		"data": {
+			"duration": 146.143,
 			"genre": "東方Project"
 		},
 		"id": 973,
@@ -11678,6 +12610,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 152.8,
 			"genre": "東方Project"
 		},
 		"id": 974,
@@ -11690,6 +12623,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「ソニックカラーズ アルティメット」",
 		"data": {
+			"duration": 153.399,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 975,
@@ -11700,6 +12634,7 @@
 		"altTitles": [],
 		"artist": "すりぃ",
 		"data": {
+			"duration": 149.379,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 976,
@@ -11713,6 +12648,7 @@
 		"altTitles": [],
 		"artist": "柊マグネタイト",
 		"data": {
+			"duration": 147.347,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 977,
@@ -11728,6 +12664,7 @@
 		"altTitles": [],
 		"artist": "Sampling Masters AYA",
 		"data": {
+			"duration": 148.929,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 978,
@@ -11740,6 +12677,7 @@
 		"altTitles": [],
 		"artist": "作詞：セガ社員、作曲：若草恵、歌：135",
 		"data": {
+			"duration": 91.655,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 979,
@@ -11753,6 +12691,7 @@
 		"altTitles": [],
 		"artist": "NAOKI feat.小坂りゆ",
 		"data": {
+			"duration": 135.366,
 			"genre": "maimai"
 		},
 		"id": 980,
@@ -11768,6 +12707,7 @@
 		"altTitles": [],
 		"artist": "NAOKI underground",
 		"data": {
+			"duration": 137.554,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 981,
@@ -11778,6 +12718,7 @@
 		"altTitles": [],
 		"artist": "すりぃ",
 		"data": {
+			"duration": 113.333,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 982,
@@ -11791,6 +12732,7 @@
 		"altTitles": [],
 		"artist": "フロクロ",
 		"data": {
+			"duration": 128.071,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 983,
@@ -11805,6 +12747,7 @@
 		"altTitles": [],
 		"artist": "すりぃ feat.りょーくん",
 		"data": {
+			"duration": 152.93,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 984,
@@ -11817,6 +12760,7 @@
 		"altTitles": [],
 		"artist": "和田アキ子",
 		"data": {
+			"duration": 144,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 985,
@@ -11827,6 +12771,7 @@
 		"altTitles": [],
 		"artist": "曲：小高光太郎／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 159.75,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 986,
@@ -11837,6 +12782,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 159.56,
 			"genre": "maimai"
 		},
 		"id": 987,
@@ -11851,6 +12797,7 @@
 		"altTitles": [],
 		"artist": "いるかアイス feat.ちょこ",
 		"data": {
+			"duration": 128.4,
 			"genre": "maimai"
 		},
 		"id": 988,
@@ -11861,6 +12808,7 @@
 		"altTitles": [],
 		"artist": "ああ…翡翠茶漬け…",
 		"data": {
+			"duration": 133.333,
 			"genre": "maimai"
 		},
 		"id": 989,
@@ -11874,6 +12822,7 @@
 		"altTitles": [],
 		"artist": "Blacklolita",
 		"data": {
+			"duration": 149.334,
 			"genre": "maimai"
 		},
 		"id": 990,
@@ -11886,6 +12835,7 @@
 		"altTitles": [],
 		"artist": "un:c・konoco×cosMo＠暴走P",
 		"data": {
+			"duration": 163.871,
 			"genre": "maimai"
 		},
 		"id": 991,
@@ -11898,6 +12848,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる",
 		"data": {
+			"duration": 144.07,
 			"genre": "maimai"
 		},
 		"id": 992,
@@ -11908,6 +12859,7 @@
 		"altTitles": [],
 		"artist": "TAG",
 		"data": {
+			"duration": 123.6,
 			"genre": "maimai"
 		},
 		"id": 993,
@@ -11921,6 +12873,7 @@
 		"altTitles": [],
 		"artist": "きくお×cosMo＠暴走P feat.影縫英",
 		"data": {
+			"duration": 143.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 994,
@@ -11936,6 +12889,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 161.018,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 995,
@@ -11949,6 +12903,7 @@
 		"altTitles": [],
 		"artist": "曲：TAKU INOUE／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
+			"duration": 167.077,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 996,
@@ -11959,6 +12914,7 @@
 		"altTitles": [],
 		"artist": "Yu-dachi",
 		"data": {
+			"duration": 145.412,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 997,
@@ -11969,6 +12925,7 @@
 		"altTitles": [],
 		"artist": "AJURIKA",
 		"data": {
+			"duration": 153.6,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 998,
@@ -11979,6 +12936,7 @@
 		"altTitles": [],
 		"artist": "五十嵐双葉（ＣＶ：楠木ともり）、桜井桃子（ＣＶ：早見沙織）、黒部夏美（ＣＶ：青山玲菜）、月城モナ（ＣＶ：古賀葵）",
 		"data": {
+			"duration": 92.639,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 999,
@@ -11994,6 +12952,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 153.885,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1000,
@@ -12006,6 +12965,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 156.383,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1001,
@@ -12018,6 +12978,7 @@
 		"altTitles": [],
 		"artist": "Ado",
 		"data": {
+			"duration": 156.571,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1002,
@@ -12030,6 +12991,7 @@
 		"altTitles": [],
 		"artist": "Aimer",
 		"data": {
+			"duration": 159.912,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1003,
@@ -12043,6 +13005,7 @@
 		"altTitles": [],
 		"artist": "ツミキ　feat.音楽的同位体　可不（KAFU）",
 		"data": {
+			"duration": 138.706,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1004,
@@ -12055,6 +13018,7 @@
 		"altTitles": [],
 		"artist": "flower・てにをは",
 		"data": {
+			"duration": 132.353,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1005,
@@ -12067,6 +13031,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 136.248,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1006,
@@ -12077,6 +13042,7 @@
 		"altTitles": [],
 		"artist": "七条レタスグループ",
 		"data": {
+			"duration": 120.016,
 			"genre": "東方Project"
 		},
 		"id": 1007,
@@ -12094,6 +13060,7 @@
 		"altTitles": [],
 		"artist": "立秋 feat.ちょこ",
 		"data": {
+			"duration": 136.29,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1008,
@@ -12106,6 +13073,7 @@
 		"altTitles": [],
 		"artist": "Sobrem × Silentroom",
 		"data": {
+			"duration": 137.955,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1009,
@@ -12116,6 +13084,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 149.292,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1010,
@@ -12126,6 +13095,7 @@
 		"altTitles": [],
 		"artist": "Eve / 初音ミク、星乃一歌、花里みのり、小豆沢こはね、天馬司、宵崎奏「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 102.626,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1011,
@@ -12138,6 +13108,7 @@
 		"altTitles": [],
 		"artist": "DECO*27 × 堀江晶太(kemu) / 初音ミク、星乃一歌、天馬司、宵崎奏「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 111.429,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1012,
@@ -12150,6 +13121,7 @@
 		"altTitles": [],
 		"artist": "Giga & Mitchie M / 初音ミク、花里みのり、小豆沢こはね「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 112.021,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1013,
@@ -12163,6 +13135,7 @@
 		"altTitles": [],
 		"artist": "SYNC.ART'S feat. 3L",
 		"data": {
+			"duration": 129.882,
 			"genre": "東方Project"
 		},
 		"id": 1014,
@@ -12175,6 +13148,7 @@
 		"altTitles": [],
 		"artist": "さわわ",
 		"data": {
+			"duration": 151.502,
 			"genre": "東方Project"
 		},
 		"id": 1015,
@@ -12185,6 +13159,7 @@
 		"altTitles": [],
 		"artist": "名取さな",
 		"data": {
+			"duration": 146.207,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1016,
@@ -12197,6 +13172,7 @@
 		"altTitles": [],
 		"artist": "名取さな",
 		"data": {
+			"duration": 145.833,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1017,
@@ -12209,6 +13185,7 @@
 		"altTitles": [],
 		"artist": "柊マグネタイト　feat.音楽的同位体　可不（KAFU）",
 		"data": {
+			"duration": 152.211,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1018,
@@ -12221,6 +13198,7 @@
 		"altTitles": [],
 		"artist": "子牛 feat.音街ウナ",
 		"data": {
+			"duration": 143.027,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1019,
@@ -12233,6 +13211,7 @@
 		"altTitles": [],
 		"artist": "Mameyudoufu feat. Shully",
 		"data": {
+			"duration": 129.333,
 			"genre": "maimai"
 		},
 		"id": 1021,
@@ -12243,6 +13222,7 @@
 		"altTitles": [],
 		"artist": "litmus*",
 		"data": {
+			"duration": 143.077,
 			"genre": "maimai"
 		},
 		"id": 1022,
@@ -12253,6 +13233,7 @@
 		"altTitles": [],
 		"artist": "DJ Raisei",
 		"data": {
+			"duration": 128.471,
 			"genre": "maimai"
 		},
 		"id": 1023,
@@ -12266,6 +13247,7 @@
 		"altTitles": [],
 		"artist": "s-don",
 		"data": {
+			"duration": 141.691,
 			"genre": "maimai"
 		},
 		"id": 1024,
@@ -12276,6 +13258,7 @@
 		"altTitles": [],
 		"artist": "夏代孝明",
 		"data": {
+			"duration": 147.541,
 			"genre": "maimai"
 		},
 		"id": 1025,
@@ -12286,6 +13269,7 @@
 		"altTitles": [],
 		"artist": "シノ feat.しほ",
 		"data": {
+			"duration": 141.639,
 			"genre": "maimai"
 		},
 		"id": 1026,
@@ -12296,6 +13280,7 @@
 		"altTitles": [],
 		"artist": "Ponchi♪ feat.はぁち",
 		"data": {
+			"duration": 140.308,
 			"genre": "maimai"
 		},
 		"id": 1027,
@@ -12308,6 +13293,7 @@
 		"altTitles": [],
 		"artist": "テヅカ feat. 獅子神レオナ",
 		"data": {
+			"duration": 153.786,
 			"genre": "maimai"
 		},
 		"id": 1028,
@@ -12322,6 +13308,7 @@
 		"altTitles": [],
 		"artist": "ぞん子",
 		"data": {
+			"duration": 142.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1029,
@@ -12332,6 +13319,7 @@
 		"altTitles": [],
 		"artist": "冥堂院・アレクサンドル・ヴィクトリア・リヒテンシュタイン・聖斗 feat.TINOP",
 		"data": {
+			"duration": 102.931,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1030,
@@ -12346,6 +13334,7 @@
 		"altTitles": [],
 		"artist": "樋口楓",
 		"data": {
+			"duration": 150.977,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1031,
@@ -12356,6 +13345,7 @@
 		"altTitles": [],
 		"artist": "桐生一馬(黒田崇矢)",
 		"data": {
+			"duration": 124.054,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1032,
@@ -12369,6 +13359,7 @@
 		"altTitles": [],
 		"artist": "Laur feat.みしゃも",
 		"data": {
+			"duration": 160.215,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1033,
@@ -12381,6 +13372,7 @@
 		"altTitles": [],
 		"artist": "bermei.inazawa",
 		"data": {
+			"duration": 135.406,
 			"genre": "maimai"
 		},
 		"id": 1035,
@@ -12393,6 +13385,7 @@
 		"altTitles": [],
 		"artist": "秋田 真典",
 		"data": {
+			"duration": 147.237,
 			"genre": "maimai"
 		},
 		"id": 1036,
@@ -12405,6 +13398,7 @@
 		"altTitles": [],
 		"artist": "Tanchiky",
 		"data": {
+			"duration": 133.696,
 			"genre": "maimai"
 		},
 		"id": 1037,
@@ -12417,6 +13411,7 @@
 		"altTitles": [],
 		"artist": "Spiegel vs Yukino",
 		"data": {
+			"duration": 141.923,
 			"genre": "maimai"
 		},
 		"id": 1038,
@@ -12431,6 +13426,7 @@
 		"altTitles": [],
 		"artist": "亜沙 feat.くろくも",
 		"data": {
+			"duration": 150.779,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1039,
@@ -12441,6 +13437,7 @@
 		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
+			"duration": 141.455,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1040,
@@ -12455,6 +13452,7 @@
 		"altTitles": [],
 		"artist": "ETIA.",
 		"data": {
+			"duration": 149.486,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1041,
@@ -12465,6 +13463,7 @@
 		"altTitles": [],
 		"artist": "日高零奈・東雲和音・茅野ふたば「電音部」",
 		"data": {
+			"duration": 138.947,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1042,
@@ -12477,6 +13476,7 @@
 		"altTitles": [],
 		"artist": "鳳凰火凛・瀬戸海月・大賀ルキア「電音部」",
 		"data": {
+			"duration": 134.996,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1043,
@@ -12489,6 +13489,7 @@
 		"altTitles": [],
 		"artist": "Ino(chronoize) feat. 柳瀬マサキ",
 		"data": {
+			"duration": 128.261,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1044,
@@ -12501,6 +13502,7 @@
 		"altTitles": [],
 		"artist": "わかどり",
 		"data": {
+			"duration": 131.13,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1045,
@@ -12511,6 +13513,7 @@
 		"altTitles": [],
 		"artist": "syudou　feat.音楽的同位体　可不（KAFU）",
 		"data": {
+			"duration": 132.375,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1046,
@@ -12524,6 +13527,7 @@
 		"altTitles": [],
 		"artist": "syudou",
 		"data": {
+			"duration": 152.308,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1047,
@@ -12538,6 +13542,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 146.182,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1048,
@@ -12550,6 +13555,7 @@
 		"altTitles": [],
 		"artist": "Orangestar",
 		"data": {
+			"duration": 138,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1049,
@@ -12563,6 +13569,7 @@
 		"altTitles": [],
 		"artist": "Powerless feat. Sennzai",
 		"data": {
+			"duration": 158.824,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1050,
@@ -12573,6 +13580,7 @@
 		"altTitles": [],
 		"artist": "Silentroom vs Frums",
 		"data": {
+			"duration": 149.744,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1051,
@@ -12583,6 +13591,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE vs USAO",
 		"data": {
+			"duration": 145.171,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1052,
@@ -12597,6 +13606,7 @@
 		"altTitles": [],
 		"artist": "Hiro",
 		"data": {
+			"duration": 145.6,
 			"genre": "maimai"
 		},
 		"id": 1053,
@@ -12607,6 +13617,7 @@
 		"altTitles": [],
 		"artist": "Endorfin.",
 		"data": {
+			"duration": 153.953,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1054,
@@ -12617,6 +13628,7 @@
 		"altTitles": [],
 		"artist": "アリスシャッハと魔法の楽団",
 		"data": {
+			"duration": 145.263,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1055,
@@ -12631,6 +13643,7 @@
 		"altTitles": [],
 		"artist": "柊キライ",
 		"data": {
+			"duration": 146.824,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1056,
@@ -12643,6 +13656,7 @@
 		"altTitles": [],
 		"artist": "SLAVE.V-V-R",
 		"data": {
+			"duration": 156.585,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1057,
@@ -12655,6 +13669,7 @@
 		"altTitles": [],
 		"artist": "koyori（電ポルP）",
 		"data": {
+			"duration": 155,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1058,
@@ -12667,6 +13682,7 @@
 		"altTitles": [],
 		"artist": "青栗鼠",
 		"data": {
+			"duration": 152.535,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1059,
@@ -12679,6 +13695,7 @@
 		"altTitles": [],
 		"artist": "s-don vs. 翡乃イスカ",
 		"data": {
+			"duration": 149.032,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1060,
@@ -12691,6 +13708,7 @@
 		"altTitles": [],
 		"artist": "HARDCORE TANO*C & エリザベス（CV:大西沙織）",
 		"data": {
+			"duration": 123.243,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1061,
@@ -12701,6 +13719,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 132,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1062,
@@ -12711,6 +13730,7 @@
 		"altTitles": [],
 		"artist": "Aiobahn feat. KOTOKO",
 		"data": {
+			"duration": 163.436,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1063,
@@ -12721,6 +13741,7 @@
 		"altTitles": [],
 		"artist": "ぼっちぼろまる",
 		"data": {
+			"duration": 140.118,
 			"genre": "maimai"
 		},
 		"id": 1064,
@@ -12733,6 +13754,7 @@
 		"altTitles": [],
 		"artist": "linear ring",
 		"data": {
+			"duration": 154.265,
 			"genre": "maimai"
 		},
 		"id": 1065,
@@ -12743,6 +13765,7 @@
 		"altTitles": [],
 		"artist": "MYUKKE.",
 		"data": {
+			"duration": 136.235,
 			"genre": "maimai"
 		},
 		"id": 1066,
@@ -12753,6 +13776,7 @@
 		"altTitles": [],
 		"artist": "大国奏音 feat.timao",
 		"data": {
+			"duration": 160.421,
 			"genre": "maimai"
 		},
 		"id": 1067,
@@ -12765,6 +13789,7 @@
 		"altTitles": [],
 		"artist": "orangentle",
 		"data": {
+			"duration": 139.895,
 			"genre": "maimai"
 		},
 		"id": 1068,
@@ -12778,6 +13803,7 @@
 		"altTitles": [],
 		"artist": "koyori（電ポルP）",
 		"data": {
+			"duration": 154.161,
 			"genre": "maimai"
 		},
 		"id": 1069,
@@ -12791,6 +13817,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 163.404,
 			"genre": "maimai"
 		},
 		"id": 1070,
@@ -12803,6 +13830,7 @@
 		"altTitles": [],
 		"artist": "しーけー feat.ricono",
 		"data": {
+			"duration": 150.313,
 			"genre": "maimai"
 		},
 		"id": 1071,
@@ -12816,6 +13844,7 @@
 		"altTitles": [],
 		"artist": "青栗鼠 feat.sekai",
 		"data": {
+			"duration": 120.241,
 			"genre": "maimai"
 		},
 		"id": 1072,
@@ -12828,6 +13857,7 @@
 		"altTitles": [],
 		"artist": "ARForest feat.nayuta",
 		"data": {
+			"duration": 130.803,
 			"genre": "maimai"
 		},
 		"id": 1073,
@@ -12838,6 +13868,7 @@
 		"altTitles": [],
 		"artist": "n.k feat.影縫英",
 		"data": {
+			"duration": 150.667,
 			"genre": "maimai"
 		},
 		"id": 1074,
@@ -12851,6 +13882,7 @@
 		"altTitles": [],
 		"artist": "ああああ／大国奏音",
 		"data": {
+			"duration": 152.842,
 			"genre": "maimai"
 		},
 		"id": 1075,
@@ -12863,6 +13895,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK／水野健治",
 		"data": {
+			"duration": 137.647,
 			"genre": "maimai"
 		},
 		"id": 1076,
@@ -12876,6 +13909,7 @@
 		"altTitles": [],
 		"artist": "Hiro／rintaro soma",
 		"data": {
+			"duration": 146.962,
 			"genre": "maimai"
 		},
 		"id": 1077,
@@ -12886,6 +13920,7 @@
 		"altTitles": [],
 		"artist": "Kobaryo",
 		"data": {
+			"duration": 149.048,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1078,
@@ -12896,6 +13931,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 117.643,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1079,
@@ -12908,6 +13944,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 148.508,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1080,
@@ -12918,6 +13955,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 116.923,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1081,
@@ -12930,6 +13968,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 108.169,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1082,
@@ -12944,6 +13983,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 133.6,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1083,
@@ -12957,6 +13997,7 @@
 		"altTitles": [],
 		"artist": "Ado",
 		"data": {
+			"duration": 126.538,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1084,
@@ -12969,6 +14010,7 @@
 		"altTitles": [],
 		"artist": "ぼっちぼろまる",
 		"data": {
+			"duration": 153.898,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1085,
@@ -12982,6 +14024,7 @@
 		"altTitles": [],
 		"artist": "ぬゆり",
 		"data": {
+			"duration": 147.273,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1086,
@@ -12994,6 +14037,7 @@
 		"altTitles": [],
 		"artist": "香椎モイミ",
 		"data": {
+			"duration": 117.423,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1087,
@@ -13006,6 +14050,7 @@
 		"altTitles": [],
 		"artist": "ビートまりおとまろん",
 		"data": {
+			"duration": 145.778,
 			"genre": "東方Project"
 		},
 		"id": 1088,
@@ -13018,6 +14063,7 @@
 		"altTitles": [],
 		"artist": "高橋洋子 [covered by 光吉猛修]",
 		"data": {
+			"duration": 124.615,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1089,
@@ -13030,6 +14076,7 @@
 		"altTitles": [],
 		"artist": "Sammy Sound Team",
 		"data": {
+			"duration": 102.685,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1090,
@@ -13042,6 +14089,7 @@
 		"altTitles": [],
 		"artist": "Ayatsugu_Otowa",
 		"data": {
+			"duration": 101.833,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1091,
@@ -13052,6 +14100,7 @@
 		"altTitles": [],
 		"artist": "Sugar & Co.",
 		"data": {
+			"duration": 148.174,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1092,
@@ -13062,6 +14111,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 138.583,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1093,
@@ -13072,6 +14122,7 @@
 		"altTitles": [],
 		"artist": "MYUKKE.",
 		"data": {
+			"duration": 135.938,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1094,
@@ -13082,6 +14133,7 @@
 		"altTitles": [],
 		"artist": "ボス",
 		"data": {
+			"duration": 157.476,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1095,
@@ -13094,6 +14146,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 157.507,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1096,
@@ -13104,6 +14157,7 @@
 		"altTitles": [],
 		"artist": "三枝明那",
 		"data": {
+			"duration": 150.968,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1097,
@@ -13116,6 +14170,7 @@
 		"altTitles": [],
 		"artist": "あやぽんず＊ feat.ビートまりお × まろん",
 		"data": {
+			"duration": 124.186,
 			"genre": "東方Project"
 		},
 		"id": 1098,
@@ -13128,6 +14183,7 @@
 		"altTitles": [],
 		"artist": "lapix",
 		"data": {
+			"duration": 156,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1099,
@@ -13140,6 +14196,7 @@
 		"altTitles": [],
 		"artist": "Mameyudoufu",
 		"data": {
+			"duration": 142.657,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1100,
@@ -13150,6 +14207,7 @@
 		"altTitles": [],
 		"artist": "rejection",
 		"data": {
+			"duration": 135.771,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1101,
@@ -13160,6 +14218,7 @@
 		"altTitles": [],
 		"artist": "Blacklolita",
 		"data": {
+			"duration": 148.114,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1102,
@@ -13170,6 +14229,7 @@
 		"altTitles": [],
 		"artist": "YUKIYANAGI",
 		"data": {
+			"duration": 145.371,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1103,
@@ -13180,6 +14240,7 @@
 		"altTitles": [],
 		"artist": "Zekk & poplavor",
 		"data": {
+			"duration": 157.994,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1104,
@@ -13190,6 +14251,7 @@
 		"altTitles": [],
 		"artist": "からめる",
 		"data": {
+			"duration": 153,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1105,
@@ -13202,6 +14264,7 @@
 		"altTitles": [],
 		"artist": "Tanchiky",
 		"data": {
+			"duration": 127.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1106,
@@ -13212,6 +14275,7 @@
 		"altTitles": [],
 		"artist": "雄之助　feat.音楽的同位体　可不（KAFU）",
 		"data": {
+			"duration": 108.923,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1107,
@@ -13224,6 +14288,7 @@
 		"altTitles": [],
 		"artist": "DIVELA　feat.音楽的同位体　可不（KAFU）",
 		"data": {
+			"duration": 140.211,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1108,
@@ -13236,6 +14301,7 @@
 		"altTitles": [],
 		"artist": "USAO & Yuta Imai",
 		"data": {
+			"duration": 147.6,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1109,
@@ -13246,6 +14312,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 129.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1110,
@@ -13256,6 +14323,7 @@
 		"altTitles": [],
 		"artist": "Omoi",
 		"data": {
+			"duration": 155.027,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1111,
@@ -13268,6 +14336,7 @@
 		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
+			"duration": 133.167,
 			"genre": "東方Project"
 		},
 		"id": 1112,
@@ -13280,6 +14349,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 141.474,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1113,
@@ -13292,6 +14362,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima [covered by 五十嵐 撫子(CV:花井 美春)]",
 		"data": {
+			"duration": 148.085,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1114,
@@ -13305,6 +14376,7 @@
 		"altTitles": [],
 		"artist": "イロドリミドリ「CHUNITHM」",
 		"data": {
+			"duration": 171.951,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1115,
@@ -13317,6 +14389,7 @@
 		"altTitles": [],
 		"artist": "EmoCosine",
 		"data": {
+			"duration": 147.2,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1116,
@@ -13327,6 +14400,7 @@
 		"altTitles": [],
 		"artist": "カルロス袴田 feat. 日南めい, 古川由彩",
 		"data": {
+			"duration": 132.387,
 			"genre": "maimai"
 		},
 		"id": 1117,
@@ -13339,6 +14413,7 @@
 		"altTitles": [],
 		"artist": "立秋 feat.ちょこ",
 		"data": {
+			"duration": 124.936,
 			"genre": "maimai"
 		},
 		"id": 1118,
@@ -13352,6 +14427,7 @@
 		"altTitles": [],
 		"artist": "ピエロ☆マン",
 		"data": {
+			"duration": 137.684,
 			"genre": "maimai"
 		},
 		"id": 1119,
@@ -13362,6 +14438,7 @@
 		"altTitles": [],
 		"artist": "FANTAGIRAFF",
 		"data": {
+			"duration": 142.039,
 			"genre": "maimai"
 		},
 		"id": 1120,
@@ -13375,6 +14452,7 @@
 		"altTitles": [],
 		"artist": "r-906",
 		"data": {
+			"duration": 154.828,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1121,
@@ -13388,6 +14466,7 @@
 		"altTitles": [],
 		"artist": "ろーある",
 		"data": {
+			"duration": 123.429,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1122,
@@ -13400,6 +14479,7 @@
 		"altTitles": [],
 		"artist": "なきそ",
 		"data": {
+			"duration": 122.087,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1123,
@@ -13413,6 +14493,7 @@
 		"altTitles": [],
 		"artist": "メドミア",
 		"data": {
+			"duration": 117.474,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1124,
@@ -13425,6 +14506,7 @@
 		"altTitles": [],
 		"artist": "曲：広川恵一 (MONACA)／歌：オンゲキシューターズ",
 		"data": {
+			"duration": 146.661,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1125,
@@ -13435,6 +14517,7 @@
 		"altTitles": [],
 		"artist": "曲：烏屋茶房／歌：R.B.P. [九條 楓(CV：佳村 はるか)、逢坂 茜(CV：大空 直美)、珠洲島 有栖(CV：長縄 まりあ)]",
 		"data": {
+			"duration": 151.613,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1126,
@@ -13447,6 +14530,7 @@
 		"altTitles": [],
 		"artist": "USAO",
 		"data": {
+			"duration": 147.2,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1127,
@@ -13457,6 +14541,7 @@
 		"altTitles": [],
 		"artist": "BlackY",
 		"data": {
+			"duration": 147.739,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1128,
@@ -13467,6 +14552,7 @@
 		"altTitles": [],
 		"artist": "のらねこさい feat.ricono",
 		"data": {
+			"duration": 122.455,
 			"genre": "maimai"
 		},
 		"id": 1129,
@@ -13480,6 +14566,7 @@
 		"altTitles": [],
 		"artist": "大谷智哉「ソニックフロンティア」",
 		"data": {
+			"duration": 146.31,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1130,
@@ -13490,6 +14577,7 @@
 		"altTitles": [],
 		"artist": "モリモリあつし",
 		"data": {
+			"duration": 127.723,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1131,
@@ -13500,6 +14588,7 @@
 		"altTitles": [],
 		"artist": "KIHOW from MYTH & ROID",
 		"data": {
+			"duration": 125.619,
 			"genre": "東方Project"
 		},
 		"id": 1132,
@@ -13512,6 +14601,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 131.351,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1133,
@@ -13525,6 +14615,7 @@
 		"altTitles": [],
 		"artist": "八王子P feat. ななひら・まめこ",
 		"data": {
+			"duration": 137.2,
 			"genre": "maimai"
 		},
 		"id": 1134,
@@ -13537,6 +14628,7 @@
 		"altTitles": [],
 		"artist": "水野健治 feat.光吉猛修",
 		"data": {
+			"duration": 153.529,
 			"genre": "maimai"
 		},
 		"id": 1135,
@@ -13549,6 +14641,7 @@
 		"altTitles": [],
 		"artist": "pan",
 		"data": {
+			"duration": 135.254,
 			"genre": "maimai"
 		},
 		"id": 1136,
@@ -13559,6 +14652,7 @@
 		"altTitles": [],
 		"artist": "Sound Artz",
 		"data": {
+			"duration": 138.158,
 			"genre": "maimai"
 		},
 		"id": 1137,
@@ -13569,6 +14663,7 @@
 		"altTitles": [],
 		"artist": "Laur vs 大国奏音",
 		"data": {
+			"duration": 164.478,
 			"genre": "maimai"
 		},
 		"id": 1138,
@@ -13579,6 +14674,7 @@
 		"altTitles": [],
 		"artist": "ひとしずく×やま△ feat.悠佑＆ないこ（いれいす）",
 		"data": {
+			"duration": 157.895,
 			"genre": "maimai"
 		},
 		"id": 1139,
@@ -13589,6 +14685,7 @@
 		"altTitles": [],
 		"artist": "FLG4 feat.Flower",
 		"data": {
+			"duration": 160.488,
 			"genre": "maimai"
 		},
 		"id": 1140,
@@ -13599,6 +14696,7 @@
 		"altTitles": [],
 		"artist": "ぽわわん劇場",
 		"data": {
+			"duration": 146.211,
 			"genre": "maimai"
 		},
 		"id": 1141,
@@ -13612,6 +14710,7 @@
 		"altTitles": [],
 		"artist": "crayvxn",
 		"data": {
+			"duration": 130.318,
 			"genre": "maimai"
 		},
 		"id": 1142,
@@ -13622,6 +14721,7 @@
 		"altTitles": [],
 		"artist": "Zekk",
 		"data": {
+			"duration": 132.316,
 			"genre": "maimai"
 		},
 		"id": 1143,
@@ -13632,6 +14732,7 @@
 		"altTitles": [],
 		"artist": "Artifact vs. Dualcast",
 		"data": {
+			"duration": 134.925,
 			"genre": "maimai"
 		},
 		"id": 1144,
@@ -13644,6 +14745,7 @@
 		"altTitles": [],
 		"artist": "カラスヤサボウ feat. もるでお",
 		"data": {
+			"duration": 138.119,
 			"genre": "maimai"
 		},
 		"id": 1145,
@@ -13656,6 +14758,7 @@
 		"altTitles": [],
 		"artist": "アオワイファイ feat.犀羅",
 		"data": {
+			"duration": 136.8,
 			"genre": "maimai"
 		},
 		"id": 1146,
@@ -13668,6 +14771,7 @@
 		"altTitles": [],
 		"artist": "針原翼（はりーP）feat. はく",
 		"data": {
+			"duration": 152,
 			"genre": "maimai"
 		},
 		"id": 1147,
@@ -13680,6 +14784,7 @@
 		"altTitles": [],
 		"artist": "KAZE Lab",
 		"data": {
+			"duration": 142.059,
 			"genre": "maimai"
 		},
 		"id": 1148,
@@ -13692,6 +14797,7 @@
 		"altTitles": [],
 		"artist": "Getty vs DJ DiA",
 		"data": {
+			"duration": 135.6,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1149,
@@ -13704,6 +14810,7 @@
 		"altTitles": [],
 		"artist": "山本真央樹",
 		"data": {
+			"duration": 156,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1150,
@@ -13714,6 +14821,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 158.689,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1151,
@@ -13727,6 +14835,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 146.4,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1152,
@@ -13740,6 +14849,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 150.337,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1153,
@@ -13750,6 +14860,7 @@
 		"altTitles": [],
 		"artist": "Shohei Tsuchiya (ZUNTATA) feat. Aimee B",
 		"data": {
+			"duration": 116.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1154,
@@ -13760,6 +14871,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
+			"duration": 118.5,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1155,
@@ -13770,6 +14882,7 @@
 		"altTitles": [],
 		"artist": "結束バンド",
 		"data": {
+			"duration": 150.316,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1156,
@@ -13795,6 +14908,7 @@
 		"altTitles": [],
 		"artist": "さくゆい",
 		"data": {
+			"duration": 154.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1158,
@@ -13808,6 +14922,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 145.806,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1159,
@@ -13820,6 +14935,7 @@
 		"altTitles": [],
 		"artist": "南ノ南",
 		"data": {
+			"duration": 154.909,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1160,
@@ -13832,6 +14948,7 @@
 		"altTitles": [],
 		"artist": "She is Legend",
 		"data": {
+			"duration": 144,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1161,
@@ -13842,6 +14959,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite & Massive New Krew feat. リリィ(CV:青木志貴)",
 		"data": {
+			"duration": 143.226,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1162,
@@ -13852,6 +14970,7 @@
 		"altTitles": [],
 		"artist": "EmoCosine",
 		"data": {
+			"duration": 139.125,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1163,
@@ -13862,6 +14981,7 @@
 		"altTitles": [],
 		"artist": "Laur",
 		"data": {
+			"duration": 136.875,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1164,
@@ -13874,6 +14994,7 @@
 		"altTitles": [],
 		"artist": "REDALiCE & cosMo＠暴走P",
 		"data": {
+			"duration": 140.985,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1165,
@@ -13887,6 +15008,7 @@
 		"altTitles": [],
 		"artist": "前島麻由",
 		"data": {
+			"duration": 92.727,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1166,
@@ -13897,6 +15019,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 125.69,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1167,
@@ -13909,6 +15032,7 @@
 		"altTitles": [],
 		"artist": "TJ.hangneil",
 		"data": {
+			"duration": 153.148,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1168,
@@ -13921,6 +15045,7 @@
 		"altTitles": [],
 		"artist": "TJ.hangneil",
 		"data": {
+			"duration": 156.432,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1169,
@@ -13931,6 +15056,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 157.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1170,
@@ -13944,6 +15070,7 @@
 		"altTitles": [],
 		"artist": "TJ.hangneil",
 		"data": {
+			"duration": 157.657,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1171,
@@ -13954,6 +15081,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK × TJ.hangneil",
 		"data": {
+			"duration": 161.398,
 			"genre": "maimai"
 		},
 		"id": 1172,
@@ -13964,6 +15092,7 @@
 		"altTitles": [],
 		"artist": "Yamajet",
 		"data": {
+			"duration": 131.591,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1173,
@@ -13976,6 +15105,7 @@
 		"altTitles": [],
 		"artist": "八王子P / 初音ミク / Vivid BAD SQUAD「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 142.286,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1174,
@@ -13986,6 +15116,7 @@
 		"altTitles": [],
 		"artist": "とあ / MEIKO / 25時、ナイトコードで。「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 134.737,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1175,
@@ -13998,6 +15129,7 @@
 		"altTitles": [],
 		"artist": "ワンダフル☆オポチュニティ！ / 初音ミク / ワンダーランズ×ショウタイム「プロジェクトセカイ カラフルステージ！ feat. 初音ミク」",
 		"data": {
+			"duration": 125,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1176,
@@ -14010,6 +15142,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree Remixed by sasakure.UK",
 		"data": {
+			"duration": 158.019,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1177,
@@ -14024,6 +15157,7 @@
 		"altTitles": [],
 		"artist": "ひらうみ",
 		"data": {
+			"duration": 125.566,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1178,
@@ -14037,6 +15171,7 @@
 		"altTitles": [],
 		"artist": "なみぐる",
 		"data": {
+			"duration": 139.714,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1179,
@@ -14049,6 +15184,7 @@
 		"altTitles": [],
 		"artist": "SARUKANI",
 		"data": {
+			"duration": 152.039,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1180,
@@ -14059,6 +15195,7 @@
 		"altTitles": [],
 		"artist": "SARUKANI",
 		"data": {
+			"duration": 142.817,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1181,
@@ -14069,6 +15206,7 @@
 		"altTitles": [],
 		"artist": "Iris",
 		"data": {
+			"duration": 157.588,
 			"genre": "maimai"
 		},
 		"id": 1182,
@@ -14079,6 +15217,7 @@
 		"altTitles": [],
 		"artist": "XinG、10lulu",
 		"data": {
+			"duration": 131.657,
 			"genre": "maimai"
 		},
 		"id": 1183,
@@ -14089,6 +15228,7 @@
 		"altTitles": [],
 		"artist": "Akira Complex",
 		"data": {
+			"duration": 127.2,
 			"genre": "maimai"
 		},
 		"id": 1184,
@@ -14099,6 +15239,7 @@
 		"altTitles": [],
 		"artist": "Cosmograph",
 		"data": {
+			"duration": 153.333,
 			"genre": "maimai"
 		},
 		"id": 1185,
@@ -14109,6 +15250,7 @@
 		"altTitles": [],
 		"artist": "R Sound Design feat.向日葵",
 		"data": {
+			"duration": 150.909,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1186,
@@ -14119,6 +15261,7 @@
 		"altTitles": [],
 		"artist": "ツミキ feat.月乃",
 		"data": {
+			"duration": 141.159,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1187,
@@ -14131,6 +15274,7 @@
 		"altTitles": [],
 		"artist": "Zekk",
 		"data": {
+			"duration": 136.216,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1188,
@@ -14143,6 +15287,7 @@
 		"altTitles": [],
 		"artist": "wotaku",
 		"data": {
+			"duration": 158.906,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1189,
@@ -14156,6 +15301,7 @@
 		"altTitles": [],
 		"artist": "とあ",
 		"data": {
+			"duration": 159.712,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1190,
@@ -14169,6 +15315,7 @@
 		"altTitles": [],
 		"artist": "暁Records",
 		"data": {
+			"duration": 126.961,
 			"genre": "東方Project"
 		},
 		"id": 1191,
@@ -14179,6 +15326,7 @@
 		"altTitles": [],
 		"artist": "litmus*",
 		"data": {
+			"duration": 128.036,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1192,
@@ -14191,6 +15339,7 @@
 		"altTitles": [],
 		"artist": "rintaro soma",
 		"data": {
+			"duration": 171.463,
 			"genre": "maimai"
 		},
 		"id": 1193,
@@ -14203,6 +15352,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
+			"duration": 169.325,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1194,
@@ -14213,6 +15363,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 144.706,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1197,
@@ -14223,6 +15374,7 @@
 		"altTitles": [],
 		"artist": "A4。",
 		"data": {
+			"duration": 150.72,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1198,
@@ -14235,6 +15387,7 @@
 		"altTitles": [],
 		"artist": "Kai",
 		"data": {
+			"duration": 129.846,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1199,
@@ -14247,6 +15400,7 @@
 		"altTitles": [],
 		"artist": "カロンズベカラズ",
 		"data": {
+			"duration": 138.367,
 			"genre": "maimai"
 		},
 		"id": 1200,
@@ -14259,6 +15413,7 @@
 		"altTitles": [],
 		"artist": "なみぐる feat.ちょこ 桃寝ちのい",
 		"data": {
+			"duration": 130.125,
 			"genre": "maimai"
 		},
 		"id": 1201,
@@ -14271,6 +15426,7 @@
 		"altTitles": [],
 		"artist": "やどりぎ",
 		"data": {
+			"duration": 142.143,
 			"genre": "maimai"
 		},
 		"id": 1202,
@@ -14281,6 +15437,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree feat.nie＊tree",
 		"data": {
+			"duration": 143.915,
 			"genre": "maimai"
 		},
 		"id": 1203,
@@ -14291,6 +15448,7 @@
 		"altTitles": [],
 		"artist": "MisoilePunch♪",
 		"data": {
+			"duration": 158.612,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1204,
@@ -14303,6 +15461,7 @@
 		"altTitles": [],
 		"artist": "Aiobahn feat. KOTOKO",
 		"data": {
+			"duration": 172.541,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1205,
@@ -14313,6 +15472,7 @@
 		"altTitles": [],
 		"artist": "花譜",
 		"data": {
+			"duration": 153.69,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1206,
@@ -14325,6 +15485,7 @@
 		"altTitles": [],
 		"artist": "A-One",
 		"data": {
+			"duration": 159.107,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1207,
@@ -14337,6 +15498,7 @@
 		"altTitles": [],
 		"artist": "ゆこぴ",
 		"data": {
+			"duration": 138.222,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1208,
@@ -14349,6 +15511,7 @@
 		"altTitles": [],
 		"artist": "ゆこぴ",
 		"data": {
+			"duration": 117,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1209,
@@ -14361,6 +15524,7 @@
 		"altTitles": [],
 		"artist": "YOASOBI",
 		"data": {
+			"duration": 154.308,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1210,
@@ -14373,6 +15537,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 156.763,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1211,
@@ -14385,6 +15550,7 @@
 		"altTitles": [],
 		"artist": "Kanaria",
 		"data": {
+			"duration": 137.739,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1212,
@@ -14397,6 +15563,7 @@
 		"altTitles": [],
 		"artist": "雄之助 feat. POPY & ROSE",
 		"data": {
+			"duration": 147.667,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1213,
@@ -14409,6 +15576,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 160.484,
 			"genre": "東方Project"
 		},
 		"id": 1214,
@@ -14421,6 +15589,7 @@
 		"altTitles": [],
 		"artist": "saaa + kei_iwata + stuv + わかどり",
 		"data": {
+			"duration": 152.25,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1215,
@@ -14431,6 +15600,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 160.286,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1216,
@@ -14444,6 +15614,7 @@
 		"altTitles": [],
 		"artist": "MyGO!!!!!",
 		"data": {
+			"duration": 95,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1217,
@@ -14456,6 +15627,7 @@
 		"altTitles": [],
 		"artist": "SOUND HOLIC Vs. Eurobeat Union feat. Nana Takahashi",
 		"data": {
+			"duration": 152.625,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1218,
@@ -14468,6 +15640,7 @@
 		"altTitles": [],
 		"artist": "MisoilePunch♪",
 		"data": {
+			"duration": 128.526,
 			"genre": "maimai"
 		},
 		"id": 1219,
@@ -14478,6 +15651,7 @@
 		"altTitles": [],
 		"artist": "aran",
 		"data": {
+			"duration": 126.9,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1220,
@@ -14488,6 +15662,7 @@
 		"altTitles": [],
 		"artist": "黒魔",
 		"data": {
+			"duration": 122.553,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1221,
@@ -14498,6 +15673,7 @@
 		"altTitles": [],
 		"artist": "Cranky VS MASAKI",
 		"data": {
+			"duration": 149.754,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1222,
@@ -14508,6 +15684,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 154.615,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1223,
@@ -14520,6 +15697,7 @@
 		"altTitles": [],
 		"artist": "いよわ",
 		"data": {
+			"duration": 140.941,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1224,
@@ -14532,6 +15710,7 @@
 		"altTitles": [],
 		"artist": "EZFG",
 		"data": {
+			"duration": 135.31,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1225,
@@ -14544,6 +15723,7 @@
 		"altTitles": [],
 		"artist": "もちうつね",
 		"data": {
+			"duration": 162.462,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1226,
@@ -14556,6 +15736,7 @@
 		"altTitles": [],
 		"artist": "Ryo Fukuda",
 		"data": {
+			"duration": 150.666,
 			"genre": "maimai"
 		},
 		"id": 1227,
@@ -14568,6 +15749,7 @@
 		"altTitles": [],
 		"artist": "siqlo",
 		"data": {
+			"duration": 138.7,
 			"genre": "maimai"
 		},
 		"id": 1228,
@@ -14580,6 +15762,7 @@
 		"altTitles": [],
 		"artist": "K-forest",
 		"data": {
+			"duration": 140.432,
 			"genre": "maimai"
 		},
 		"id": 1229,
@@ -14590,6 +15773,7 @@
 		"altTitles": [],
 		"artist": "Hommarju",
 		"data": {
+			"duration": 149.846,
 			"genre": "maimai"
 		},
 		"id": 1230,
@@ -14612,6 +15796,7 @@
 		"altTitles": [],
 		"artist": "打打だいず Vs. Tanchiky Vs. からめる",
 		"data": {
+			"duration": 159.273,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1232,
@@ -14625,6 +15810,7 @@
 		"altTitles": [],
 		"artist": "まらしぃ×じん×堀江晶太(kemu) feat.鏡音リン",
 		"data": {
+			"duration": 155.833,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1233,
@@ -14637,6 +15823,7 @@
 		"altTitles": [],
 		"artist": "花畑チャイカ＆椎名唯華",
 		"data": {
+			"duration": 112.889,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1234,
@@ -14649,6 +15836,7 @@
 		"altTitles": [],
 		"artist": "マサラダ",
 		"data": {
+			"duration": 159.882,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1235,
@@ -14661,6 +15849,7 @@
 		"altTitles": [],
 		"artist": "isonosuke",
 		"data": {
+			"duration": 150,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1236,
@@ -14673,6 +15862,7 @@
 		"altTitles": [],
 		"artist": "てにをは",
 		"data": {
+			"duration": 148.264,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1237,
@@ -16207,6 +17397,7 @@
 		"altTitles": [],
 		"artist": "黒沢ダイスケ × 小寺可南子",
 		"data": {
+			"duration": 148.723,
 			"genre": "maimai"
 		},
 		"id": 1373,
@@ -16217,6 +17408,7 @@
 		"altTitles": [],
 		"artist": "高瀬一矢 feat. R.I.N.A",
 		"data": {
+			"duration": 139.437,
 			"genre": "maimai"
 		},
 		"id": 1374,
@@ -16227,6 +17419,7 @@
 		"altTitles": [],
 		"artist": "伊藤和馬(Arte Refact) feat.konoco",
 		"data": {
+			"duration": 140.667,
 			"genre": "maimai"
 		},
 		"id": 1375,
@@ -16239,6 +17432,7 @@
 		"altTitles": [],
 		"artist": "AJURIKA feat.SAK.",
 		"data": {
+			"duration": 126.108,
 			"genre": "maimai"
 		},
 		"id": 1376,
@@ -16249,6 +17443,7 @@
 		"altTitles": [],
 		"artist": "岸田教団&THE明星ロケッツ×草野華余子",
 		"data": {
+			"duration": 130.376,
 			"genre": "東方Project"
 		},
 		"id": 1377,
@@ -16259,6 +17454,7 @@
 		"altTitles": [],
 		"artist": "Masayoshi Minoshima Remixed by 小室哲哉",
 		"data": {
+			"duration": 135.111,
 			"genre": "東方Project"
 		},
 		"id": 1378,
@@ -16269,6 +17465,7 @@
 		"altTitles": [],
 		"artist": "まらしぃ",
 		"data": {
+			"duration": 149.053,
 			"genre": "東方Project"
 		},
 		"id": 1379,
@@ -16279,6 +17476,7 @@
 		"altTitles": [],
 		"artist": "Reku Mochizuki",
 		"data": {
+			"duration": 121.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1380,
@@ -16291,6 +17489,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite & Srav3R",
 		"data": {
+			"duration": 157,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1381,
@@ -16301,6 +17500,7 @@
 		"altTitles": [],
 		"artist": "P*Light",
 		"data": {
+			"duration": 123.882,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1382,
@@ -16311,6 +17511,7 @@
 		"altTitles": [],
 		"artist": "DJ Noriken",
 		"data": {
+			"duration": 150.706,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1383,
@@ -16321,6 +17522,7 @@
 		"altTitles": [],
 		"artist": "DJ Genki",
 		"data": {
+			"duration": 143,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1384,
@@ -16333,6 +17535,7 @@
 		"altTitles": [],
 		"artist": "Massive New Krew feat. 光吉猛修",
 		"data": {
+			"duration": 157.548,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1385,
@@ -16343,6 +17546,7 @@
 		"altTitles": [],
 		"artist": "すりぃ",
 		"data": {
+			"duration": 148.525,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1386,
@@ -16355,6 +17559,7 @@
 		"altTitles": [],
 		"artist": "Omoi",
 		"data": {
+			"duration": 152.842,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1387,
@@ -16367,6 +17572,7 @@
 		"altTitles": [],
 		"artist": "Junky",
 		"data": {
+			"duration": 150.341,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1388,
@@ -16379,6 +17585,7 @@
 		"altTitles": [],
 		"artist": "Osanzi feat.藍月なくる",
 		"data": {
+			"duration": 155.6,
 			"genre": "maimai"
 		},
 		"id": 1389,
@@ -16389,6 +17596,7 @@
 		"altTitles": [],
 		"artist": "清風明月（Drop×葉月ゆら）",
 		"data": {
+			"duration": 142.443,
 			"genre": "maimai"
 		},
 		"id": 1390,
@@ -16399,6 +17607,7 @@
 		"altTitles": [],
 		"artist": "Morrigan feat.Lily and 結城碧",
 		"data": {
+			"duration": 144.973,
 			"genre": "maimai"
 		},
 		"id": 1391,
@@ -16411,6 +17620,7 @@
 		"altTitles": [],
 		"artist": "Kai",
 		"data": {
+			"duration": 159.13,
 			"genre": "maimai"
 		},
 		"id": 1392,
@@ -16423,6 +17633,7 @@
 		"altTitles": [],
 		"artist": "曲：本多友紀（Arte Refact）／歌：日向 千夏(CV：岡咲 美保)",
 		"data": {
+			"duration": 159.783,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1393,
@@ -16435,6 +17646,7 @@
 		"altTitles": [],
 		"artist": "曲：本田正樹(Dream Monster)／歌：7EVENDAYS⇔HOLIDAYS [井之原 小星(CV：ももの はるな)、柏木 咲姫(CV：石見 舞菜香)]",
 		"data": {
+			"duration": 156.863,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1394,
@@ -16447,6 +17659,7 @@
 		"altTitles": [],
 		"artist": "owl＊tree",
 		"data": {
+			"duration": 158.308,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1395,
@@ -16457,6 +17670,7 @@
 		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
+			"duration": 135.079,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1396,
@@ -16467,6 +17681,7 @@
 		"altTitles": [],
 		"artist": "周防パトラ",
 		"data": {
+			"duration": 149.538,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1397,
@@ -16480,6 +17695,7 @@
 		"altTitles": [],
 		"artist": "周防パトラ",
 		"data": {
+			"duration": 149.294,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1398,
@@ -16492,6 +17708,7 @@
 		"altTitles": [],
 		"artist": "BlackY a.k.a. WAiKURO survive",
 		"data": {
+			"duration": 143.133,
 			"genre": "maimai"
 		},
 		"id": 1399,
@@ -16502,6 +17719,7 @@
 		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.Sana",
 		"data": {
+			"duration": 152.516,
 			"genre": "maimai"
 		},
 		"id": 1400,
@@ -16514,6 +17732,7 @@
 		"altTitles": [],
 		"artist": "Teary Planet",
 		"data": {
+			"duration": 136.667,
 			"genre": "maimai"
 		},
 		"id": 1401,
@@ -16526,6 +17745,7 @@
 		"altTitles": [],
 		"artist": "r-906",
 		"data": {
+			"duration": 150,
 			"genre": "maimai"
 		},
 		"id": 1402,
@@ -16536,6 +17756,7 @@
 		"altTitles": [],
 		"artist": "Pizuya's Cell feat.中村さん",
 		"data": {
+			"duration": 150.978,
 			"genre": "maimai"
 		},
 		"id": 1403,
@@ -16548,6 +17769,7 @@
 		"altTitles": [],
 		"artist": "TAKU1175 ft.駄々子",
 		"data": {
+			"duration": 136.854,
 			"genre": "maimai"
 		},
 		"id": 1404,
@@ -16560,6 +17782,7 @@
 		"altTitles": [],
 		"artist": "Yooh",
 		"data": {
+			"duration": 148.712,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1405,
@@ -16570,6 +17793,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 149.169,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1406,
@@ -16582,6 +17806,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
+			"duration": 143.137,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1407,
@@ -16594,6 +17819,7 @@
 		"altTitles": [],
 		"artist": "Ado",
 		"data": {
+			"duration": 132.727,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1408,
@@ -16606,6 +17832,7 @@
 		"altTitles": [],
 		"artist": "HIMEHINA",
 		"data": {
+			"duration": 159.149,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1409,
@@ -16618,6 +17845,7 @@
 		"altTitles": [],
 		"artist": "松平健 [covered by 光吉猛修]",
 		"data": {
+			"duration": 154.505,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1410,
@@ -16630,6 +17858,7 @@
 		"altTitles": [],
 		"artist": "DECO*27, ピノキオピー",
 		"data": {
+			"duration": 139.481,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1411,
@@ -16642,6 +17871,7 @@
 		"altTitles": [],
 		"artist": "なみぐる feat.ずんだもん",
 		"data": {
+			"duration": 155.459,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1412,
@@ -16654,6 +17884,7 @@
 		"altTitles": [],
 		"artist": "ぱらどっと",
 		"data": {
+			"duration": 166.414,
 			"genre": "東方Project"
 		},
 		"id": 1413,
@@ -16664,6 +17895,7 @@
 		"altTitles": [],
 		"artist": "Lime",
 		"data": {
+			"duration": 147.225,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1414,
@@ -16674,6 +17906,7 @@
 		"altTitles": [],
 		"artist": "Street",
 		"data": {
+			"duration": 140.914,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1415,
@@ -16684,6 +17917,7 @@
 		"altTitles": [],
 		"artist": "からとP⍺ոchii少年 feat.はるの",
 		"data": {
+			"duration": 135.273,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1416,
@@ -16697,6 +17931,7 @@
 		"altTitles": [],
 		"artist": "BlackY feat. Risa Yuzuki",
 		"data": {
+			"duration": 141.878,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1417,
@@ -16707,6 +17942,7 @@
 		"altTitles": [],
 		"artist": "Ashrount vs. 打打だいず",
 		"data": {
+			"duration": 163.889,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1418,
@@ -16717,6 +17953,7 @@
 		"altTitles": [],
 		"artist": "柊マグネタイト",
 		"data": {
+			"duration": 160.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1419,
@@ -16729,6 +17966,7 @@
 		"altTitles": [],
 		"artist": "削除",
 		"data": {
+			"duration": 152.229,
 			"genre": "maimai"
 		},
 		"id": 1420,
@@ -16739,6 +17977,7 @@
 		"altTitles": [],
 		"artist": "YOASOBI",
 		"data": {
+			"duration": 93.462,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1421,
@@ -16752,6 +17991,7 @@
 		"altTitles": [],
 		"artist": "原口沙輔 feat.重音テト",
 		"data": {
+			"duration": 128.8,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1422,
@@ -16764,6 +18004,7 @@
 		"altTitles": [],
 		"artist": "MonsterZ MATE",
 		"data": {
+			"duration": 131.625,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1423,
@@ -16776,6 +18017,7 @@
 		"altTitles": [],
 		"artist": "魂音泉",
 		"data": {
+			"duration": 159.429,
 			"genre": "東方Project"
 		},
 		"id": 1424,
@@ -16788,6 +18030,7 @@
 		"altTitles": [],
 		"artist": "ビートまりお",
 		"data": {
+			"duration": 155.422,
 			"genre": "東方Project"
 		},
 		"id": 1425,
@@ -16801,6 +18044,7 @@
 		"altTitles": [],
 		"artist": "原口沙輔 feat.重音テト",
 		"data": {
+			"duration": 122.471,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1426,
@@ -16814,6 +18058,7 @@
 		"altTitles": [],
 		"artist": "RiraN",
 		"data": {
+			"duration": 135.375,
 			"genre": "maimai"
 		},
 		"id": 1427,
@@ -16824,6 +18069,7 @@
 		"altTitles": [],
 		"artist": "Reku Mochizuki",
 		"data": {
+			"duration": 122.27,
 			"genre": "maimai"
 		},
 		"id": 1428,
@@ -16834,6 +18080,7 @@
 		"altTitles": [],
 		"artist": "かねこちはる vs t+pazolite",
 		"data": {
+			"duration": 158.88,
 			"genre": "maimai"
 		},
 		"id": 1429,
@@ -16846,6 +18093,7 @@
 		"altTitles": [],
 		"artist": "t+pazolite vs かねこちはる",
 		"data": {
+			"duration": 161.165,
 			"genre": "maimai"
 		},
 		"id": 1430,
@@ -16858,6 +18106,7 @@
 		"altTitles": [],
 		"artist": "かゆき",
 		"data": {
+			"duration": 147.5,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1431,
@@ -16870,6 +18119,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 148.138,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1432,
@@ -16882,6 +18132,7 @@
 		"altTitles": [],
 		"artist": "夢限大みゅーたいぷ",
 		"data": {
+			"duration": 155.077,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1433,
@@ -16894,6 +18145,7 @@
 		"altTitles": [],
 		"artist": "wotaku feat.SHIKI",
 		"data": {
+			"duration": 155.2,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1434,
@@ -16904,6 +18156,7 @@
 		"altTitles": [],
 		"artist": "和田たけあき",
 		"data": {
+			"duration": 135.789,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1435,
@@ -16917,6 +18170,7 @@
 		"altTitles": [],
 		"artist": "satella feat.藍月なくる",
 		"data": {
+			"duration": 145.735,
 			"genre": "maimai"
 		},
 		"id": 1436,
@@ -16927,6 +18181,7 @@
 		"altTitles": [],
 		"artist": "花徒めと（Metomate）",
 		"data": {
+			"duration": 135.843,
 			"genre": "maimai"
 		},
 		"id": 1437,
@@ -16939,6 +18194,7 @@
 		"altTitles": [],
 		"artist": "void (Mournfinale) feat. 古泉葉月",
 		"data": {
+			"duration": 144.663,
 			"genre": "maimai"
 		},
 		"id": 1438,
@@ -16949,6 +18205,7 @@
 		"altTitles": [],
 		"artist": "大国奏音",
 		"data": {
+			"duration": 161.122,
 			"genre": "maimai"
 		},
 		"id": 1439,
@@ -16964,6 +18221,7 @@
 		"altTitles": [],
 		"artist": "鳳 ここな(CV.石見舞菜香)、静香(CV.長谷川育美)、カトリナ・グリーベル(CV.天城サリー)、新妻八恵(CV.長縄まりあ)、柳場ぱんだ(CV.大空直美)、流石知冴(CV.佐々木李子)",
 		"data": {
+			"duration": 116.035,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1440,
@@ -16978,6 +18236,7 @@
 		"altTitles": [],
 		"artist": "千寿 暦(CV.鳥部万里子)、ラモーナ・ウォルフ(CV.田中美海)、王 雪(CV.花井美春)、リリヤ・クルトベイ(CV.安齋由香里)、与那国緋花里(CV.下地紫野)",
 		"data": {
+			"duration": 95.647,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1441,
@@ -16990,6 +18249,7 @@
 		"altTitles": [],
 		"artist": "ナノウ",
 		"data": {
+			"duration": 154.773,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1442,
@@ -17003,6 +18263,7 @@
 		"altTitles": [],
 		"artist": "森羅万象",
 		"data": {
+			"duration": 139.39,
 			"genre": "東方Project"
 		},
 		"id": 1443,
@@ -17016,6 +18277,7 @@
 		"altTitles": [],
 		"artist": "sky_delta vs KO3 vs Tanchiky",
 		"data": {
+			"duration": 138,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1444,
@@ -17026,6 +18288,7 @@
 		"altTitles": [],
 		"artist": "蓮ノ空女学院スクールアイドルクラブ",
 		"data": {
+			"duration": 149.61,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1445,
@@ -17036,6 +18299,7 @@
 		"altTitles": [],
 		"artist": "OSTER project",
 		"data": {
+			"duration": 152.108,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1446,
@@ -17048,6 +18312,7 @@
 		"altTitles": [],
 		"artist": "吉田夜世",
 		"data": {
+			"duration": 140.588,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1447,
@@ -17060,6 +18325,7 @@
 		"altTitles": [],
 		"artist": "はるふり",
 		"data": {
+			"duration": 134.4,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1448,
@@ -17073,6 +18339,7 @@
 		"altTitles": [],
 		"artist": "マサラダ",
 		"data": {
+			"duration": 172.337,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1449,
@@ -17085,6 +18352,7 @@
 		"altTitles": [],
 		"artist": "いよわ feat.重音テト",
 		"data": {
+			"duration": 149.333,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1450,
@@ -17097,6 +18365,7 @@
 		"altTitles": [],
 		"artist": "164 feat.ELISA・小林太郎",
 		"data": {
+			"duration": 141.024,
 			"genre": "maimai"
 		},
 		"id": 1451,
@@ -17109,6 +18378,7 @@
 		"altTitles": [],
 		"artist": "せきこみごはん",
 		"data": {
+			"duration": 154.4,
 			"genre": "maimai"
 		},
 		"id": 1452,
@@ -17121,6 +18391,7 @@
 		"altTitles": [],
 		"artist": "SIINCA",
 		"data": {
+			"duration": 160.737,
 			"genre": "maimai"
 		},
 		"id": 1453,
@@ -17131,6 +18402,7 @@
 		"altTitles": [],
 		"artist": "aran & Kobaryo",
 		"data": {
+			"duration": 144.947,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1454,
@@ -17144,6 +18416,7 @@
 		"altTitles": [],
 		"artist": "曲：ANCHOR／歌：皇城 セツナ(CV：八巻 アンナ)",
 		"data": {
+			"duration": 157.895,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1455,
@@ -17154,6 +18427,7 @@
 		"altTitles": [],
 		"artist": "曲：ヒゲドライバー／歌：いちげきしゅーたーず！",
 		"data": {
+			"duration": 154.629,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1456,
@@ -17166,6 +18440,7 @@
 		"altTitles": [],
 		"artist": "Nhato",
 		"data": {
+			"duration": 146.323,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1457,
@@ -17176,6 +18451,7 @@
 		"altTitles": [],
 		"artist": "Lite Show Magic",
 		"data": {
+			"duration": 128.182,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1458,
@@ -17186,6 +18462,7 @@
 		"altTitles": [],
 		"artist": "ARM×狐夢想 feat. ななひら",
 		"data": {
+			"duration": 163.886,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1459,
@@ -17199,6 +18476,7 @@
 		"altTitles": [],
 		"artist": "ななひら",
 		"data": {
+			"duration": 148.661,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1460,
@@ -17212,6 +18490,7 @@
 		"altTitles": [],
 		"artist": "Neko Hacker",
 		"data": {
+			"duration": 154.957,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1461,
@@ -17235,6 +18514,7 @@
 		"altTitles": [],
 		"artist": "おめがシスターズ",
 		"data": {
+			"duration": 154.286,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1463,
@@ -17245,6 +18525,7 @@
 		"altTitles": [],
 		"artist": "TOKOTOKO（西沢さんP）",
 		"data": {
+			"duration": 155.493,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1464,
@@ -17255,6 +18536,7 @@
 		"altTitles": [],
 		"artist": "saaa",
 		"data": {
+			"duration": 141.765,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1465,
@@ -17265,6 +18547,7 @@
 		"altTitles": [],
 		"artist": "F Rabbeat feat.マスタード",
 		"data": {
+			"duration": 152.432,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1466,

--- a/seeds/collections/songs-maimaidx.json
+++ b/seeds/collections/songs-maimaidx.json
@@ -1137,6 +1137,7 @@
 		"altTitles": [],
 		"artist": "supercell「化物語」",
 		"data": {
+			"duration": 91.317,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 91,
@@ -2260,6 +2261,7 @@
 		"altTitles": [],
 		"artist": "クーナ(CV 喜多村英梨)「PHANTASY STAR ONLINE 2」",
 		"data": {
+			"duration": 132.61,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 178,
@@ -2895,6 +2897,7 @@
 		"altTitles": [],
 		"artist": "SIAM SHADE [covered by 湯毛]",
 		"data": {
+			"duration": 116.447,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 227,
@@ -3579,6 +3582,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 133.941,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 279,
@@ -3631,6 +3635,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 101.321,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 283,
@@ -4152,6 +4157,7 @@
 		"altTitles": [],
 		"artist": "GigaReol",
 		"data": {
+			"duration": 145,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 323,
@@ -5175,6 +5181,7 @@
 		"altTitles": [],
 		"artist": "MYTH & ROID「Re：ゼロから始める異世界生活」",
 		"data": {
+			"duration": 91.636,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 401,
@@ -5658,6 +5665,7 @@
 		"altTitles": [],
 		"artist": "劇団ひととせ「ひなこのーと」",
 		"data": {
+			"duration": 93.105,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 438,
@@ -5759,6 +5767,7 @@
 		"altTitles": [],
 		"artist": "鈴木このみ「ノーゲーム・ノーライフ」",
 		"data": {
+			"duration": 91.43,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 446,
@@ -5769,6 +5778,7 @@
 		"altTitles": [],
 		"artist": "ターニャ・デグレチャフ(CV.悠木碧)「幼女戦記」",
 		"data": {
+			"duration": 93.268,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 447,
@@ -5969,6 +5979,7 @@
 		"altTitles": [],
 		"artist": "ガヴリール（富田美憂），ヴィーネ（大西沙織），サターニャ（大空直美），ラフィエル（花澤香菜）「ガヴリールドロップアウト」",
 		"data": {
+			"duration": 91.518,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 463,
@@ -6425,6 +6436,7 @@
 		"altTitles": [],
 		"artist": "After the Rain（そらる×まふまふ）",
 		"data": {
+			"duration": 92.993,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 499,
@@ -6887,6 +6899,7 @@
 		"altTitles": [],
 		"artist": "亜咲花",
 		"data": {
+			"duration": 96.394,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 534,
@@ -6911,6 +6924,7 @@
 		"altTitles": [],
 		"artist": "fripSide",
 		"data": {
+			"duration": 104.8,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 536,
@@ -7364,6 +7378,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 148.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 571,
@@ -8745,6 +8760,7 @@
 		"altTitles": [],
 		"artist": "カクとイムラ(CV：松本慶祐)",
 		"data": {
+			"duration": 149.487,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 676,
@@ -9055,6 +9071,7 @@
 		"altTitles": [],
 		"artist": "六厘舎",
 		"data": {
+			"duration": 118.571,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 701,
@@ -9473,6 +9490,7 @@
 		"altTitles": [],
 		"artist": "Petit Rabbit's",
 		"data": {
+			"duration": 94.177,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 734,
@@ -9485,6 +9503,7 @@
 		"altTitles": [],
 		"artist": "shami momo（吉田優子・千代田桃）／CV：小原好美・鬼頭明里",
 		"data": {
+			"duration": 94.545,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 735,
@@ -9497,6 +9516,7 @@
 		"altTitles": [],
 		"artist": "LiSA",
 		"data": {
+			"duration": 156.444,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 736,
@@ -9509,6 +9529,7 @@
 		"altTitles": [],
 		"artist": "StylipS",
 		"data": {
+			"duration": 93.929,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 737,
@@ -9937,6 +9958,7 @@
 		"altTitles": [],
 		"artist": "Official髭男dism",
 		"data": {
+			"duration": 157.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 770,
@@ -10328,6 +10350,7 @@
 		"altTitles": [],
 		"artist": "Mrs. GREEN APPLE",
 		"data": {
+			"duration": 92.477,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 800,
@@ -10340,6 +10363,7 @@
 		"altTitles": [],
 		"artist": "原田知世",
 		"data": {
+			"duration": 116.949,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 801,
@@ -10354,6 +10378,7 @@
 		"altTitles": [],
 		"artist": "涼宮ハルヒ（CV.平野 綾） TVアニメ「涼宮ハルヒの憂鬱」",
 		"data": {
+			"duration": 161.635,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 802,
@@ -10377,6 +10402,7 @@
 		"altTitles": [],
 		"artist": "ずっと真夜中でいいのに。",
 		"data": {
+			"duration": 158.375,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 804,
@@ -10406,6 +10432,7 @@
 		"altTitles": [],
 		"artist": "angela",
 		"data": {
+			"duration": 91.576,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 806,
@@ -10418,6 +10445,7 @@
 		"altTitles": [],
 		"artist": "ビックカメラ",
 		"data": {
+			"duration": 121.936,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 807,
@@ -10444,6 +10472,7 @@
 		"altTitles": [],
 		"artist": "hololive IDOL PROJECT",
 		"data": {
+			"duration": 98.929,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 809,
@@ -11251,6 +11280,7 @@
 		"altTitles": [],
 		"artist": "YOASOBI",
 		"data": {
+			"duration": 166,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 870,
@@ -11267,6 +11297,7 @@
 		"altTitles": [],
 		"artist": "Ado",
 		"data": {
+			"duration": 136.18,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 871,
@@ -11281,6 +11312,7 @@
 		"altTitles": [],
 		"artist": "クレシェンドブルー [最上静香 (CV.田所あずさ)、北上麗花 (CV.平山笑美)、北沢志保 (CV.雨宮 天)、野々原 茜 (CV.小笠原早紀)、箱崎星梨花 (CV.麻倉もも)]",
 		"data": {
+			"duration": 136.02,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 872,
@@ -11291,6 +11323,7 @@
 		"altTitles": [],
 		"artist": "DRAMATIC STARS [天道 輝 (CV.仲村宗悟), 桜庭 薫 (CV.内田雄馬), 柏木 翼 (CV.八代 拓)]",
 		"data": {
+			"duration": 122.553,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 873,
@@ -11543,6 +11576,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 133.867,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 892,
@@ -11560,6 +11594,7 @@
 		"altTitles": [],
 		"artist": "Rain Drops",
 		"data": {
+			"duration": 142.268,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 893,
@@ -11611,6 +11646,7 @@
 		"altTitles": [],
 		"artist": "亜咲花",
 		"data": {
+			"duration": 90.416,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 897,
@@ -11781,6 +11817,7 @@
 		"altTitles": [],
 		"artist": "須田景凪",
 		"data": {
+			"duration": 144.013,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 910,
@@ -11804,6 +11841,7 @@
 		"altTitles": [],
 		"artist": "ARuFa",
 		"data": {
+			"duration": 149.143,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 912,
@@ -12153,6 +12191,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 151.714,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 938,
@@ -12271,6 +12310,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 137.319,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 947,
@@ -12285,6 +12325,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 135.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 948,
@@ -14895,6 +14936,7 @@
 		"altTitles": [],
 		"artist": "ツユ",
 		"data": {
+			"duration": 162.4,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1157,
@@ -15784,6 +15826,7 @@
 		"altTitles": [],
 		"artist": "☆リズムに合わせてボタンを叩き達成率を競うゲームです☆",
 		"data": {
+			"duration": 71.343,
 			"genre": "maimai"
 		},
 		"id": 1231,
@@ -15876,6 +15919,7 @@
 		"altTitles": [],
 		"artist": "木村由姫 [cover]",
 		"data": {
+			"duration": 105.437,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1238,
@@ -15886,6 +15930,7 @@
 		"altTitles": [],
 		"artist": "いきものがかり [cover]",
 		"data": {
+			"duration": 96.491,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1239,
@@ -15898,6 +15943,7 @@
 		"altTitles": [],
 		"artist": "AKB48 [PV]",
 		"data": {
+			"duration": 141.674,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1240,
@@ -15911,6 +15957,7 @@
 		"altTitles": [],
 		"artist": "「化物語」 [cover]",
 		"data": {
+			"duration": 90.002,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1241,
@@ -15923,6 +15970,7 @@
 		"altTitles": [],
 		"artist": "ClariS　「魔法少女まどか☆マギカ」",
 		"data": {
+			"duration": 111.086,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1242,
@@ -15935,6 +15983,7 @@
 		"altTitles": [],
 		"artist": "EXILE",
 		"data": {
+			"duration": 103.388,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1243,
@@ -15945,6 +15994,7 @@
 		"altTitles": [],
 		"artist": "May J. [cover]",
 		"data": {
+			"duration": 98.776,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1244,
@@ -15955,6 +16005,7 @@
 		"altTitles": [],
 		"artist": "moumoon [PV]",
 		"data": {
+			"duration": 124.9,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1245,
@@ -15965,6 +16016,7 @@
 		"altTitles": [],
 		"artist": "倖田 來未 [PV]",
 		"data": {
+			"duration": 109.158,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1246,
@@ -15978,6 +16030,7 @@
 		"altTitles": [],
 		"artist": "EXILE [PV]",
 		"data": {
+			"duration": 144,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1247,
@@ -15988,6 +16041,7 @@
 		"altTitles": [],
 		"artist": "サカナクション [cover]",
 		"data": {
+			"duration": 97.235,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1248,
@@ -16000,6 +16054,7 @@
 		"altTitles": [],
 		"artist": "AKB48 [PV]",
 		"data": {
+			"duration": 116.93,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1249,
@@ -16012,6 +16067,7 @@
 		"altTitles": [],
 		"artist": "w-inds. [PV]",
 		"data": {
+			"duration": 104.565,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1250,
@@ -16022,6 +16078,7 @@
 		"altTitles": [],
 		"artist": "きゃりーぱみゅぱみゅ [PV]",
 		"data": {
+			"duration": 112.502,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1251,
@@ -16032,6 +16089,7 @@
 		"altTitles": [],
 		"artist": "w-inds. [PV]",
 		"data": {
+			"duration": 115.87,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1252,
@@ -16042,6 +16100,7 @@
 		"altTitles": [],
 		"artist": "きゃりーぱみゅぱみゅ [PV]",
 		"data": {
+			"duration": 105.935,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1253,
@@ -16054,6 +16113,7 @@
 		"altTitles": [],
 		"artist": "MAN WITH A MISSION [PV]",
 		"data": {
+			"duration": 132.447,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1254,
@@ -16064,6 +16124,7 @@
 		"altTitles": [],
 		"artist": "家入レオ [PV]",
 		"data": {
+			"duration": 139.796,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1255,
@@ -16076,6 +16137,7 @@
 		"altTitles": [],
 		"artist": "Acid Black Cherry [PV]",
 		"data": {
+			"duration": 122.742,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1256,
@@ -16086,6 +16148,7 @@
 		"altTitles": [],
 		"artist": "きゃりーぱみゅぱみゅ [PV]",
 		"data": {
+			"duration": 108.925,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1257,
@@ -16096,6 +16159,7 @@
 		"altTitles": [],
 		"artist": "L'Arc～en～Ciel [cover]",
 		"data": {
+			"duration": 100.418,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1258,
@@ -16106,6 +16170,7 @@
 		"altTitles": [],
 		"artist": "ASIAN KUNG-FU GENERATION [cover]",
 		"data": {
+			"duration": 119.43,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1259,
@@ -16118,6 +16183,7 @@
 		"altTitles": [],
 		"artist": "BUMP OF CHICKEN [cover]",
 		"data": {
+			"duration": 99.215,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1260,
@@ -16130,6 +16196,7 @@
 		"altTitles": [],
 		"artist": "FLOW / 「NARUTO」[cover]",
 		"data": {
+			"duration": 107.52,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1261,
@@ -16140,6 +16207,7 @@
 		"altTitles": [],
 		"artist": "club Prince[cover]",
 		"data": {
+			"duration": 122.469,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1262,
@@ -16152,6 +16220,7 @@
 		"altTitles": [],
 		"artist": "galaxias! [PV]",
 		"data": {
+			"duration": 107.565,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1263,
@@ -16162,6 +16231,7 @@
 		"altTitles": [],
 		"artist": "ゴールデンボンバー [PV]",
 		"data": {
+			"duration": 99.023,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1264,
@@ -16174,6 +16244,7 @@
 		"altTitles": [],
 		"artist": "ももいろクローバーZ [PV]",
 		"data": {
+			"duration": 122.147,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1265,
@@ -16186,6 +16257,7 @@
 		"altTitles": [],
 		"artist": "AKINO[cover]",
 		"data": {
+			"duration": 105.067,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1266,
@@ -16198,6 +16270,7 @@
 		"altTitles": [],
 		"artist": "和田光司 [cover]",
 		"data": {
+			"duration": 96.651,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1267,
@@ -16210,6 +16283,7 @@
 		"altTitles": [],
 		"artist": "高橋洋子 [cover]",
 		"data": {
+			"duration": 92.645,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1268,
@@ -16223,6 +16297,7 @@
 		"altTitles": [],
 		"artist": "SEKAI NO OWARI",
 		"data": {
+			"duration": 102.668,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1269,
@@ -16233,6 +16308,7 @@
 		"altTitles": [],
 		"artist": "mamenoi(MANYO & やなぎなぎ)",
 		"data": {
+			"duration": 128.771,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1270,
@@ -16243,6 +16319,7 @@
 		"altTitles": [],
 		"artist": "ナムコエンジェル「アイドルマスター」",
 		"data": {
+			"duration": 133.338,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1271,
@@ -16253,6 +16330,7 @@
 		"altTitles": [],
 		"artist": "ナムコエンジェル「アイドルマスター」",
 		"data": {
+			"duration": 142.427,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1272,
@@ -16263,6 +16341,7 @@
 		"altTitles": [],
 		"artist": "ナムコエンジェル「アイドルマスター」",
 		"data": {
+			"duration": 137.333,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1273,
@@ -16273,6 +16352,7 @@
 		"altTitles": [],
 		"artist": "Linked Horizon「進撃の巨人」 [アニメPV]",
 		"data": {
+			"duration": 93.545,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1274,
@@ -16285,6 +16365,7 @@
 		"altTitles": [],
 		"artist": "ROOKiEZ is PUNK'D「弱虫ペダル」 [アニメPV]",
 		"data": {
+			"duration": 91.474,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1275,
@@ -16297,6 +16378,7 @@
 		"altTitles": [],
 		"artist": "姫野湖鳥(CV 田村ゆかり)「弱虫ペダル」",
 		"data": {
+			"duration": 94.883,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1276,
@@ -16309,6 +16391,7 @@
 		"altTitles": [],
 		"artist": "SEX MACHINEGUNS [cover]",
 		"data": {
+			"duration": 121.668,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1277,
@@ -16321,6 +16404,7 @@
 		"altTitles": [],
 		"artist": "DECO*27",
 		"data": {
+			"duration": 118.351,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1278,
@@ -16333,6 +16417,7 @@
 		"altTitles": [],
 		"artist": "藍井エイル「キルラキル」 [アニメPV]",
 		"data": {
+			"duration": 90.714,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1279,
@@ -16345,6 +16430,7 @@
 		"altTitles": [],
 		"artist": "ネコネコカワイイ「ニンジャスレイヤー」",
 		"data": {
+			"duration": 111.325,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1280,
@@ -16357,6 +16443,7 @@
 		"altTitles": [],
 		"artist": "藤澤健至(Team-MAX)「ニンジャスレイヤー」",
 		"data": {
+			"duration": 115.592,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1281,
@@ -16367,6 +16454,7 @@
 		"altTitles": [],
 		"artist": "鈴木結愛(CV:西 明日香)/佐藤陽菜(CV:明坂聡美)/高橋 葵(CV:荻野可鈴)/田中心春(CV:大橋彩香)/「てさぐれ！部活もの」 [アニメPV]",
 		"data": {
+			"duration": 115.387,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1282,
@@ -16377,6 +16465,7 @@
 		"altTitles": [],
 		"artist": "きゃりーぱみゅぱみゅ [PV]",
 		"data": {
+			"duration": 112.583,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1283,
@@ -16389,6 +16478,7 @@
 		"altTitles": [],
 		"artist": "「gdgd妖精s」",
 		"data": {
+			"duration": 94.852,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1284,
@@ -16401,6 +16491,7 @@
 		"altTitles": [],
 		"artist": "GRANRODEO [PV]",
 		"data": {
+			"duration": 97.21,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1285,
@@ -16411,6 +16502,7 @@
 		"altTitles": [],
 		"artist": "GRANRODEO [PV]",
 		"data": {
+			"duration": 96.004,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1286,
@@ -16421,6 +16513,7 @@
 		"altTitles": [],
 		"artist": "BACK-ON [cover]",
 		"data": {
+			"duration": 93.491,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1287,
@@ -16433,6 +16526,7 @@
 		"altTitles": [],
 		"artist": "宮野真守 [PV]",
 		"data": {
+			"duration": 112.299,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1288,
@@ -16446,6 +16540,7 @@
 		"altTitles": [],
 		"artist": "宮野真守 [PV]",
 		"data": {
+			"duration": 106.449,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1289,
@@ -16458,6 +16553,7 @@
 		"altTitles": [],
 		"artist": "nobodyknows+ [cover]",
 		"data": {
+			"duration": 97.531,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1290,
@@ -16470,6 +16566,7 @@
 		"altTitles": [],
 		"artist": "ナノ feat.MY FIRST STORY",
 		"data": {
+			"duration": 90.313,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1291,
@@ -16480,6 +16577,7 @@
 		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
+			"duration": 148.416,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1292,
@@ -16490,6 +16588,7 @@
 		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
+			"duration": 135.843,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1293,
@@ -16500,6 +16599,7 @@
 		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
+			"duration": 141.658,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1294,
@@ -16510,6 +16610,7 @@
 		"altTitles": [],
 		"artist": "目黒 将司 Remixed by 山岡 晃",
 		"data": {
+			"duration": 143.368,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1295,
@@ -16520,6 +16621,7 @@
 		"altTitles": [],
 		"artist": "ピノキオピー",
 		"data": {
+			"duration": 148.875,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1296,
@@ -16532,6 +16634,7 @@
 		"altTitles": [],
 		"artist": "アルスマグナ",
 		"data": {
+			"duration": 101.587,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1297,
@@ -16544,6 +16647,7 @@
 		"altTitles": [],
 		"artist": "ハッカドール",
 		"data": {
+			"duration": 91.622,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1298,
@@ -16554,6 +16658,7 @@
 		"altTitles": [],
 		"artist": "キング・クリームソーダ「妖怪ウォッチ」",
 		"data": {
+			"duration": 89.546,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1299,
@@ -16566,6 +16671,7 @@
 		"altTitles": [],
 		"artist": "田村 ゆかり「のうりん」",
 		"data": {
+			"duration": 92.56,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1300,
@@ -16578,6 +16684,7 @@
 		"altTitles": [],
 		"artist": "土間うまる [CV.田中あいみ]「干物妹！うまるちゃん」",
 		"data": {
+			"duration": 93.264,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1301,
@@ -16590,6 +16697,7 @@
 		"altTitles": [],
 		"artist": "Wake Up, Girls！",
 		"data": {
+			"duration": 91.07,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1302,
@@ -16602,6 +16710,7 @@
 		"altTitles": [],
 		"artist": "SEKAI NO OWARI",
 		"data": {
+			"duration": 139.288,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1303,
@@ -16612,6 +16721,7 @@
 		"altTitles": [],
 		"artist": "でんぱ組.Inc",
 		"data": {
+			"duration": 87.662,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1304,
@@ -16624,6 +16734,7 @@
 		"altTitles": [],
 		"artist": "fripSide「フューチャーカード バディファイト ハンドレッド」",
 		"data": {
+			"duration": 93.215,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1305,
@@ -16636,6 +16747,7 @@
 		"altTitles": [],
 		"artist": "シンガンクリムゾンズ「SHOW BY ROCK!!」",
 		"data": {
+			"duration": 96,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1306,
@@ -16646,6 +16758,7 @@
 		"altTitles": [],
 		"artist": "プラズマジカ「SHOW BY ROCK!!」",
 		"data": {
+			"duration": 93.227,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1307,
@@ -16658,6 +16771,7 @@
 		"altTitles": [],
 		"artist": "Dream5「妖怪ウォッチ」",
 		"data": {
+			"duration": 88.866,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1308,
@@ -16670,6 +16784,7 @@
 		"altTitles": [],
 		"artist": "イタリア (CV.浪川大輔)「ヘタリア The World Twinkle」",
 		"data": {
+			"duration": 105.456,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1309,
@@ -16682,6 +16797,7 @@
 		"altTitles": [],
 		"artist": "アルスマグナ",
 		"data": {
+			"duration": 136.703,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1310,
@@ -16694,6 +16810,7 @@
 		"altTitles": [],
 		"artist": "Jitterin' Jinn [covered by ろん]",
 		"data": {
+			"duration": 129.044,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1311,
@@ -16706,6 +16823,7 @@
 		"altTitles": [],
 		"artist": "UNISON SQUARE GARDEN",
 		"data": {
+			"duration": 144.869,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1312,
@@ -16718,6 +16836,7 @@
 		"altTitles": [],
 		"artist": "Petit Rabbit's「ご注文はうさぎですか？」",
 		"data": {
+			"duration": 94.504,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1313,
@@ -16728,6 +16847,7 @@
 		"altTitles": [],
 		"artist": "Scatman John",
 		"data": {
+			"duration": 104.393,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1314,
@@ -16738,6 +16858,7 @@
 		"altTitles": [],
 		"artist": "アイドルカレッジ「俺がお嬢様学校に「庶民サンプル」としてゲッツされた件」",
 		"data": {
+			"duration": 94.725,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1315,
@@ -16750,6 +16871,7 @@
 		"altTitles": [],
 		"artist": "学園生活部「がっこうぐらし！」",
 		"data": {
+			"duration": 92.092,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1316,
@@ -16763,6 +16885,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり さん☆ハイ！」",
 		"data": {
+			"duration": 90.633,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1317,
@@ -16775,6 +16898,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 147.671,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1318,
@@ -16785,6 +16909,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり」",
 		"data": {
+			"duration": 91.373,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1319,
@@ -16797,6 +16922,7 @@
 		"altTitles": [],
 		"artist": "RADIO FISH",
 		"data": {
+			"duration": 104.359,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1320,
@@ -16807,6 +16933,7 @@
 		"altTitles": [],
 		"artist": "新庄かなえ(CV:三森すずこ)「てーきゅう」",
 		"data": {
+			"duration": 100.313,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1321,
@@ -16819,6 +16946,7 @@
 		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり♪♪」",
 		"data": {
+			"duration": 91.37,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1322,
@@ -16831,6 +16959,7 @@
 		"altTitles": [],
 		"artist": "セブンスシスターズ",
 		"data": {
+			"duration": 124.212,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1323,
@@ -16844,6 +16973,7 @@
 		"altTitles": [],
 		"artist": "777☆SISTERS",
 		"data": {
+			"duration": 120.007,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1324,
@@ -16856,6 +16986,7 @@
 		"altTitles": [],
 		"artist": "ORANGE RANGE",
 		"data": {
+			"duration": 138.446,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1325,
@@ -16868,6 +16999,7 @@
 		"altTitles": [],
 		"artist": "Rhodanthe*",
 		"data": {
+			"duration": 91.646,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1326,
@@ -16878,6 +17010,7 @@
 		"altTitles": [],
 		"artist": "Wake Up, Girls！",
 		"data": {
+			"duration": 90.667,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1327,
@@ -16888,6 +17021,7 @@
 		"altTitles": [],
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
+			"duration": 93.091,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1328,
@@ -16900,6 +17034,7 @@
 		"altTitles": [],
 		"artist": "讃州中学勇者部「結城友奈は勇者である」",
 		"data": {
+			"duration": 92.166,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1329,
@@ -16912,6 +17047,7 @@
 		"altTitles": [],
 		"artist": "てにをは",
 		"data": {
+			"duration": 136,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1330,
@@ -16924,6 +17060,7 @@
 		"altTitles": [],
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
+			"duration": 91.02,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1331,
@@ -16934,6 +17071,7 @@
 		"altTitles": [],
 		"artist": "Questy「ポッピンQ」",
 		"data": {
+			"duration": 96.479,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1332,
@@ -16946,6 +17084,7 @@
 		"altTitles": [],
 		"artist": "夢色キャスト",
 		"data": {
+			"duration": 120.488,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1333,
@@ -16956,6 +17095,7 @@
 		"altTitles": [],
 		"artist": "夢色キャスト",
 		"data": {
+			"duration": 118.286,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1334,
@@ -16966,6 +17106,7 @@
 		"altTitles": [],
 		"artist": "上坂すみれ",
 		"data": {
+			"duration": 135.887,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1335,
@@ -16978,6 +17119,7 @@
 		"altTitles": [],
 		"artist": "上坂すみれ「ポプテピピック」",
 		"data": {
+			"duration": 94.69,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1336,
@@ -16988,6 +17130,7 @@
 		"altTitles": [],
 		"artist": "土間うまる（田中あいみ）「干物妹！うまるちゃんR」",
 		"data": {
+			"duration": 92.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1337,
@@ -17000,6 +17143,7 @@
 		"altTitles": [],
 		"artist": "妹Ｓ「干物妹！うまるちゃんR」",
 		"data": {
+			"duration": 91.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1338,
@@ -17012,6 +17156,7 @@
 		"altTitles": [],
 		"artist": "angela「アホガール」",
 		"data": {
+			"duration": 137.57,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1339,
@@ -17024,6 +17169,7 @@
 		"altTitles": [],
 		"artist": "Otomania feat. 初音ミク",
 		"data": {
+			"duration": 148,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1340,
@@ -17034,6 +17180,7 @@
 		"altTitles": [],
 		"artist": "彩音",
 		"data": {
+			"duration": 118,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1341,
@@ -17044,6 +17191,7 @@
 		"altTitles": [],
 		"artist": "陰陽座",
 		"data": {
+			"duration": 145,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1342,
@@ -17056,6 +17204,7 @@
 		"altTitles": [],
 		"artist": "大橋彩香",
 		"data": {
+			"duration": 94.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1343,
@@ -17066,6 +17215,7 @@
 		"altTitles": [],
 		"artist": "リコ（CV：富田美憂）、レグ（CV：伊瀬茉莉也）",
 		"data": {
+			"duration": 91.5,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1344,
@@ -17076,6 +17226,7 @@
 		"altTitles": [],
 		"artist": "池頼広",
 		"data": {
+			"duration": 140,
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1345,
@@ -17088,6 +17239,7 @@
 		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
+			"duration": 146.5,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1346,
@@ -17100,6 +17252,7 @@
 		"altTitles": [],
 		"artist": "A-Lin",
 		"data": {
+			"duration": 125.063,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1347,
@@ -17112,6 +17265,7 @@
 		"altTitles": [],
 		"artist": "唐禹哲",
 		"data": {
+			"duration": 106.671,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1348,
@@ -17124,6 +17278,7 @@
 		"altTitles": [],
 		"artist": "信",
 		"data": {
+			"duration": 112.271,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1349,
@@ -17136,6 +17291,7 @@
 		"altTitles": [],
 		"artist": "Roomie",
 		"data": {
+			"duration": 141.465,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1350,
@@ -17146,6 +17302,7 @@
 		"altTitles": [],
 		"artist": "阿蘭",
 		"data": {
+			"duration": 111.336,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1351,
@@ -17158,6 +17315,7 @@
 		"altTitles": [],
 		"artist": "米津玄師",
 		"data": {
+			"duration": 162.645,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1352,
@@ -17168,6 +17326,7 @@
 		"altTitles": [],
 		"artist": "DA PUMP",
 		"data": {
+			"duration": 151.504,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1353,
@@ -17178,6 +17337,7 @@
 		"altTitles": [],
 		"artist": "サカナクション",
 		"data": {
+			"duration": 134.777,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1354,
@@ -17190,6 +17350,7 @@
 		"altTitles": [],
 		"artist": "OxT",
 		"data": {
+			"duration": 92.035,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1355,
@@ -17200,6 +17361,7 @@
 		"altTitles": [],
 		"artist": "どうぶつビスケッツ×PPP「けものフレンズ２」",
 		"data": {
+			"duration": 92.687,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1356,
@@ -17212,6 +17374,7 @@
 		"altTitles": [],
 		"artist": "どうぶつビスケッツ×PPP「けものフレンズ」",
 		"data": {
+			"duration": 94.225,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1357,
@@ -17224,6 +17387,7 @@
 		"altTitles": [],
 		"artist": "Eve",
 		"data": {
+			"duration": 148.954,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1358,
@@ -17236,6 +17400,7 @@
 		"altTitles": [],
 		"artist": "夏代孝明 feat. 初音ミク",
 		"data": {
+			"duration": 145.895,
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1359,
@@ -17248,6 +17413,7 @@
 		"altTitles": [],
 		"artist": "ポプ子(CV:五十嵐裕美)＆ピピ美(CV:松嵜麗)",
 		"data": {
+			"duration": 139.108,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1360,
@@ -17258,6 +17424,7 @@
 		"altTitles": [],
 		"artist": "OxT",
 		"data": {
+			"duration": 92.687,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1361,
@@ -17268,6 +17435,7 @@
 		"altTitles": [],
 		"artist": "Fear, and Loathing in Las Vegas",
 		"data": {
+			"duration": 92.75,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1362,
@@ -17278,6 +17446,7 @@
 		"altTitles": [],
 		"artist": "フランシュシュ",
 		"data": {
+			"duration": 92.327,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1363,
@@ -17290,6 +17459,7 @@
 		"altTitles": [],
 		"artist": "フランシュシュ",
 		"data": {
+			"duration": 136.639,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1364,
@@ -17302,6 +17472,7 @@
 		"altTitles": [],
 		"artist": "BLACK STARS（ブラック指令・ペガッサ星人・シルバーブルーメ・ノーバ）",
 		"data": {
+			"duration": 142.122,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1365,
@@ -17314,6 +17485,7 @@
 		"altTitles": [],
 		"artist": "アギラ・キングジョー・ガッツ星人（CV：飯田里穂・三森すずこ・松田利冴）",
 		"data": {
+			"duration": 103.151,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1366,
@@ -17324,6 +17496,7 @@
 		"altTitles": [],
 		"artist": "ンダホ&ぺけたん from Fischer's",
 		"data": {
+			"duration": 129.73,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1367,
@@ -17336,6 +17509,7 @@
 		"altTitles": [],
 		"artist": "fhána",
 		"data": {
+			"duration": 94.667,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1368,
@@ -17348,6 +17522,7 @@
 		"altTitles": [],
 		"artist": "鈴木雅之",
 		"data": {
+			"duration": 93.954,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1369,
@@ -17360,6 +17535,7 @@
 		"altTitles": [],
 		"artist": "アインズ(日野聡)、カズマ(福島潤)、スバル(小林裕介)、ターニャ(悠木碧)",
 		"data": {
+			"duration": 93.649,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1370,
@@ -17372,6 +17548,7 @@
 		"altTitles": [],
 		"artist": "オーイシマサヨシ",
 		"data": {
+			"duration": 93.066,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1371,
@@ -17384,6 +17561,7 @@
 		"altTitles": [],
 		"artist": "米津玄師",
 		"data": {
+			"duration": 88,
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1372,
@@ -18504,6 +18682,7 @@
 		"altTitles": [],
 		"artist": "Massive New Krew",
 		"data": {
+			"duration": 122.71,
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1462,

--- a/seeds/scripts/rerunners/maimaidx/merge-options.ts
+++ b/seeds/scripts/rerunners/maimaidx/merge-options.ts
@@ -180,11 +180,11 @@ for (const optionsDir of options.input) {
 
 				const cueName = cueFileName.replace(/\.awb$/u, "");
 				const cuePath = path.join(soundDataDir, cueFileName);
-				const stdout = execFileSync(options.vgmsBinary, ["-m", "-I", cuePath], {
-					encoding: "utf-8",
-				});
 
 				try {
+					const stdout = execFileSync(options.vgmsBinary, ["-m", "-I", cuePath], {
+						encoding: "utf-8",
+					});
 					const res = JSON.parse(stdout);
 
 					if (res.sampleRate !== 48000) {
@@ -199,7 +199,7 @@ for (const optionsDir of options.input) {
 
 					logger.info(`Cue file ${cueName} has duration ${duration} seconds.`);
 				} catch (e) {
-					logger.error(`Error parsing vgmstream-cli output: ${e} ${stdout}`);
+					logger.error(`Error parsing song duration: ${e}`);
 				}
 			}
 		}


### PR DESCRIPTION
Graph support for maimai DX's percent and life was added based on nairobi's work in #1214 #1284.

Only one graph data (either percent or life) needs to be submitted for graph to show up. This is because maimai DX life gauge is either a challenge or a track skip option that needs to be enabled explicitly.

~~The PR is feature-complete; currently in draft because I need to find duration data for removed songs.~~

![percent graph](https://github.com/user-attachments/assets/a3d4be52-9d15-45aa-a8a6-7b65a68818d8)
![life graph](https://github.com/user-attachments/assets/06a2ade4-9eab-4ac0-b2a0-4d118ae6c70d)



