### PR TITLE
Gekichumai search tags update

### DIFF
--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -14303,7 +14303,7 @@
 			"Spiderweb",
 			"Spider's Web",
 			"spider's thread",
-            "kumono no ito"
+            "kumo no ito"
 		],
 		"title": "蜘蛛の糸"
 	},

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -144,7 +144,7 @@
 		},
 		"id": 18,
 		"searchTerms": [
-			"Senbon Zakura",
+			"Senbonzakura",
 			"Thousands of Cherry Trees",
 			"Thousand Cherry Blossoms"
 		],
@@ -447,7 +447,8 @@
 		},
 		"id": 49,
 		"searchTerms": [
-			"Epikouros no niji wa mou mienai"
+			"Epikouros no niji wa mou mienai",
+            "epicurus"
 		],
 		"title": "エピクロスの虹はもう見えない"
 	},
@@ -763,7 +764,8 @@
 		"id": 74,
 		"searchTerms": [
 			"Lilithia",
-			"lilysia"
+			"lilysia",
+            "lylysia"
 		],
 		"title": "リリーシア"
 	},
@@ -1307,8 +1309,7 @@
 		},
 		"id": 116,
 		"searchTerms": [
-			"kimi no shiranai monogatari",
-			"the story you don't know"
+			"kimi no shiranai monogatari"
 		],
 		"title": "君の知らない物語"
 	},
@@ -1363,7 +1364,8 @@
 		},
 		"id": 120,
 		"searchTerms": [
-			"Four-Dimensional Warp Device"
+			"Four-Dimensional Warp Device",
+            "yojigen chouyaku kikan"
 		],
 		"title": "四次元跳躍機関"
 	},
@@ -1647,7 +1649,9 @@
 			"genre": "niconico"
 		},
 		"id": 143,
-		"searchTerms": [],
+		"searchTerms": [
+            "odds and ends"
+        ],
 		"title": "ODDS&ENDS"
 	},
 	{
@@ -1873,7 +1877,8 @@
 		"searchTerms": [
 			"long song",
 			"long",
-			"A consideration of the fantastic world view in me and the events in a certain reality that reminded me of its manifestation"
+			"A consideration of the fantastic world view in me and the events in a certain reality that reminded me of its manifestation",
+            "watashi no naka no"
 		],
 		"title": "私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察"
 	},
@@ -2310,7 +2315,8 @@
 		},
 		"id": 199,
 		"searchTerms": [
-			"heart・beat"
+			"heart・beat",
+            "heart beat"
 		],
 		"title": "ハート・ビート"
 	},
@@ -2742,7 +2748,8 @@
 		},
 		"id": 231,
 		"searchTerms": [
-			"colorful"
+			"colorful",
+            "colourful"
 		],
 		"title": "カラフル。"
 	},
@@ -3363,7 +3370,8 @@
 		"id": 281,
 		"searchTerms": [
 			"Graffitist",
-			"Luckgakist"
+			"Luckgakist",
+            "luckghakist"
 		],
 		"title": "ラクガキスト"
 	},
@@ -3639,7 +3647,8 @@
 		},
 		"id": 301,
 		"searchTerms": [
-			"The Snow White Princess is"
+			"The Snow White Princess is",
+            "shiroiyuki"
 		],
 		"title": "白い雪のプリンセスは"
 	},
@@ -3694,7 +3703,7 @@
 		"id": 305,
 		"searchTerms": [
 			"gensounosateraito",
-			"Gensou no Satelite",
+			"Gensou no Satellite",
 			"Satelite",
 			"Gensou"
 		],
@@ -3786,7 +3795,9 @@
 		},
 		"id": 312,
 		"searchTerms": [
-			"buiesu!! raibaru!!"
+			"buiesu!! raibaru!!",
+            "VS Rival",
+            "versus"
 		],
 		"title": "ぶいえす!!らいばる!!"
 	},
