### PR TITLE
feat: update sdvx seeds to 2025042202

### DIFF
--- a/seeds/collections/charts-sdvx.json
+++ b/seeds/collections/charts-sdvx.json
@@ -147865,7 +147865,8 @@
 		"playtype": "Single",
 		"songID": 2170,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -147880,7 +147881,8 @@
 		"playtype": "Single",
 		"songID": 2170,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -147900,7 +147902,8 @@
 		"playtype": "Single",
 		"songID": 2170,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -147915,7 +147918,8 @@
 		"playtype": "Single",
 		"songID": 2170,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -150104,7 +150108,8 @@
 		"playtype": "Single",
 		"songID": 2201,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -150124,7 +150129,8 @@
 		"playtype": "Single",
 		"songID": 2201,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -150144,7 +150150,8 @@
 		"playtype": "Single",
 		"songID": 2201,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -150159,7 +150166,8 @@
 		"playtype": "Single",
 		"songID": 2201,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157619,7 +157627,8 @@
 		"playtype": "Single",
 		"songID": 2308,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157634,7 +157643,8 @@
 		"playtype": "Single",
 		"songID": 2308,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157654,7 +157664,8 @@
 		"playtype": "Single",
 		"songID": 2308,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157669,7 +157680,8 @@
 		"playtype": "Single",
 		"songID": 2308,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157684,7 +157696,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157699,7 +157712,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157719,7 +157733,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157734,7 +157749,8 @@
 		"playtype": "Single",
 		"songID": 2309,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157749,7 +157765,8 @@
 		"playtype": "Single",
 		"songID": 2310,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157764,7 +157781,8 @@
 		"playtype": "Single",
 		"songID": 2310,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157784,7 +157802,8 @@
 		"playtype": "Single",
 		"songID": 2310,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157799,7 +157818,8 @@
 		"playtype": "Single",
 		"songID": 2310,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157814,7 +157834,8 @@
 		"playtype": "Single",
 		"songID": 2311,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157829,7 +157850,8 @@
 		"playtype": "Single",
 		"songID": 2311,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157849,7 +157871,8 @@
 		"playtype": "Single",
 		"songID": 2311,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157864,7 +157887,8 @@
 		"playtype": "Single",
 		"songID": 2311,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -157999,7 +158023,8 @@
 		"playtype": "Single",
 		"songID": 2314,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -158014,7 +158039,8 @@
 		"playtype": "Single",
 		"songID": 2314,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -158034,7 +158060,8 @@
 		"playtype": "Single",
 		"songID": 2314,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -158049,7 +158076,8 @@
 		"playtype": "Single",
 		"songID": 2314,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159490,7 +159518,8 @@
 		"playtype": "Single",
 		"songID": 2336,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159505,7 +159534,8 @@
 		"playtype": "Single",
 		"songID": 2336,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159525,7 +159555,8 @@
 		"playtype": "Single",
 		"songID": 2336,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159540,7 +159571,8 @@
 		"playtype": "Single",
 		"songID": 2336,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159555,7 +159587,8 @@
 		"playtype": "Single",
 		"songID": 2337,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159575,7 +159608,8 @@
 		"playtype": "Single",
 		"songID": 2337,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159595,7 +159629,8 @@
 		"playtype": "Single",
 		"songID": 2337,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159610,7 +159645,8 @@
 		"playtype": "Single",
 		"songID": 2337,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159625,7 +159661,8 @@
 		"playtype": "Single",
 		"songID": 2338,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159640,7 +159677,8 @@
 		"playtype": "Single",
 		"songID": 2338,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159660,7 +159698,8 @@
 		"playtype": "Single",
 		"songID": 2338,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159675,7 +159714,8 @@
 		"playtype": "Single",
 		"songID": 2338,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159690,7 +159730,8 @@
 		"playtype": "Single",
 		"songID": 2339,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159705,7 +159746,8 @@
 		"playtype": "Single",
 		"songID": 2339,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159725,7 +159767,8 @@
 		"playtype": "Single",
 		"songID": 2339,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159740,7 +159783,8 @@
 		"playtype": "Single",
 		"songID": 2339,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159755,7 +159799,8 @@
 		"playtype": "Single",
 		"songID": 2340,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159770,7 +159815,8 @@
 		"playtype": "Single",
 		"songID": 2340,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159790,7 +159836,8 @@
 		"playtype": "Single",
 		"songID": 2340,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
 		]
 	},
 	{
@@ -159805,7 +159852,968 @@
 		"playtype": "Single",
 		"songID": 2340,
 		"versions": [
-			"konaste"
+			"konaste",
+			"exceed"
+		]
+	},
+	{
+		"chartID": "c4a95e7c3363eaa7e143b1dc052998e8a9e44984",
+		"data": {
+			"inGameID": 2198
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"songID": 2341,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "40c19cce31873a6bc70ad81dc0180841ef60541f",
+		"data": {
+			"inGameID": 2198
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2341,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "7f42964d2495666cafe78d1f6d01dba576a170f5",
+		"data": {
+			"inGameID": 2198
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "20",
+		"levelNum": 20,
+		"playtype": "Single",
+		"songID": 2341,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "9ec79a9522d4a522db2cb7c2417acac3a9abdd1b",
+		"data": {
+			"inGameID": 2198
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"songID": 2341,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "6dfcd561019f9237e879ce5bf33f48c39becd5ce",
+		"data": {
+			"inGameID": 2199
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"songID": 2342,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d943935efe9a76678b6d122e59aa0efb37143af9",
+		"data": {
+			"inGameID": 2199
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2342,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "bdd733d673e03ff90878e52f997e3f839f88641e",
+		"data": {
+			"inGameID": 2199
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "20",
+		"levelNum": 20,
+		"playtype": "Single",
+		"songID": 2342,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "007f1d3536c642a1b8e8ecece1873e224383f1af",
+		"data": {
+			"inGameID": 2199
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"songID": 2342,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "22c1cb639c0a6401ac1ca0aa75b23a9a66bc03f7",
+		"data": {
+			"inGameID": 2200
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2343,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "28e2b16bb597c4de9a7b1286290baa0d48569041",
+		"data": {
+			"inGameID": 2200
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2343,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "0c8437fe55671a0584ec8c9d7be683dd95068c98",
+		"data": {
+			"inGameID": 2200
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2343,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "0cdaf0cc0c252a26d17990b7cde10a5339607517",
+		"data": {
+			"inGameID": 2200
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2343,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "47793608327a97ce5bd3f86120e74437f5177b3e",
+		"data": {
+			"inGameID": 2201
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2344,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "e0616f5a32250027d04384d4d5aece1250261b8b",
+		"data": {
+			"inGameID": 2201
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2344,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d282f60f9cbe1ee9500fb7a540142b1c1a05cf9e",
+		"data": {
+			"inGameID": 2201
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2344,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "a7d5baecdb632a6938cb305ee413beffaad1989c",
+		"data": {
+			"inGameID": 2201
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2344,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "f95844d794ec4e6f75dbe7864d4c10b602b3c509",
+		"data": {
+			"inGameID": 2202
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2345,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "af889f31e7653040d69badc0f7ae3acc557a4c99",
+		"data": {
+			"inGameID": 2202
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2345,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "4f0c79461502714efca6e8d2bc86d34b854964c2",
+		"data": {
+			"inGameID": 2202
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2345,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "788f531b9d5dc19a198d16dae4e934bd43f38202",
+		"data": {
+			"inGameID": 2202
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2345,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "6387708bdd5940bc06ce2ac5cadc1ae2fdc6265c",
+		"data": {
+			"inGameID": 2203
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2346,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "a90bebd2c5fbd060a7d34148f43f752f63e33dec",
+		"data": {
+			"inGameID": 2203
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2346,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "6083e5dad2f44565cee62b2bfab52f361e63cae5",
+		"data": {
+			"inGameID": 2203
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2346,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "8a65e1e773866f44169218fd65aad4c0c62d4f41",
+		"data": {
+			"inGameID": 2203
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2346,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "bf559aeaba6a3411739a940030b0831eb604897e",
+		"data": {
+			"inGameID": 2204
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2347,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "2d2003699a5a1b07c2ff32c77260b6a4b895e742",
+		"data": {
+			"inGameID": 2204
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2347,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "4e3778a0f0f17095771a5ec83ba7deeb7bf5e561",
+		"data": {
+			"inGameID": 2204
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2347,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "c18035eee7f6620346c089c7b37d7189c2a269c8",
+		"data": {
+			"inGameID": 2204
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2347,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "dc62b95586abb791b1d3d33be5b235926542158c",
+		"data": {
+			"inGameID": 2225
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2348,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "0aa6af238994dc2c6468efac094d3a967299a7b2",
+		"data": {
+			"inGameID": 2225
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2348,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "78a83202f5e851581d4ce9eb2f66f120e063650d",
+		"data": {
+			"inGameID": 2225
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2348,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d6a177afa1ee53747ed0f3aa4c8eabb30a2f4e97",
+		"data": {
+			"inGameID": 2225
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2348,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "1a333fe8f7b09e3c28d38d0c63bd3ede51521222",
+		"data": {
+			"inGameID": 2226
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2349,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "a146eae4893c04a2af062d3bc15ed71db5c993bd",
+		"data": {
+			"inGameID": 2226
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2349,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "42777e3ef784610625c95d681b2429d9e2c6e043",
+		"data": {
+			"inGameID": 2226
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2349,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "6429e2f03dd708479dc1c93ae6bc80f04d1540d2",
+		"data": {
+			"inGameID": 2226
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2349,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "c0e909ee0c6ec017bae5bdb2de9744f9878e66a2",
+		"data": {
+			"inGameID": 2227
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2350,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "fcbe96bfbd707b2b12f8ccdba6fb5298d982560d",
+		"data": {
+			"inGameID": 2227
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2350,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "e07f4a5ac8bc1415779a352bf070866a5b83f629",
+		"data": {
+			"inGameID": 2227
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2350,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d3e3986dac81290035d7dd6bbf1c8cfd1c89d927",
+		"data": {
+			"inGameID": 2227
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2350,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "c911ab64271040d8124b68773fe050f910a2ab2b",
+		"data": {
+			"inGameID": 2228
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"songID": 2351,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "913b0b3b818581b05932002384c53edbe3c03ac6",
+		"data": {
+			"inGameID": 2228
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "15",
+		"levelNum": 15,
+		"playtype": "Single",
+		"songID": 2351,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "858cd9d7cb6f462b0e0c16ed7b3ceab3f2383c25",
+		"data": {
+			"inGameID": 2228
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2351,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "6e8efc0429a8ee73b6b4005cbbf72033523cb79b",
+		"data": {
+			"inGameID": 2228
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"songID": 2351,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "48513167b78c41015b4ff6b5e71f38a46f7ec7c8",
+		"data": {
+			"inGameID": 2229
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2352,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "f6227c62e72a5490e0abf81e3e20425ce5fc5b1a",
+		"data": {
+			"inGameID": 2229
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2352,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d52d380c9211d105818aecd8ce3e27949b49db5f",
+		"data": {
+			"inGameID": 2229
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2352,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "ac3a32e33e06150cf8d6d176f6efa50995fdb3b5",
+		"data": {
+			"inGameID": 2229
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2352,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "118109a7b52ec70f77598416b8a4824530fd8e0f",
+		"data": {
+			"inGameID": 2230
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2353,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "24bfa45bc45d487693d408f428df2a96487f6167",
+		"data": {
+			"inGameID": 2230
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2353,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "8ea65994cd4bca2a09d6592c359edb3f5b6888a6",
+		"data": {
+			"inGameID": 2230
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2353,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "b1b3596f89f595cf33d14c64af3e83fd05aba5f2",
+		"data": {
+			"inGameID": 2230
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2353,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "8943913100837df9bc6b6c6f1d867e1e5f6e3765",
+		"data": {
+			"inGameID": 2231
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12,
+		"playtype": "Single",
+		"songID": 2354,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "9bea46d71be498133b7a2d25e22c9d1a4695086d",
+		"data": {
+			"inGameID": 2231
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2354,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "f545d8faa1f3ff1a6307b637e4b10c83c77ede3a",
+		"data": {
+			"inGameID": 2231
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2354,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "d2d66b99a1ddc9bf81a8f738f303ab5ce582ee9c",
+		"data": {
+			"inGameID": 2231
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"songID": 2354,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "4c716106191ddf9673ab0b1e14a9b2c545de77b9",
+		"data": {
+			"inGameID": 2232
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13,
+		"playtype": "Single",
+		"songID": 2355,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "280782461875cfadfa2e727a868982b514a2e922",
+		"data": {
+			"inGameID": 2232
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "16",
+		"levelNum": 16,
+		"playtype": "Single",
+		"songID": 2355,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "363d9f7354b5ad83e5fbc90658c9badedbe5d217",
+		"data": {
+			"inGameID": 2232
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "18",
+		"levelNum": 18,
+		"playtype": "Single",
+		"songID": 2355,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "8dbb68c7a182d9c53e956a038ce1a8c74d774556",
+		"data": {
+			"inGameID": 2232
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"songID": 2355,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "5b744c2cda866cbc448dd983bb0fc665ad401671",
+		"data": {
+			"inGameID": 2233
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"songID": 2356,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "25e41263d37396fc15ce153072f5f695f75ec07d",
+		"data": {
+			"inGameID": 2233
+		},
+		"difficulty": "EXH",
+		"isPrimary": true,
+		"level": "17",
+		"levelNum": 17,
+		"playtype": "Single",
+		"songID": 2356,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "75983238524738a7fb46e2e899d86e74f4905788",
+		"data": {
+			"inGameID": 2233
+		},
+		"difficulty": "MXM",
+		"isPrimary": true,
+		"level": "19",
+		"levelNum": 19,
+		"playtype": "Single",
+		"songID": 2356,
+		"versions": [
+			"exceed"
+		]
+	},
+	{
+		"chartID": "33b677d2f3160b7d0d8381dcdc54a6d8a88c828e",
+		"data": {
+			"inGameID": 2233
+		},
+		"difficulty": "NOV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"songID": 2356,
+		"versions": [
+			"exceed"
 		]
 	}
 ]

--- a/seeds/collections/songs-sdvx.json
+++ b/seeds/collections/songs-sdvx.json
@@ -25606,7 +25606,9 @@
 		"title": "星界のアルペジオ"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"疉<3rf10鑒"
+		],
 		"artist": "momocaca (月乃×Capchii)",
 		"data": {
 			"displayVersion": "exceed"
@@ -25615,6 +25617,6 @@
 		"searchTerms": [
 			"overflow_momocaca"
 		],
-		"title": "疉<3rf10鑒"
+		"title": "Ö<3rf10₩"
 	}
 ]

--- a/seeds/collections/songs-sdvx.json
+++ b/seeds/collections/songs-sdvx.json
@@ -25424,5 +25424,197 @@
 		"id": 2340,
 		"searchTerms": [],
 		"title": "Dynasty -dal segno-"
+	},
+	{
+		"altTitles": [],
+		"artist": "庭師+Aoi",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2341,
+		"searchTerms": [
+			"ourgardenisblue_niwashiaoi"
+		],
+		"title": "Our garden is blue."
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2342,
+		"searchTerms": [
+			"kannagi_blacky"
+		],
+		"title": "神凪"
+	},
+	{
+		"altTitles": [],
+		"artist": "xi",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2343,
+		"searchTerms": [
+			"goldenrotation_xi"
+		],
+		"title": "Golden Rotation"
+	},
+	{
+		"altTitles": [],
+		"artist": "打打だいず vs. siromaru",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2344,
+		"searchTerms": [
+			"titanomachia_dadadaizusiromaru"
+		],
+		"title": "Titanomachia"
+	},
+	{
+		"altTitles": [],
+		"artist": "kanone VS nora2r",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2345,
+		"searchTerms": [
+			"ardenok_kanonenora2r"
+		],
+		"title": "Ardenok"
+	},
+	{
+		"altTitles": [],
+		"artist": "technoplanet feat. Tamako Kinoshita",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2346,
+		"searchTerms": [
+			"jupiter_technoplanet"
+		],
+		"title": "Jupiter"
+	},
+	{
+		"altTitles": [],
+		"artist": "めと（Metomate）",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2347,
+		"searchTerms": [
+			"rutennisaku_meto"
+		],
+		"title": "流転に咲く魂の花"
+	},
+	{
+		"altTitles": [],
+		"artist": "ぺのれり",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2348,
+		"searchTerms": [
+			"waltzofdahlia_penoreri"
+		],
+		"title": "黒蝶のワルツ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ETIA.",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2349,
+		"searchTerms": [
+			"gryphone_etia"
+		],
+		"title": "Gryphone"
+	},
+	{
+		"altTitles": [],
+		"artist": "星野音楽工房",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2350,
+		"searchTerms": [
+			"whothenno_hoshinoongakukoubou"
+		],
+		"title": "Who then no 灯"
+	},
+	{
+		"altTitles": [],
+		"artist": "DECO黻27",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2351,
+		"searchTerms": [
+			"telepathy_deco27"
+		],
+		"title": "テレパシ"
+	},
+	{
+		"altTitles": [],
+		"artist": "TJ.hangneil",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2352,
+		"searchTerms": [
+			"kamui_tjhangneil"
+		],
+		"title": "神威"
+	},
+	{
+		"altTitles": [],
+		"artist": "Capchii feat. 初音ミク",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2353,
+		"searchTerms": [
+			"whatsuppop_capchii"
+		],
+		"title": "What's up? Pop!"
+	},
+	{
+		"altTitles": [],
+		"artist": "La prière",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2354,
+		"searchTerms": [
+			"crossfade_lapriere"
+		],
+		"title": "Crossfade"
+	},
+	{
+		"altTitles": [],
+		"artist": "yuichi NAGAO",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2355,
+		"searchTerms": [
+			"seikainoarp_yuichinagao"
+		],
+		"title": "星界のアルペジオ"
+	},
+	{
+		"altTitles": [],
+		"artist": "momocaca (月乃×Capchii)",
+		"data": {
+			"displayVersion": "exceed"
+		},
+		"id": 2356,
+		"searchTerms": [
+			"overflow_momocaca"
+		],
+		"title": "疉<3rf10鑒"
 	}
 ]

--- a/seeds/scripts/rerunners/sdvx/merge-mdb.ts
+++ b/seeds/scripts/rerunners/sdvx/merge-mdb.ts
@@ -161,6 +161,8 @@ const InsaneCharRebinds = {
 	鬥: "Ã",
 	鬆: "Ý",
 	瀑: "À",
+	疉: "Ö",
+	鑒: "₩",
 };
 
 // apply char rebinds


### PR DESCRIPTION
Added exceed difficulty to numerous existing konaste-only songs:

2 from older updates (schrodinger's cat + caldwell 99)
5 from #1277
5 from #1297

Added 16 new songs (and fixed title for Ö<3rf10₩):

1. 庭師+Aoi - Our garden is blue.
2. BlackY feat. Risa Yuzuki - 神凪
3. xi - Golden Rotation
4. 打打だいず vs. siromaru - Titanomachia
5. kanone VS nora2r - Ardenok
6. technoplanet feat. Tamako Kinoshita - Jupiter
7. めと（Metomate） - 流転に咲く魂の花
8. ぺのれり - 黒蝶のワルツ
9. ETIA. - Gryphone
10. 星野音楽工房 - Who then no 灯
11. DECO黻27 - テレパシ
12. TJ.hangneil - 神威
13. Capchii feat. 初音ミク - What's up? Pop!
14. La prière - Crossfade
15. yuichi NAGAO - 星界のアルペジオ
16. momocaca (月乃×Capchii) - Ö<3rf10₩
