### PR TITLE
feat: always show score alg desc under profile alg desc

### DIFF
--- a/client/src/components/user/UGPTStatsOverview.tsx
+++ b/client/src/components/user/UGPTStatsOverview.tsx
@@ -51,16 +51,24 @@ export default function UGPTRatingsTable({ ugs }: { ugs: UserGameStats }) {
 								tooltipContent={
 									<div>
 										{gptConfig.profileRatingAlgs[k].description}
-										{k in gptConfig.scoreRatingAlgs && (
+										{(gptConfig.profileRatingAlgs[k].associatedScoreAlgs ?? [])
+											.length > 0 && (
 											<>
-												<Divider />(
-												{FormatGPTScoreRatingName(
-													ugs.game,
-													ugs.playtype,
-													k
-												)}
-												: {gptConfig.scoreRatingAlgs[k].description})
+												<Divider />
 											</>
+										)}
+										{gptConfig.profileRatingAlgs[k].associatedScoreAlgs?.map(
+											(alg) => (
+												<div>
+													(
+													{FormatGPTScoreRatingName(
+														ugs.game,
+														ugs.playtype,
+														alg
+													)}
+													: {gptConfig.scoreRatingAlgs[alg].description})
+												</div>
+											)
 										)}
 									</div>
 								}

--- a/common/src/config/game-support/arcaea.ts
+++ b/common/src/config/game-support/arcaea.ts
@@ -87,6 +87,7 @@ export const ARCAEA_TOUCH_CONF = {
 			description:
 				"The average of your best 30 potential values. This is different to in-game, as it does not take into account your recent scores in any way.",
 			formatter: ToDecimalPlaces(2),
+			associatedScoreAlgs: ["potential"],
 		},
 	},
 

--- a/common/src/config/game-support/bms.ts
+++ b/common/src/config/game-support/bms.ts
@@ -311,6 +311,7 @@ export const BMS_7K_CONF = {
 		sieglinde: {
 			description: "The average of your best 20 sieglinde ratings.",
 			formatter: FormatSieglindeBMS,
+			associatedScoreAlgs: ["sieglinde"],
 		},
 	},
 

--- a/common/src/config/game-support/chunithm.ts
+++ b/common/src/config/game-support/chunithm.ts
@@ -123,6 +123,7 @@ export const CHUNITHM_SINGLE_CONF = {
 		naiveRating: {
 			description: "The average of your best 50 ratings.",
 			formatter: ToDecimalPlaces(2),
+			associatedScoreAlgs: ["rating"],
 		},
 	},
 

--- a/common/src/config/game-support/ddr.ts
+++ b/common/src/config/game-support/ddr.ts
@@ -161,6 +161,7 @@ export const DDR_SP_CONF = {
 			description:
 				"Flare Skill as it's implemented in DDR World, taking 30 best flare points from 3 different categories: CLASSIC (DDR 1st～X3 vs 2ndMIX), WHITE (DDR(2013)～DDR A), GOLD (DDR A20～WORLD).",
 			formatter: FmtScoreNoCommas,
+			associatedScoreAlgs: ["flareSkill"],
 		},
 	},
 

--- a/common/src/config/game-support/gitadora.ts
+++ b/common/src/config/game-support/gitadora.ts
@@ -72,6 +72,7 @@ export const GITADORA_GITA_CONF = {
 		naiveSkill: {
 			description:
 				"Your best 50 skill levels added together, regardless of whether the chart is HOT or not.",
+			associatedScoreAlgs: ["skill"],
 		},
 	},
 

--- a/common/src/config/game-support/iidx.ts
+++ b/common/src/config/game-support/iidx.ts
@@ -171,8 +171,11 @@ export const IIDX_SP_CONF = {
 	},
 
 	profileRatingAlgs: {
-		ktLampRating: { description: `An average of your best 20 ktLampRatings.` },
-		BPI: { description: `An average of your best 20 BPIs.` },
+		ktLampRating: {
+			description: `An average of your best 20 ktLampRatings.`,
+			associatedScoreAlgs: ["ktLampRating"],
+		},
+		BPI: { description: `An average of your best 20 BPIs.`, associatedScoreAlgs: ["BPI"] },
 	},
 	sessionRatingAlgs: {
 		ktLampRating: { description: `An average of the best 10 ktLampRatings this session.` },

--- a/common/src/config/game-support/itg.ts
+++ b/common/src/config/game-support/itg.ts
@@ -112,10 +112,12 @@ export const ITG_STAMINA_CONF = {
 		highestBlock: {
 			description: "The highest block level this player has cleared.",
 			formatter: NoDecimalPlace,
+			associatedScoreAlgs: ["blockRating"],
 		},
 		fastest32: {
 			description: "The fastest BPM this user has streamed 32 unbroken measures at.",
 			formatter: NoDecimalPlace,
+			associatedScoreAlgs: ["fastest32"],
 		},
 	},
 

--- a/common/src/config/game-support/jubeat.ts
+++ b/common/src/config/game-support/jubeat.ts
@@ -79,10 +79,12 @@ export const JUBEAT_SINGLE_CONF = {
 		jubility: {
 			description:
 				"Your profile jubility. This takes your best 30 scores on PICK UP songs, and your best 30 elsewhere.",
+			associatedScoreAlgs: ["jubility"],
 		},
 		naiveJubility: {
 			description:
 				"A naive version of jubility which just adds together your best 60 scores.",
+			associatedScoreAlgs: ["jubility"],
 		},
 	},
 

--- a/common/src/config/game-support/maimai-dx.ts
+++ b/common/src/config/game-support/maimai-dx.ts
@@ -163,6 +163,7 @@ export const MAIMAI_DX_SINGLE_CONF = {
 		naiveRate: {
 			description: "A naive rating algorithm that just sums your 50 best scores.",
 			formatter: NoDecimalPlace,
+			associatedScoreAlgs: ["rate"],
 		},
 	},
 

--- a/common/src/config/game-support/maimai.ts
+++ b/common/src/config/game-support/maimai.ts
@@ -113,6 +113,7 @@ export const MAIMAI_SINGLE_CONF = {
 			description:
 				"An average of your 30 best ratings. This is different from the rating in-game, as that is song-based and takes into account recent scores.",
 			formatter: ToDecimalPlaces(2),
+			associatedScoreAlgs: ["rate"],
 		},
 	},
 

--- a/common/src/config/game-support/museca.ts
+++ b/common/src/config/game-support/museca.ts
@@ -71,6 +71,7 @@ export const MUSECA_SINGLE_CONF = {
 			description:
 				"The sum of your best 20 Curator Skills. This is identical to how it's calculated in-game.",
 			formatter: NoDecimalPlace,
+			associatedScoreAlgs: ["curatorSkill"],
 		},
 	},
 

