### PR TITLE
fix: sort saved BMS table levels

### DIFF
--- a/seeds/scripts/rerunners/bms-pms/sync-bms-tablefolders.ts
+++ b/seeds/scripts/rerunners/bms-pms/sync-bms-tablefolders.ts
@@ -3,7 +3,7 @@ import { CreateFolderIDFromFolder } from "../../util";
 
 const { BMS_TABLES } = require("tachi-common");
 const logger = require("../../logger");
-const { CreateFolderID, ReadCollection, MutateCollection } = require("../../util");
+const { ReadCollection, MutateCollection } = require("../../util");
 const { LoadBMSTable } = require("bms-table-loader");
 
 const existsTables = ReadCollection("tables.json").map((e) => e.tableID);

--- a/server/src/lib/jobs/backsync-bms-pms-data.ts
+++ b/server/src/lib/jobs/backsync-bms-pms-data.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-await-in-loop */
 import db from "external/mongo/db";
-import { VERSION_INFO } from "lib/constants/version";
 import CreateLogCtx from "lib/logger/logger";
 import { PullDatabaseSeeds } from "lib/seeds/repo";
 import { WrapScriptPromise } from "utils/misc";

--- a/server/src/lib/jobs/bms-table-sync.ts
+++ b/server/src/lib/jobs/bms-table-sync.ts
@@ -165,6 +165,14 @@ async function ImportTableLevels(
 
 		tableFolders.push({ table: prefix, level: td.content.level.toString() });
 
+		tableFolders.sort((a, b) => {
+			if (a.table !== b.table) {
+				return a.table.localeCompare(b.table);
+			}
+
+			return a.level.localeCompare(b.level);
+		});
+
 		await db.charts.bms.update(
 			{
 				chartID: chart.chartID,


### PR DESCRIPTION
Fixes most of changes in BMS backsync commits being table folders changing order.
Current collection will get stably sorted on next automatic update.