### PR TITLE
fix: migrate default folder info for chunithm + don't hardcode allowed preferredDefaultEnum values

### DIFF
--- a/server/src/lib/migration/migrations.ts
+++ b/server/src/lib/migration/migrations.ts
@@ -2,6 +2,7 @@ import UserFollowersMigration from "./migrations/add-following-to-users";
 import AddLockedAt from "./migrations/add-lockedat";
 import UGPTAddPreferredRanking from "./migrations/add-preferredRanking-to-ugpt";
 import UGPTRivalsMigration from "./migrations/add-rivals-to-ugpt";
+import ChunithmFixPreferredDefaultEnum from "./migrations/chunithm-fix-preferred-default-enum";
 import ChunithmLampSplit from "./migrations/chunithm-lamp-split";
 import FixUndefinedBMSData from "./migrations/fix-undefined-bms-data";
 import JoinINFCastHourCharts from "./migrations/join-inf-casthour-charts";
@@ -75,7 +76,8 @@ if (Environment.nodeEnv !== "test") {
 			RemoveIIDX2dxtraBeginners,
 			RmHot,
 			ChunithmLampSplit,
-			OngekiV2
+			OngekiV2,
+			ChunithmFixPreferredDefaultEnum
 			// SdvxMaxxiveLampRearrange,
 			// SdvxMaxxiveGoals
 		);

--- a/server/src/lib/migration/migrations/chunithm-fix-preferred-default-enum.ts
+++ b/server/src/lib/migration/migrations/chunithm-fix-preferred-default-enum.ts
@@ -1,0 +1,25 @@
+import db from "external/mongo/db";
+import type { Migration } from "utils/types";
+
+const migration: Migration = {
+	id: "chunithm-fix-preferred-default-enum",
+	up: async () => {
+		await db["game-settings"].update(
+			{
+				game: "chunithm",
+				"preferences.preferredDefaultEnum": "lamp",
+			},
+			{
+				$set: {
+					"preferences.preferredDefaultEnum": "noteLamp",
+				},
+			},
+			{ multi: true }
+		);
+	},
+	down: () => {
+		throw new Error(`Reverting this change is not possible.`);
+	},
+};
+
+export default migration;

--- a/server/src/server/router/api/v1/users/_userID/games/_game/_playtype/settings/router.ts
+++ b/server/src/server/router/api/v1/users/_userID/games/_game/_playtype/settings/router.ts
@@ -4,7 +4,7 @@ import db from "external/mongo/db";
 import CreateLogCtx from "lib/logger/logger";
 import { p } from "prudence";
 import { RequirePermissions } from "server/middleware/auth";
-import { GetGamePTConfig, PrudenceZodShim } from "tachi-common";
+import { GetGamePTConfig, GetScoreMetrics, PrudenceZodShim } from "tachi-common";
 import { FormatPrError, optNull } from "utils/prudence";
 import { GetUGPT } from "utils/req-tachi-data";
 import { FormatUserDoc } from "utils/user";
@@ -46,7 +46,7 @@ router.patch(
 			preferredRanking: optNull(p.isIn("global", "rival")),
 
 			gameSpecific: optNull(gameSpecificSchema),
-			preferredDefaultEnum: optNull(p.isIn("grade", "lamp")),
+			preferredDefaultEnum: optNull(p.isIn(...GetScoreMetrics(gptConfig, "ENUM"))),
 		});
 
 		if (err) {


### PR DESCRIPTION
Another fallout of the #1269 lamp split. People set their preferred folder info to `lamp` -> lamp split happens -> no more `lamp` metric -> crash like below

<img width="3234" height="1710" alt="image" src="https://github.com/user-attachments/assets/4806561c-846a-40cf-b97e-928dca87c6ab" />

On a related note, fix `PATCH /api/v1/users/:userID/games/:game/:playtype/settings` to allow the specific game's enum metrics, instead of hardcoding `grade` and `lamp`.