### PR TITLE
fix(client): show table pager if dataset is larger than current page size

### DIFF
--- a/client/src/components/tables/components/TachiTable.tsx
+++ b/client/src/components/tables/components/TachiTable.tsx
@@ -211,7 +211,7 @@ export default function TachiTable<D>({
 					)}
 				</div>
 				<div className="col-lg-4 ms-auto d-flex justify-content-center justify-content-lg-end">
-					{dataset.length > 10 && !noBottomDisplayPager && (
+					{dataset.length > ztable.pageLen && !noBottomDisplayPager && (
 						<div className="btn-group">
 							<Button
 								variant="secondary"


### PR DESCRIPTION
Instead of showing the table pager when the dataset has more than a fixed 10 items, check the table page length. This fixes an edge case where the pager doesn't appear if `pageLen < dataset.length < 10`:

https://github.com/zkrising/Tachi/blob/633c946adcb2c1ff31ac540afead88c31b76e24d/client/src/components/sessions/SessionCard.tsx#L68

This has the side effect of *not* showing the pager if `10 < dataset.length < pageLen`, but I think that's an acceptable tradeoff since there would be only one page anyways.

<img width="1427" height="717" alt="before change" src="https://github.com/user-attachments/assets/91b8272f-dfd9-4092-bc5c-f90977b00190" />

<img width="1425" height="697" alt="after change" src="https://github.com/user-attachments/assets/4c6af4b0-d0e5-401b-b05a-052355e3a41c" />
