### PR TITLE
fix: iidx lamp cell: check whether combobreak is nullish

### DIFF
--- a/client/src/components/tables/cells/IIDXLampCell.tsx
+++ b/client/src/components/tables/cells/IIDXLampCell.tsx
@@ -40,7 +40,7 @@ export default function IIDXLampCell({
 	let cbrkCount;
 	let cbrkText;
 
-	if (sc.scoreData.optional.comboBreak) {
+	if (IsNotNullish(sc.scoreData.optional.comboBreak)) {
 		cbrkCount = sc.scoreData.optional.comboBreak;
 	} else if (
 		IsNotNullish(sc.scoreData.judgements.pgreat) &&


### PR DESCRIPTION
Check for the existence of `scoreData.optional.comboBreak` rather than its value in `IIDXLampCell.tsx`