--- a/common/src/config/game-support/ongeki.ts
+++ b/common/src/config/game-support/ongeki.ts
@@ -133,7 +133,7 @@ export const ONGEKI_SINGLE_CONF = {
 
 	scoreRatingAlgs: {
 		rating: {
-			description: "Technical Score-based Rating as it's implemented in bright MEMORY.",
+			description: "Technical Score-based rating as it's implemented in bright MEMORY.",
 			formatter: ToDecimalPlaces(2),
 		},
 		scoreRating: {
@@ -141,7 +141,7 @@ export const ONGEKI_SINGLE_CONF = {
 			formatter: ToDecimalPlaces(3),
 		},
 		starRating: {
-			description: "Platinum Star-based rating as it's implemented in Re:Fresh.",
+			description: "Platinum Stars-based rating as it's implemented in Re:Fresh.",
 			formatter: ToDecimalPlaces(3),
 		},
 	},

--- a/common/src/config/game-support/ongeki.ts
+++ b/common/src/config/game-support/ongeki.ts
@@ -133,18 +133,15 @@ export const ONGEKI_SINGLE_CONF = {
 
 	scoreRatingAlgs: {
 		rating: {
-			description:
-				"A rating value of this score, capping at +2.0 at SSS+. This is identical to the system used in bright MEMORY and earlier versions.",
+			description: "Technical Score-based Rating as it's implemented in bright MEMORY.",
 			formatter: ToDecimalPlaces(2),
 		},
 		scoreRating: {
-			description:
-				"A rating value of this score, capping at +2.7 at 1,010,000. This is identical to the system used in Re:Fresh.",
+			description: "Technical Score-based rating as it's implemented in Re:Fresh.",
 			formatter: ToDecimalPlaces(3),
 		},
 		starRating: {
-			description:
-				"A rating value of this score, based on stars derived from Platinum Score. This is identical to the system used in Re:Fresh.",
+			description: "Platinum Star-based rating as it's implemented in Re:Fresh.",
 			formatter: ToDecimalPlaces(3),
 		},
 	},
@@ -165,13 +162,15 @@ export const ONGEKI_SINGLE_CONF = {
 	profileRatingAlgs: {
 		naiveRating: {
 			description:
-				"The average of your best 45 classic ratings. This is a simpler variant of the rating algorithm used in bright MEMORY and earlier versions, without distinguishing between new and old charts, and without taking recent scores into account.",
+				"The average of your best 45 ClassicRatings. This is a simpler variant of the rating algorithm used in bright MEMORY and earlier versions, without distinguishing between new and old charts, and without taking recent scores into account.",
 			formatter: ToDecimalPlaces(2),
+			associatedScoreAlgs: ["rating"],
 		},
 		naiveRatingRefresh: {
 			description:
-				"A weighted sum of the average of your best 60 score ratings, and your best 50 star ratings. This is a simpler variant of the rating algorithm used in Re:Fresh, without distinguishing between new and old charts.",
+				"A weighted sum of the average of your best 60 ScoreRatings, and your best 50 StarRatings. This is a simpler variant of the rating algorithm used in Re:Fresh, without distinguishing between new and old charts.",
 			formatter: ToDecimalPlaces(3),
+			associatedScoreAlgs: ["scoreRating", "starRating"],
 		},
 	},
 

--- a/common/src/config/game-support/pms.ts
+++ b/common/src/config/game-support/pms.ts
@@ -111,6 +111,7 @@ export const PMS_CONTROLLER_CONF = {
 		sieglinde: {
 			description: "The average of your best 20 sieglinde ratings.",
 			formatter: FormatSieglindePMS,
+			associatedScoreAlgs: ["sieglinde"],
 		},
 	},
 

--- a/common/src/config/game-support/popn.ts
+++ b/common/src/config/game-support/popn.ts
@@ -105,6 +105,7 @@ export const POPN_9B_CONF = {
 		naiveClassPoints: {
 			description:
 				"A naive average of your best 20 scores. This is different to in game class points, as that is affected by recent scores, and not just your best scores.",
+			associatedScoreAlgs: ["classPoints"],
 		},
 	},
 

--- a/common/src/config/game-support/sdvx.ts
+++ b/common/src/config/game-support/sdvx.ts
@@ -145,6 +145,7 @@ export const SDVX_SINGLE_CONF = {
 		VF6: {
 			description: "Your best 50 VF6 values added together.",
 			formatter: ToDecimalPlaces(3),
+			associatedScoreAlgs: ["VF6"],
 		},
 	},
 

--- a/common/src/config/game-support/usc.ts
+++ b/common/src/config/game-support/usc.ts
@@ -74,6 +74,7 @@ export const USC_CONTROLLER_CONF = {
 		VF6: {
 			description: "Your best 50 VF6 values added together.",
 			formatter: ToDecimalPlaces(3),
+			associatedScoreAlgs: ["VF6"],
 		},
 	},
 

--- a/common/src/config/game-support/wacca.ts
+++ b/common/src/config/game-support/wacca.ts
@@ -97,6 +97,7 @@ export const WACCA_SINGLE_CONF = {
 	profileRatingAlgs: {
 		naiveRate: {
 			description: "A naive rating algorithm that just sums your 50 best scores.",
+			associatedScoreAlgs: ["rate"],
 		},
 	},
 	sessionRatingAlgs: {

--- a/common/src/types/game-config-utils.ts
+++ b/common/src/types/game-config-utils.ts
@@ -15,6 +15,14 @@ export interface RatingAlgorithmConfig {
 	formatter?: (value: number) => string;
 }
 
+export interface ProfileRatingAlgorithmConfig extends RatingAlgorithmConfig {
+	/**
+	 * Which score rating algorithms should be mentioned in the footnote
+	 * of this algorithm's description?
+	 */
+	associatedScoreAlgs: ReadonlyArray<string>;
+}
+
 export interface ClassInfo<ClassID extends string> {
 	display: string;
 	id: ClassID;

--- a/common/src/types/game-config.ts
+++ b/common/src/types/game-config.ts
@@ -4,6 +4,7 @@ import type { MatchTypes } from "./batch-manual";
 import type {
 	ExtractClassValues,
 	FixedDifficulties,
+	ProfileRatingAlgorithmConfig,
 	RatingAlgorithmConfig,
 } from "./game-config-utils";
 import type { INTERNAL_GAME_PT_CONFIG } from "./internals";
@@ -332,7 +333,7 @@ export interface SpecificGamePTConfig<GPT extends GPTString> {
 	 * server config. By defining them here, the typesystem will enforce that you
 	 * implement them elsewhere.
 	 */
-	profileRatingAlgs: Record<ProfileRatingAlgorithms[GPT], RatingAlgorithmConfig>;
+	profileRatingAlgs: Record<ProfileRatingAlgorithms[GPT], ProfileRatingAlgorithmConfig>;
 
 	/**
 	 * What classes may a profile have attached onto it for this GPT?

--- a/common/src/types/internals.ts
+++ b/common/src/types/internals.ts
@@ -1,5 +1,10 @@
 import type { MatchTypes } from "./batch-manual";
-import type { ClassConfig, DifficultyConfig, RatingAlgorithmConfig } from "./game-config-utils";
+import type {
+	ClassConfig,
+	DifficultyConfig,
+	ProfileRatingAlgorithmConfig,
+	RatingAlgorithmConfig,
+} from "./game-config-utils";
 import type { ConfScoreMetric } from "./metrics";
 import type { AnyZodObject } from "zod";
 
@@ -39,7 +44,7 @@ export type INTERNAL_GAME_PT_CONFIG = Readonly<{
 
 	scoreRatingAlgs: Record<string, RatingAlgorithmConfig>;
 	sessionRatingAlgs: Record<string, RatingAlgorithmConfig>;
-	profileRatingAlgs: Record<string, RatingAlgorithmConfig>;
+	profileRatingAlgs: Record<string, ProfileRatingAlgorithmConfig>;
 
 	defaultScoreRatingAlg: string;
 	defaultSessionRatingAlg: string;


### PR DESCRIPTION
In the live version, the score rating algorithm description only pops up if it's named exactly like the profile rating algorithm, which doesn't work with "Naive" algorithms.


Before:
<img width="333" height="402" alt="Screenshot_20250711_141810" src="https://github.com/user-attachments/assets/f65e6b1c-4f9f-4e24-8f99-602e01704c5a" />
<img width="333" height="402" alt="Screenshot_20250711_141724" src="https://github.com/user-attachments/assets/b30d1316-ca0e-4c3a-8246-b1aaf36f58ef" />

After:
<img width="333" height="402" alt="Screenshot_20250711_141753" src="https://github.com/user-attachments/assets/8a6d79b3-b196-462d-9cb6-42ed333dbcf3" />
<img width="333" height="402" alt="Screenshot_20250711_141713" src="https://github.com/user-attachments/assets/4e66b25b-dece-4942-a5e5-3c73b545762b" />