@@ -4256,7 +4267,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 350,
-		"searchTerms": [],
+		"searchTerms": [
+            "feel alive"
+        ],
 		"title": "FEEL×ALIVE"
 	},
 	{
@@ -4282,7 +4295,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 352,
-		"searchTerms": [],
+		"searchTerms": [
+            "star glitter"
+        ],
 		"title": "Star☆Glitter"
 	},
 	{
@@ -4825,7 +4840,7 @@
 		},
 		"id": 398,
 		"searchTerms": [
-			"tengokutojigokukotonoharinne"
+			"tengoku to jigokuko tonoharinne"
 		],
 		"title": "天国と地獄 -言ノ葉リンネ-"
 	},
@@ -5055,7 +5070,8 @@
 		"id": 421,
 		"searchTerms": [
 			"Zenzenzense",
-			"Your Name"
+			"Your Name",
+            "zen zen zense"
 		],
 		"title": "前前前世"
 	},
@@ -5172,7 +5188,8 @@
 		"id": 432,
 		"searchTerms": [
 			"Ray Tuning",
-			"Rays Tuning"
+			"Rays Tuning",
+            "kousen tuning"
 		],
 		"title": "光線チューニング"
 	},
@@ -5434,7 +5451,8 @@
 		},
 		"id": 456,
 		"searchTerms": [
-			"KERO⑨destiny"
+			"KERO⑨destiny",
+            "kero destiny"
 		],
 		"title": "ケロ⑨destiny"
 	},
@@ -6309,7 +6327,8 @@
 		},
 		"id": 533,
 		"searchTerms": [
-			"OWARINAKIMONOGATARI"
+			"OWARINAKIMONOGATARI",
+            "owari naki monogatari"
 		],
 		"title": "終わりなき物語"
 	},
@@ -6485,7 +6504,7 @@
 		},
 		"id": 549,
 		"searchTerms": [
-			"Iro Ha Nioedo Chirinuruwo"
+			"Iro wa Nioedo Chirinuruwo"
 		],
 		"title": "色は匂へど散りぬるを"
 	},
@@ -6567,7 +6586,8 @@
 		},
 		"id": 555,
 		"searchTerms": [
-			"Kire Kyari On"
+			"Kire Kyari On",
+            "kill carry on"
 		],
 		"title": "キレキャリオン"
 	},
@@ -6798,7 +6818,8 @@
 		},
 		"id": 574,
 		"searchTerms": [
-			"NE!KO!"
+			"NE!KO!",
+            "neko"
 		],
 		"title": "ネ！コ！"
 	},
@@ -7717,7 +7738,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 652,
-		"searchTerms": [],
+		"searchTerms": [
+            "LLL"
+        ],
 		"title": "L.L.L."
 	},
 	{
@@ -8411,7 +8434,7 @@
 		},
 		"id": 707,
 		"searchTerms": [
-			"Tyagaku Ninennsei no Android",
+			"Chuugaku Ninennsei no Android",
 			"Chuni Android"
 		],
 		"title": "中学2年生のアンドロイド"
@@ -8617,7 +8640,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 727,
-		"searchTerms": [],
+		"searchTerms": [
+            "USA"
+        ],
 		"title": "U.S.A."
 	},
 	{
@@ -8970,7 +8995,8 @@
 		},
 		"id": 754,
 		"searchTerms": [
-			"Divertimento"
+			"Divertimento",
+            "issei ureshi"
 		],
 		"title": "一世嬉遊曲‐ディヴェルティメント‐"
 	},
@@ -10094,7 +10120,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 845,
-		"searchTerms": [],
+		"searchTerms": [
+            "mew mew cake"
+        ],
 		"title": "▲MEW▲△MEW△CAKE"
 	},
 	{
@@ -11859,7 +11887,8 @@
 		},
 		"id": 980,
 		"searchTerms": [
-			"RetaiSparkEx"
+			"RetaiSparkEx",
+            "reitai spark ex"
 		],
 		"title": "レータイスパークEx"
 	},
@@ -11873,7 +11902,8 @@
 		},
 		"id": 981,
 		"searchTerms": [
-			"shoakuma no yuenchi"
+			"shoakuma no yuenchi",
+            "koakuma"
 		],
 		"title": "小悪魔の遊園地"
 	},
