### PR TITLE
fix(search): make searches case-insensitive

### DIFF
--- a/server/src/lib/search/search.ts
+++ b/server/src/lib/search/search.ts
@@ -105,6 +105,7 @@ export async function SearchCollection<T extends object>(
 	const fzf = new AsyncFzf(searchData, {
 		selector: (item) => item.searchKey,
 		sort: true,
+		casing: "case-insensitive",
 	});
 	let results = await fzf.find(search);
 


### PR DESCRIPTION
The default behavior of `fzf` is to assume that [searches are case-sensitive if the query is not all lowercase](https://github.com/ajitid/fzf-for-js/blob/cf3903255b6bba6143bfbed5a387f3cadfd6938a/src/lib/pattern.ts#L203-L207). This can be surprising to the end user, especially when searching songs with silly casing like `VERTeX` (notice that `VERTeX` is not in the results if the first letter is capitalized):

| <img width="1514" height="587" alt="image" src="https://github.com/user-attachments/assets/37377435-7df9-4b73-9b52-7f52bc2a0ef2" /> | <img width="1500" height="866" alt="image" src="https://github.com/user-attachments/assets/9fcb7fa7-9489-4938-a861-1570f177acef" /> |
|-|-|

This PR makes searches case-insensitive to fix the issue.

