### PR TITLE
fix: seeds corrections for iidx 32 and 33

### DIFF
--- a/seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
+++ b/seeds/scripts/rerunners/iidx/iidx-mdb-parse/convert.ts
@@ -162,10 +162,12 @@ export async function ParseIIDXData(
 
 		const extractedIFSLeggLoc = path.join(ifsOUT, `${iSongID}-p0_ifs/${iSongID}/${iSongID}.1`);
 
-		if (fs.existsSync(ifsLeggPath)) {
-			if (!fs.existsSync(extractedIFSLeggLoc)) {
+		if (fs.existsSync(ifsLeggPath) || fs.existsSync(extractedIFSLeggLoc)) {
+			if (!fs.existsSync(extractedIFSLeggLoc) || alwaysExtract) {
 				ifsExtract(ifsLeggPath);
 			}
+
+			dotOnePath = extractedIFSLeggLoc;
 
 			const charts = await ParseDotOneFile(extractedIFSLeggLoc, {
 				genre,
@@ -177,15 +179,15 @@ export async function ParseIIDXData(
 			for (const chart of charts) {
 				notecounts[`${chart.playtype}-${chart.difficulty}`] = chart.notecount;
 			}
-		}
+		} else {
+			// if we've already extracted this, and --always-extract isn't set
+			if (fs.existsSync(extractedIFSLoc) && !alwaysExtract) {
+				dotOnePath = extractedIFSLoc;
+			} else if (fs.existsSync(ifsPath)) {
+				ifsExtract(ifsPath);
 
-		// if we've already extracted this, and --always-extract isn't set
-		if (fs.existsSync(extractedIFSLoc) && !alwaysExtract) {
-			dotOnePath = extractedIFSLoc;
-		} else if (fs.existsSync(ifsPath)) {
-			ifsExtract(ifsPath);
-
-			dotOnePath = extractedIFSLoc;
+				dotOnePath = extractedIFSLoc;
+			}
 		}
 
 		if (!fs.existsSync(dotOnePath)) {


### PR DESCRIPTION
This addresses a few issues:

- Mid-game version 32 removals that were not marked as removed in seeds (they were removed via server flags, data is unchanged, so it's a manual process)
- Missing songs from versions 30-32 in version 33 (issue on my end)
- Missing leggendaria charts (iidx-mdb-parse was sometimes preferring original files instead of patch files, if a -p0 exists it is not just for spl/dpl charts, it is a replacement of the original .1 file)
- I forgot to add the new version of ADVANCE via the "add new primary" script.

I adjusted the logic in iidx-mdb-parse to get the desired result but I think that whole section was made with the assumption that "p0" files are *only* for spl/dpl charts rather than patches to the whole .1, so it could use some further rework.