@@ -11901,7 +11931,8 @@
 		},
 		"id": 983,
 		"searchTerms": [
-			"Hated By Life Itself"
+			"Hated By Life Itself",
+            "inori ni kirawareteiru"
 		],
 		"title": "命に嫌われている"
 	},
@@ -12390,7 +12421,8 @@
 		},
 		"id": 1022,
 		"searchTerms": [
-			"Shirayuki"
+			"Shirayuki",
+            "snow white"
 		],
 		"title": "白ゆき"
 	},
@@ -12937,7 +12969,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 1066,
-		"searchTerms": [],
+		"searchTerms": [
+            "blazing storm"
+        ],
 		"title": "Blazing:Storm"
 	},
 	{
@@ -13588,7 +13622,8 @@
 		"searchTerms": [
 			"A Cruel Angel's Thesis",
 			"Cruel Angel's Thesis",
-			"Evangelion"
+			"Evangelion",
+            "zankoku na tenshi"
 		],
 		"title": "残酷な天使のテーゼ"
 	},
@@ -13788,7 +13823,8 @@
 		"id": 2024,
 		"searchTerms": [
 			"Skeleton Orchestra",
-			"Skeleton Orchestra and Lilia"
+			"Skeleton Orchestra and Lilia",
+            "gaikotsu gakudan"
 		],
 		"title": "骸骨楽団とリリア"
 	},
@@ -13802,7 +13838,8 @@
 		},
 		"id": 2025,
 		"searchTerms": [
-			"Failure Girl"
+			"Failure Girl",
+            "shippai saku shoujou"
 		],
 		"title": "失敗作少女"
 	},
@@ -13831,7 +13868,8 @@
 		},
 		"id": 2027,
 		"searchTerms": [
-			"Little Cry of the Abyss"
+			"Little Cry of the Abyss",
+            "shinkai no little cry"
 		],
 		"title": "深海のリトルクライ feat. 土岐麻子"
 	},
@@ -14101,7 +14139,8 @@
 		},
 		"id": 2047,
 		"searchTerms": [
-			"Hope for the Flowers"
+			"Hope for the Flowers",
+            "hanatachi ni kibou wo"
 		],
 		"title": "花たちに希望を"
 	},
@@ -14263,7 +14302,8 @@
 		"searchTerms": [
 			"Spiderweb",
 			"Spider's Web",
-			"spider's thread"
+			"spider's thread",
+            "kumono no ito"
 		],
 		"title": "蜘蛛の糸"
 	},
@@ -14629,7 +14669,8 @@
 		},
 		"id": 2087,
 		"searchTerms": [
-			"Eastern Cross"
+			"Eastern Cross",
+            "kamigami ga koishita gensoukyou"
 		],
 		"title": "神々が恋した幻想郷"
 	},
@@ -14656,7 +14697,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2089,
-		"searchTerms": [],
+		"searchTerms": [
+            "love and justice"
+        ],
 		"title": "Love & Justice"
 	},
 	{
@@ -14797,7 +14840,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2100,
-		"searchTerms": [],
+		"searchTerms": [
+            "realise"
+        ],
 		"title": "Realize"
 	},
 	{
@@ -15017,7 +15062,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2118,
-		"searchTerms": [],
+		"searchTerms": [
+            "squand phantom"
+        ],
 		"title": "SQUAD-Phvntom-"
 	},
 	{
@@ -15484,7 +15531,8 @@
 		},
 		"id": 2152,
 		"searchTerms": [
-			"Imperial Girl"
+			"Imperial Girl",
+            "teikoku shoujou"
 		],
 		"title": "帝国少女"
 	},
@@ -15750,7 +15798,8 @@
 		},
 		"id": 2173,
 		"searchTerms": [
-			"Monster"
+			"Monster",
+            "kaibutsu"
 		],
 		"title": "怪物"
 	},
@@ -15778,7 +15827,7 @@
 		},
 		"id": 2175,
 		"searchTerms": [
-			"Sʼil vous President"
+			"S'il vous President"
 		],
 		"title": "シル・ヴ・プレジデント"
 	},
