### PR TITLE
fix: correct locale entry for locale-gen

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN apt install -y git npm locales sudo
 
 # setup locales
 # https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container
-RUN echo 'en_US.UTF-8' > /etc/locale.gen && locale-gen
+RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
this should be `language[_territory][.codeset] codeset` according to https://wiki.archlinux.org/title/Locale