### PR TITLE
fix(client): mistake in the previous fix

### DIFF
--- a/client/src/components/charts/GekichumaiScoreChart.tsx
+++ b/client/src/components/charts/GekichumaiScoreChart.tsx
@@ -211,7 +211,7 @@ export default function GekichumaiScoreChart({
 
 	const gradientId = type === "Score" ? difficulty : type;
 
-	data[0].data.length = Math.min(data[0].data.length, duration + 1);
+	data[0].data.length = Math.min(data[0].data.length, Math.ceil(duration));
 
 	const commonProps: Omit<LineSvgProps, "data"> = {
 		margin: { top: 30, bottom: 50, left: 50, right: 50 },


### PR DESCRIPTION
My bad, I didn't account for non-integer song duration and it ended up throwing `invalid array length` in some cases.