@@ -16030,7 +16079,8 @@
 		"searchTerms": [
 			"molmol",
 			"morumoru",
-			"Modoru Modoru"
+			"Modoru Modoru",
+            "poruporu"
 		],
 		"title": "モ°ルモ°ル"
 	},
@@ -16426,7 +16476,8 @@
 		},
 		"id": 2222,
 		"searchTerms": [
-			"3-bai! sun shine! carnival!"
+			"3-bai! sun shine! carnival!",
+            "sanbai"
 		],
 		"title": "3倍！Sun Shine！カーニバル！"
 	},
@@ -16548,7 +16599,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2231,
-		"searchTerms": [],
+		"searchTerms": [
+            "we are back"
+        ],
 		"title": "WE'RE BACK!!"
 	},
 	{
@@ -16738,6 +16791,7 @@
 		},
 		"id": 2245,
 		"searchTerms": [
+            "koi kou enshi",
 			"koi hi koi fu en"
 		],
 		"title": "恋ひ恋ふ縁"
@@ -16831,7 +16885,9 @@
 			"genre": "POPS & ANIME"
 		},
 		"id": 2252,
-		"searchTerms": [],
+		"searchTerms": [
+            "black flag breaker"
+        ],
 		"title": "BlackFlagBreaker!!"
 	},
 	{
@@ -16980,7 +17036,8 @@
 		},
 		"id": 2264,
 		"searchTerms": [
-			"TONDEMO-WONDERZ"
+			"TONDEMO-WONDERZ",
+            "tondemo wonders"
 		],
 		"title": "トンデモワンダーズ"
 	},
@@ -17516,7 +17573,8 @@
 		},
 		"id": 2306,
 		"searchTerms": [
-			"Marshall Maximizer"
+			"Marshall Maximizer",
+            "maximiser"
 		],
 		"title": "マーシャル・マキシマイザー"
 	},
@@ -18140,7 +18198,8 @@
 		},
 		"id": 2354,
 		"searchTerms": [
-			"clair de lune"
+			"clair de lune",
+            "tsuki no hikari"
 		],
 		"title": "月の光"
 	},
@@ -18181,7 +18240,8 @@
 		},
 		"id": 2358,
 		"searchTerms": [
-			"4-tsuki 1-nichi degozaimashita"
+			"shigatsu tsuitachi degozaimashita",
+            "april 1st"
 		],
 		"title": "4月1日でございました"
 	},
@@ -18837,7 +18897,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2416,
-		"searchTerms": [],
+		"searchTerms": [
+            "snow coloured score"
+        ],
 		"title": "Snow Colored Score"
 	},
 	{
@@ -18997,7 +19059,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2430,
-		"searchTerms": [],
+		"searchTerms": [
+            "relove relive"
+        ],
 		"title": "REL0VE REL1VE"
 	},
 	{
@@ -19165,7 +19229,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2442,
-		"searchTerms": [],
+		"searchTerms": [
+            "blanoir"
+        ],
 		"title": "βlαnoir"
 	},
 	{
@@ -19461,7 +19527,9 @@
 			"genre": "イロドリミドリ"
 		},
 		"id": 2466,
-		"searchTerms": [],
+		"searchTerms": [
+            "alteration"
+        ],
 		"title": "Λlteration"
 	},
 	{
@@ -20259,7 +20327,10 @@
 			"genre": "VARIETY"
 		},
 		"id": 2533,
-		"searchTerms": [],
+		"searchTerms": [
+            "odd parts",
+            "ooparts"
+        ],
 		"title": "ΩΩPARTS"
 	},
 	{
@@ -20561,7 +20632,8 @@
 		},
 		"id": 2560,
 		"searchTerms": [
-			"April showers"
+			"April showers",
+            "shigatsu no ame"
 		],
 		"title": "四月の雨"
 	},
@@ -20675,7 +20747,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2569,
-		"searchTerms": [],
+		"searchTerms": [
+            "colourful"
+        ],
 		"title": "colorful"
 	},
 	{
@@ -21177,7 +21251,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2612,
-		"searchTerms": [],
+		"searchTerms": [
+            "dreaming"
+        ],
 		"title": "DRE4M1N9"
 	},
 	{
@@ -21226,7 +21302,7 @@
 		},
 		"id": 2616,
 		"searchTerms": [
-			"befor the dawn",
+			"before the dawn",
 			"reimei ni janzu"
 		],
 		"title": "黎命に殉ず"
