### PR TITLE
fix: correct i-ii SPA WR, add KAVG<WR test

### DIFF
--- a/seeds/scripts/test/custom.test.ts
+++ b/seeds/scripts/test/custom.test.ts
@@ -25,9 +25,13 @@ const CHART_CHECKS: { [G in Game]?: Array<Test<ChartDocument<GPTStrings[G]>>> } 
 		test("Level and LevelNum should align", (c) =>
 			(c.level === "?" && c.levelNum === 0) || c.level === c.levelNum.toString()),
 		test("Worldrecord should not exceed MAX", (c) =>
-			(c.data.worldRecord === null || c.data.worldRecord <= c.data.notecount*2)),
+			c.data.worldRecord === null || c.data.worldRecord <= c.data.notecount * 2),
 		test("KaidenAvg should not exceed MAX", (c) =>
-			(c.data.kaidenAverage === null || c.data.kaidenAverage <= c.data.notecount*2))
+			c.data.kaidenAverage === null || c.data.kaidenAverage <= c.data.notecount * 2),
+		test("KaidenAvg should not exceed WR", (c) =>
+			c.data.kaidenAverage === null ||
+			c.data.worldRecord === null ||
+			c.data.kaidenAverage < c.data.worldRecord),
 	],
 	chunithm: [
 		test("Level should not be 0", (c) => c.level !== "0"),


### PR DESCRIPTION
This fixes the world record data for i-ii SPA, and adds a seeds test to ensure KaidenAverage < WorldRecord.  Additionally, some minor prettier/linter fixes to the tests added in #1330.