### PR TITLE
fix(client): shorten maimai DX difficulties, display percent as 4dp

### DIFF
--- a/client/src/components/tables/cells/DifficultyCell.tsx
+++ b/client/src/components/tables/cells/DifficultyCell.tsx
@@ -53,8 +53,9 @@ export default function DifficultyCell({
 
 	const gptImpl = GPT_CLIENT_IMPLEMENTATIONS[GetGPTString(game, chart.playtype)];
 
-	if (game === "iidx") {
+	if (game === "iidx" || game === "maimaidx") {
 		// IIDX stuff should always be in the form SPA/SPL to save space.
+		// For the same reason, maimai DX stuff should be using (DX) EXP/MAS/Re:MAS.
 		// All players know what this means.
 		// eslint-disable-next-line no-param-reassign
 		alwaysShort = true;

--- a/client/src/components/tables/cells/ScoreCell.tsx
+++ b/client/src/components/tables/cells/ScoreCell.tsx
@@ -8,10 +8,12 @@ export default function ScoreCell({
 	colour,
 	grade,
 	percent,
+	percentDp = 4,
 	scoreRenderFn,
 }: {
 	score?: integer;
 	percent: number;
+	percentDp?: integer;
 	grade: string;
 	colour: string;
 	showScore?: boolean;
@@ -25,7 +27,7 @@ export default function ScoreCell({
 		>
 			<strong>{grade}</strong>
 			<br />
-			{`${ToFixedFloor(percent, 2)}%`}
+			{`${ToFixedFloor(percent, percentDp)}%`}
 			{score !== undefined && (
 				<>
 					<br />

--- a/client/src/components/tables/cells/ScoreCell.tsx
+++ b/client/src/components/tables/cells/ScoreCell.tsx
@@ -8,7 +8,7 @@ export default function ScoreCell({
 	colour,
 	grade,
 	percent,
-	percentDp = 4,
+	percentDp = 2,
 	scoreRenderFn,
 }: {
 	score?: integer;

--- a/client/src/lib/game-implementations.tsx
+++ b/client/src/lib/game-implementations.tsx
@@ -466,6 +466,7 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 					colour={GetEnumColour(sc, "grade")}
 					grade={sc.scoreData.grade}
 					percent={sc.scoreData.percent}
+					percentDp={4}
 				/>
 				<MaimaiDXJudgementCell score={sc} />
 				<LampCell lamp={sc.scoreData.lamp} colour={GetEnumColour(sc, "lamp")} />


### PR DESCRIPTION
- maimai DX uses 4dp percentages (e.g. 100.5000%), and they're all shown to the player in-game. Most scores on Tachi are already submitted with 4dp percentages, so this merely exposes it to the user instead of having the client truncate it.
- The game has long difficulty names (`DX Master`, `DX Re:Master`) which makes the level go down a line in some cases, which does not look nice. Instead, always use the short form.

| <img width="697" height="184" alt="image" src="https://github.com/user-attachments/assets/1b143d77-2182-449a-884f-f63deb57d827" /> | <img width="778" height="173" alt="image" src="https://github.com/user-attachments/assets/0a07b33b-1627-4c52-bd7d-37381aa57a4e" /> | 
|---|---|