@@ -21860,7 +21936,9 @@
 			"genre": "ゲキマイ"
 		},
 		"id": 2680,
-		"searchTerms": [],
+		"searchTerms": [
+            "nagareboshi rocket"
+        ],
 		"title": "NAGAREBOSHI☆ROCKET"
 	},
 	{
@@ -21955,7 +22033,8 @@
 		},
 		"id": 2689,
 		"searchTerms": [
-			"mesmerizer"
+			"mesmerizer",
+            "mesmeriser"
 		],
 		"title": "メズマライザー"
 	},
@@ -22208,7 +22287,9 @@
 			"genre": "ORIGINAL"
 		},
 		"id": 2709,
-		"searchTerms": [],
+		"searchTerms": [
+            "crystallise"
+        ],
 		"title": "Crystallize"
 	},
 	{
@@ -22659,7 +22740,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 2750,
-		"searchTerms": [],
+		"searchTerms": [
+            "infinite energy overdose"
+        ],
 		"title": "INFiNiTE ENERZY -Overdoze-"
 	},
 	{

--- a/seeds/collections/songs-chunithm.json
+++ b/seeds/collections/songs-chunithm.json
@@ -144,6 +144,7 @@
 		},
 		"id": 18,
 		"searchTerms": [
+			"senbon zakura",
 			"Senbonzakura",
 			"Thousands of Cherry Trees",
 			"Thousand Cherry Blossoms"
@@ -1309,6 +1310,7 @@
 		},
 		"id": 116,
 		"searchTerms": [
+			"the story you don't know",
 			"kimi no shiranai monogatari"
 		],
 		"title": "君の知らない物語"
@@ -15063,7 +15065,7 @@
 		},
 		"id": 2118,
 		"searchTerms": [
-            "squand phantom"
+            "squad phantom"
         ],
 		"title": "SQUAD-Phvntom-"
 	},
@@ -15827,7 +15829,8 @@
 		},
 		"id": 2175,
 		"searchTerms": [
-			"S'il vous President"
+			"S'il vous President",
+			"Sʼil"
 		],
 		"title": "シル・ヴ・プレジデント"
 	},

--- a/seeds/collections/songs-maimaidx.json
+++ b/seeds/collections/songs-maimaidx.json
@@ -320,7 +320,10 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 26,
-		"searchTerms": [],
+		"searchTerms": [
+            "zig zag",
+            "zigg zagg"
+        ],
 		"title": "ZIGG-ZAGG"
 	},
 	{
@@ -758,7 +761,8 @@
 		},
 		"id": 59,
 		"searchTerms": [
-			"HOMURA-UTA"
+			"HOMURA-UTA",
+            "homura uta"
 		],
 		"title": "炎歌 -ほむらうた-"
 	},
@@ -1467,7 +1471,8 @@
 		},
 		"id": 115,
 		"searchTerms": [
-			"KAMURO-SETSUGEKKA"
+			"KAMURO-SETSUGEKKA",
+            "kamura setsugekka"
 		],
 		"title": "神室雪月花"
 	},
@@ -11783,7 +11788,7 @@
 		"id": 907,
 		"searchTerms": [
 			"Eastern Cross",
-			"kamigami ga koishita gensou gou"
+			"kamigami ga koishita gensoukyou"
 		],
 		"title": "神々が恋した幻想郷"
 	},
@@ -12868,7 +12873,8 @@
 		},
 		"id": 990,
 		"searchTerms": [
-			"Infinity"
+			"Infinity",
+            "x"
 		],
 		"title": "[X]"
 	},
@@ -12922,7 +12928,7 @@
 			"Spiderweb",
 			"Spider's Web",
 			"spider's thread",
-			"kumono no ito"
+			"kumo no ito"
 		],
 		"title": "蜘蛛の糸"
 	},
@@ -13218,7 +13224,8 @@
 		},
 		"id": 1017,
 		"searchTerms": [
-			"Mondainai Tripper"
+			"Mondainai Tripper",
+            "mondai nightripper"
 		],
 		"title": "モンダイナイトリッパー！"
 	},
@@ -14697,7 +14704,9 @@
 			"genre": "maimai"
 		},
 		"id": 1137,
-		"searchTerms": [],
+		"searchTerms": [
+            "party people princess"
+        ],
 		"title": "Party☆People☆Princess"
 	},
 	{
@@ -15066,7 +15075,7 @@
 		},
 		"id": 1167,
 		"searchTerms": [
-			"tondemonai wonders"
+			"tondemo wonders"
 		],
 		"title": "トンデモワンダーズ"
 	},
@@ -15386,7 +15395,8 @@
 		},
 		"id": 1193,
 		"searchTerms": [
-			"tsunagite"
+			"tsunagite",
+            "tuna"
 		],
 		"title": "系ぎて"
 	},
@@ -15398,7 +15408,9 @@
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1194,
-		"searchTerms": [],
+		"searchTerms": [
+            "azure"
+        ],
 		"title": "Λzure Vixen"
 	},
 	{
@@ -17014,7 +17026,9 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1327,
-		"searchTerms": [],
+		"searchTerms": [
+            "seven girls war"
+        ],
 		"title": "7 Girls War"
 	},
 	{
@@ -17052,7 +17066,8 @@
 		},
 		"id": 1330,
 		"searchTerms": [
-			"MEITANTEIRENZOKUSATSUJINJIKEN"
+			"MEITANTEIRENZOKUSATSUJINJIKEN",
+            "mei tantei renzoku satsujin jiken"
 		],
 		"title": "名探偵連続殺人事件"
 	},
@@ -17330,7 +17345,9 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1353,
-		"searchTerms": [],
+		"searchTerms": [
+            "usa"
+        ],
 		"title": "U.S.A."
 	},
 	{
@@ -18041,7 +18058,8 @@
 		},
 		"id": 1411,
 		"searchTerms": [
-			"(not) a devil"
+			"(not) a devil",
+            "devil jya nai"
 		],
 		"title": "デビルじゃないもん"
 	},
@@ -18136,7 +18154,8 @@
 		},
 		"id": 1419,
 		"searchTerms": [
-			"realize"
+			"realize",
+            "realise"
 		],
 		"title": "リアライズ"
 	},
@@ -18148,7 +18167,9 @@
 			"genre": "maimai"
 		},
 		"id": 1420,
-		"searchTerms": [],
+		"searchTerms": [
+            "cryptarhythm"
+        ],
 		"title": "Cryptarithm"
 	},
 	{
@@ -18251,7 +18272,11 @@
 			"genre": "maimai"
 		},
 		"id": 1428,
-		"searchTerms": [],
+		"searchTerms": [
+            "colorful encounter",
+            "colorful:encounver",
+            "colourfull"
+        ],
 		"title": "Colorfull:Encounter"
 	},
 	{
@@ -18263,7 +18288,9 @@
 		},
 		"id": 1429,
 		"searchTerms": [
-			"urosousetsu"
+			"urosousetsu",
+            "uro sousetsu",
+            "rain dew frost snow"
 		],
 		"title": "雨露霜雪"
 	},
@@ -18289,7 +18316,8 @@
 		},
 		"id": 1431,
 		"searchTerms": [
-			"moon:reflection"
+			"moon:reflection",
+            "miya gekkyou"
 		],
 		"title": "美夜月鏡"
 	},
@@ -18302,7 +18330,8 @@
 		},
 		"id": 1432,
 		"searchTerms": [
-			"reincarnation apple"
+			"reincarnation apple",
+            "tensei ringo"
 		],
 		"title": "転生林檎"
 	},
@@ -18315,7 +18344,8 @@
 		},
 		"id": 1433,
 		"searchTerms": [
-			"mugen my world"
+			"mugen my world",
+            "yume utsutsu mousou sekai"
 		],
 		"title": "夢現妄想世界"
 	},
@@ -18459,7 +18489,9 @@
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1444,
-		"searchTerms": [],
+		"searchTerms": [
+            "hypertribe"
+        ],
 		"title": "HYP3RTRIBE"
 	},
 	{
@@ -18509,6 +18541,7 @@
 		"id": 1448,
 		"searchTerms": [
 			"migi ni ma girl",
+            "maguru",
 			"girlving to the right"
 		],
 		"title": "右に曲ガール"
@@ -18548,7 +18581,8 @@
 		},
 		"id": 1451,
 		"searchTerms": [
-			"jigoku"
+			"jigoku",
+            "hell"
 		],
 		"title": "地獄"
 	},
@@ -18633,7 +18667,9 @@
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1458,
-		"searchTerms": [],
+		"searchTerms": [
+            "rnr monster"
+        ],
 		"title": "R'N'R Monsta"
 	},
 	{
@@ -18697,7 +18733,9 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1463,
-		"searchTerms": [],
+		"searchTerms": [
+            "monster coming"
+        ],
 		"title": "モンスターカミング"
 	},
 	{
@@ -18708,7 +18746,9 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1464,
-		"searchTerms": [],
+		"searchTerms": [
+            "worldwide wonder"
+        ],
 		"title": "ワールドワイドワンダー"
 	},
 	{
@@ -18719,7 +18759,10 @@
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1465,
-		"searchTerms": [],
+		"searchTerms": [
+            "morning loom",
+            "gloom"
+        ],
 		"title": "MORNINGLOOM"
 	},
 	{
@@ -18730,7 +18773,9 @@
 			"genre": "ゲーム＆バラエティ"
 		},
 		"id": 1466,
-		"searchTerms": [],
+		"searchTerms": [
+            "otoge kyoku"
+        ],
 		"title": "How To Make 音ゲ～曲！"
 	},
 	{
@@ -18752,7 +18797,9 @@
 			"genre": "maimai"
 		},
 		"id": 1468,
-		"searchTerms": [],
+		"searchTerms": [
+            "utahime night storm"
+        ],
 		"title": "ウタヒメナイトストーム"
 	},
 	{
@@ -18763,7 +18810,9 @@
 			"genre": "maimai"
 		},
 		"id": 1469,
-		"searchTerms": [],
+		"searchTerms": [
+            "feel the love"
+        ],
 		"title": "Feel The Luv"
 	},
 	{
@@ -18774,7 +18823,9 @@
 			"genre": "maimai"
 		},
 		"id": 1470,
-		"searchTerms": [],
+		"searchTerms": [
+            "antinomie"
+        ],
 		"title": "Åntinomiε"
 	},
 	{
@@ -18807,7 +18858,10 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1473,
-		"searchTerms": [],
+		"searchTerms": [
+            "cubism",
+            "kyubizumu"
+        ],
 		"title": "きゅびずむ"
 	},
 	{
@@ -18818,7 +18872,10 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1474,
-		"searchTerms": [],
+		"searchTerms": [
+            "kyubibibibizumu",
+            "cubibibibism"
+        ],
 		"title": "きゅびびびびずむ"
 	},
 	{
@@ -18829,7 +18886,9 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1475,
-		"searchTerms": [],
+		"searchTerms": [
+            "yurikago"
+        ],
 		"title": "ゆりかご"
 	},
 	{
@@ -18840,7 +18899,11 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1476,
-		"searchTerms": [],
+		"searchTerms": [
+            "tsuki hikari",
+            "moonlight",
+            "gekkou"
+        ],
 		"title": "月光"
 	},
 	{
@@ -18851,7 +18914,9 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1477,
-		"searchTerms": [],
+		"searchTerms": [
+            "hai yorokonde"
+        ],
 		"title": "はいよろこんで"
 	},
 	{
@@ -18862,7 +18927,10 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1478,
-		"searchTerms": [],
+		"searchTerms": [
+            "bibidiba",
+            "suisei"
+        ],
 		"title": "ビビデバ"
 	},
 	{
@@ -18873,7 +18941,10 @@
 			"genre": "POPS＆アニメ"
 		},
 		"id": 1479,
-		"searchTerms": [],
+		"searchTerms": [
+            "shika iro days",
+            "shika noko noko noko koshi tan tan"
+        ],
 		"title": "シカ色デイズ"
 	},
 	{
@@ -18884,7 +18955,10 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1480,
-		"searchTerms": [],
+		"searchTerms": [
+            "mesmeriser",
+            "mesmerizer"
+        ],
 		"title": "メズマライザー"
 	},
 	{
@@ -18895,7 +18969,9 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1481,
-		"searchTerms": [],
+		"searchTerms": [
+            "momo iro no kagi"
+        ],
 		"title": "ももいろの鍵"
 	},
 	{
@@ -18906,7 +18982,10 @@
 			"genre": "niconico＆ボーカロイド"
 		},
 		"id": 1482,
-		"searchTerms": [],
+		"searchTerms": [
+            "no da",
+            "noda"
+        ],
 		"title": "のだ"
 	},
 	{
@@ -18917,7 +18996,9 @@
 			"genre": "東方Project"
 		},
 		"id": 1483,
-		"searchTerms": [],
+		"searchTerms": [
+            "idoratrise"
+        ],
 		"title": "Idoratrize World"
 	},
 	{
@@ -18939,7 +19020,9 @@
 			"genre": "maimai"
 		},
 		"id": 1485,
-		"searchTerms": [],
+		"searchTerms": [
+            "atlas rush"
+        ],
 		"title": "ATLAS RUSH"
 	},
 	{
@@ -18950,7 +19033,9 @@
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1486,
-		"searchTerms": [],
+		"searchTerms": [
+            "sound player"
+        ],
 		"title": "サウンドプレイヤー"
 	},
 	{
@@ -18972,7 +19057,9 @@
 			"genre": "オンゲキ＆CHUNITHM"
 		},
 		"id": 1488,
-		"searchTerms": [],
+		"searchTerms": [
+            "drives over"
+        ],
 		"title": "Drivessover"
 	}
 ]

--- a/seeds/collections/songs-ongeki.json
+++ b/seeds/collections/songs-ongeki.json
@@ -8094,7 +8094,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 667,
-		"searchTerms": [],
+		"searchTerms": [
+            "numbers"
+        ],
 		"title": "2112410403927243233368"
 	},
 	{
@@ -8733,7 +8735,9 @@
 			"genre": "オンゲキ"
 		},
 		"id": 720,
-		"searchTerms": [],
+		"searchTerms": [
+            "op1 fear titan"
+        ],
 		"title": "Op.I《fear-TITΛN-》"
 	},
 	{
@@ -10470,7 +10474,7 @@
 		},
 		"id": 860,
 		"searchTerms": [
-			"Kohi kofu enishi"
+			"Koi kou enshi"
 		],
 		"title": "恋ひ恋ふ縁"
 	},
@@ -10666,7 +10670,9 @@
 			"genre": "VARIETY"
 		},
 		"id": 876,
-		"searchTerms": [],
+		"searchTerms": [
+            "parallel prism"
+        ],
 		"title": "PARALLEL★PRISM"
 	},
 	{
@@ -10751,7 +10757,9 @@
 			"genre": "オンゲキ"
 		},
 		"id": 883,
-		"searchTerms": [],
+		"searchTerms": [
+            "starlight limited"
+        ],
 		"title": "Starlight★Limited"
 	},
 	{
@@ -12045,7 +12053,8 @@
 		},
 		"id": 988,
 		"searchTerms": [
-			"Yukiotoko"
+			"Yukiotoko",
+            "yuki otoko"
 		],
 		"title": "雪男"
 	},
@@ -13058,7 +13067,8 @@
 		},
 		"id": 1071,
 		"searchTerms": [
-			"Mesmerizer"
+			"Mesmerizer",
+            "Mesmeriser"
 		],
 		"title": "メズマライザー"
 	},


### PR DESCRIPTION
did another quick look through chuni/maimai

main points:
added tags for prism+
added missing romaji of titles when needed 
added fixes for punctation in titles (eg LLL returns no results for L.L.L.)
support both american/british english searches

I only looked at geki for 5 minutes since it seemed mostly fine